### PR TITLE
Set workspace encoding to UTF-8

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -237,6 +237,10 @@
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.core.resources/description.disableLinking"
           value="false"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.core.resources/encoding"
+          value="UTF-8"/>
     </setupTask>
   </setupTask>
   <setupTask


### PR DESCRIPTION
Most projects have explicit encodings set, but we have to make sure that the encoding defaults to UTF-8.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>