### PR TITLE
improve outline refresh performance

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/actions/SortOutlineContribution.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/actions/SortOutlineContribution.java
@@ -39,8 +39,14 @@ public class SortOutlineContribution extends AbstractToggleOutlineContribution {
 
 	@Override
 	protected void stateChanged(boolean newState) {
-		if(treeViewer != null && !treeViewer.getTree().isDisposed())
-			treeViewer.refresh();
+		if(treeViewer != null && !treeViewer.getTree().isDisposed()) {
+			treeViewer.getControl().setRedraw(false);
+			try {
+				treeViewer.refresh();
+			} finally {
+				treeViewer.getControl().setRedraw(true);
+			}
+		}
 	}
 
 	public static class DefaultComparator implements IComparator {


### PR DESCRIPTION
When changing the sorting, the complete tree needs to be refreshed.
Especially for big trees disabling all repainting during the update can
cut down the refresh time to half of before.

Signed-off-by: Michael Keppler <michael.keppler@gmx.de>