### PR TITLE
[486001] Converted Proposal Provider Example Code in Docs to Xtend

### DIFF
--- a/org.eclipse.xtext.doc/contents/304_ide_concepts.html
+++ b/org.eclipse.xtext.doc/contents/304_ide_concepts.html
@@ -127,20 +127,20 @@ public void complete_{RuleName}(
 
 <p>To provide a dummy proposal for the code of an <code>event</code> instance, you may introduce a specialization of the generated method and implement it as follows. This will propose <code>ZonkID</code> for an event with the name <code>Zonk</code>.</p>
 
-<pre><code class="language-java">public void completeEvent_Code(
+<pre><code class="language-xtend">override void completeEvent_Code(
   Event event, Assignment assignment, 
   ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
   // call implementation of superclass
-  super.completeEvent_Code(model, assignment, context, acceptor);
+  super.completeEvent_Code(model, assignment, context, acceptor)
 
   // compute the plain proposal
-  String proposal = event.getName() + "ID";
+  val String proposal = event.getName() + "ID"
 
   // Create and register the completion proposal:
   // The proposal may be null as the createCompletionProposal(..) 
   // methods check for valid prefixes and terminal token conflicts.
   // The acceptor handles null-values gracefully.
-  acceptor.accept(createCompletionProposal(proposal, context));
+  acceptor.accept(createCompletionProposal(proposal, context))
 }
 </code></pre>
 


### PR DESCRIPTION
[486001] Converted Proposal Provider Example Code in Docs to Xtend

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>