### PR TITLE
[#83] Add CI p2 repository for Xtend

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -50,6 +50,10 @@
       value="http://services.typefox.io/open-source/jenkins/job/xtext-eclipse/job/master/lastStableBuild/artifact/build/p2-repository/"/>
   <setupTask
       xsi:type="setup:VariableTask"
+      name="xtend.nightly.composite"
+      value="http://services.typefox.io/open-source/jenkins/job/xtext-xtend/job/master/lastSuccessfulBuild/artifact/build/p2-repository/"/>
+  <setupTask
+      xsi:type="setup:VariableTask"
       name="mwe2.update.site"
       value="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/maintenance/nightly/"/>
   <setupTask
@@ -255,6 +259,8 @@
     <repository
         url="${xtext.nightly.composite}"/>
     <repository
+        url="${xtend.nightly.composite}"/>
+    <repository
         url="${mwe2.update.site}"/>
   </setupTask>
   <setupTask
@@ -352,7 +358,7 @@
               project="org.eclipse.xtext"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -424,7 +430,7 @@
               project="org.eclipse.xtext.xbase.lib"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -493,7 +499,7 @@
               project="org.eclipse.xtext.xbase"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -761,7 +767,7 @@
               project="org.eclipse.xtext.sdk.feature"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2 //@projects[name='eclipse']/@setupTasks.4/@workingSets.1"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2 //@projects[name='eclipse']/@setupTasks.4/@workingSets.1"/>
         </predicate>
       </workingSet>
       <workingSet
@@ -773,7 +779,7 @@
               project="org.eclipse.xtext.sdk.feature"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2"/>
           <operand
               xsi:type="predicates:OrPredicate">
             <operand
@@ -794,7 +800,7 @@
               project="org.eclipse.xtext.sdk.feature"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
           <operand
               xsi:type="predicates:NamePredicate"
               pattern=".*\.example\..*"/>
@@ -882,7 +888,7 @@
               project="org.eclipse.xtext.core.idea.tests"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -954,7 +960,7 @@
               project="org.eclipse.xtext.web"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -1025,7 +1031,7 @@
               project="org.eclipse.xtext.maven.plugin"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -1111,7 +1117,7 @@
               project="org.eclipse.xtend.core"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>


### PR DESCRIPTION
Xtext and Xtend must be both updated from the latest CI build. Since the
Xtend p2 repository was missing, Xtext could also not be updated.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>