### PR TITLE
23: AbstractLabelProvider.convertToString(Object) handles CharSequence

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/label/DefaultEObjectLabelProviderTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/label/DefaultEObjectLabelProviderTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ParserRule;
 import org.eclipse.xtext.XtextFactory;
 import org.eclipse.xtext.ui.IImageHelper;
@@ -194,4 +195,20 @@ public class DefaultEObjectLabelProviderTest extends Assert {
 		assertEquals(4, calls.size());
 	}
 
+	@Test public void testGetTextCharSequence() throws Exception {
+		DefaultEObjectLabelProvider defaultLabelProvider = new DefaultEObjectLabelProvider() {
+
+			@SuppressWarnings("unused")
+			public Object text(ParserRule parserRule) {
+				StringConcatenation _builder = new StringConcatenation();
+			    _builder.append(parserRule.getName());
+			    return _builder;
+			}
+
+		};
+		ParserRule parserRule = XtextFactory.eINSTANCE.createParserRule();
+		parserRule.setName("testCreateStyledString");
+		String styledText = defaultLabelProvider.getText(parserRule);
+		assertEquals("testCreateStyledString", styledText);
+	}
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/label/AbstractLabelProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/label/AbstractLabelProvider.java
@@ -171,8 +171,10 @@ public abstract class AbstractLabelProvider extends LabelProvider implements ISt
 	protected String convertToString(Object text) {
 		if (text instanceof StyledString) {
 			return ((StyledString) text).getString();
-		} else if(text instanceof String){
+		} else if (text instanceof String){
 			return (String) text;
+		} else if (text instanceof CharSequence) {
+			return text.toString();
 		}
 		return null;
 	}


### PR DESCRIPTION
Closes #23 

Task-Url: https://github.com/eclipse/xtext-eclipse/issues/23
Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>