### PR TITLE
[462915] NPE when using 'Import' template variable extension and typeis not on classpath

### DIFF
--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/templates/XbaseTemplateContext.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/templates/XbaseTemplateContext.java
@@ -71,9 +71,16 @@ public class XbaseTemplateContext extends XtextTemplateContext {
 	}
 
 	@Override
+	public TemplateBuffer evaluateForDisplay(Template template) throws BadLocationException, TemplateException {
+		// Ensure clean state before evaluation starts
+		imports.clear();
+		return super.evaluateForDisplay(template);
+	}
+
+	@Override
 	public TemplateBuffer evaluate(Template template) throws BadLocationException, TemplateException {
 		XtextDocument xDocument = (XtextDocument) getDocument();
-		// Injure clean state before evaluation starts
+		// Ensure clean state before evaluation starts
 		imports.clear();
 		TemplateBuffer resolvedContent = super.evaluate(template);
 


### PR DESCRIPTION
[462915] NPE when using 'Import' template variable extension and type is not on classpath

do state cleaning in evaluateForDisplay as well

Signed-off-by: Christian Dietrich christian.dietrich@itemis.de
