### PR TITLE
[#83] Repository location for Xtext & Xtend SDK changed

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -47,11 +47,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="xtext.nightly.composite"
-      value="http://services.typefox.io/open-source/jenkins/job/xtext-eclipse/job/master/lastStableBuild/artifact/build/p2-repository/"/>
-  <setupTask
-      xsi:type="setup:VariableTask"
-      name="xtend.nightly.composite"
-      value="http://services.typefox.io/open-source/jenkins/job/xtext-xtend/job/master/lastSuccessfulBuild/artifact/build/p2-repository/"/>
+      value="http://services.typefox.io/open-source/jenkins/job/xtext/job/master/lastStableBuild/artifact/build/p2-repository/"/>
   <setupTask
       xsi:type="setup:VariableTask"
       name="mwe2.update.site"
@@ -259,8 +255,6 @@
     <repository
         url="${xtext.nightly.composite}"/>
     <repository
-        url="${xtend.nightly.composite}"/>
-    <repository
         url="${mwe2.update.site}"/>
   </setupTask>
   <setupTask
@@ -358,7 +352,7 @@
               project="org.eclipse.xtext"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -430,7 +424,7 @@
               project="org.eclipse.xtext.xbase.lib"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -499,7 +493,7 @@
               project="org.eclipse.xtext.xbase"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -767,7 +761,7 @@
               project="org.eclipse.xtext.sdk.feature"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2 //@projects[name='eclipse']/@setupTasks.4/@workingSets.1"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2 //@projects[name='eclipse']/@setupTasks.4/@workingSets.1"/>
         </predicate>
       </workingSet>
       <workingSet
@@ -779,7 +773,7 @@
               project="org.eclipse.xtext.sdk.feature"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2"/>
           <operand
               xsi:type="predicates:OrPredicate">
             <operand
@@ -800,7 +794,7 @@
               project="org.eclipse.xtext.sdk.feature"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
           <operand
               xsi:type="predicates:NamePredicate"
               pattern=".*\.example\..*"/>
@@ -888,7 +882,7 @@
               project="org.eclipse.xtext.core.idea.tests"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -960,7 +954,7 @@
               project="org.eclipse.xtext.web"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -1031,7 +1025,7 @@
               project="org.eclipse.xtext.maven.plugin"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -1117,7 +1111,7 @@
               project="org.eclipse.xtend.core"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>


### PR DESCRIPTION
Xtext repository moved from eclipse/xtext-eclipse to eclipse/xtext
Use last stable instead of last successful build

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>