### PR TITLE
[461630] Add guard condition

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -710,7 +710,7 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 	@SuppressWarnings("rawtypes")
 	private Annotation getAnnotation(final int offset, final int length) {
 		final IAnnotationModel model = getDocumentProvider().getAnnotationModel(getEditorInput());
-		if (model == null)
+		if (model == null || length < 0)
 			return null;
 
 		Iterator iterator;


### PR DESCRIPTION
length can be <0 when the selection is TextSelection#NULL.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>