### PR TITLE
[eclipse/xtext#1089] Replace (not)equal operators by triple (not)equals

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/ParallelFileSystemAccess.xtend
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/ParallelFileSystemAccess.xtend
@@ -36,7 +36,7 @@ class ParallelFileSystemAccess implements IFileSystemAccess2 {
 			if (delegate instanceof EclipseResourceFileSystemAccess2) {
 				delegate.postProcessor = fileCallback
 			}
-			if (sourceFolder != null) {
+			if (sourceFolder !== null) {
 				if (delegate instanceof AbstractFileSystemAccess) {	
 					delegate.currentSource = sourceFolder
 				}

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/debug/XtextBuildConsole.xtend
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/debug/XtextBuildConsole.xtend
@@ -45,7 +45,7 @@ class XtextBuildConsole extends IOConsole {
 		static IBuildLogger delegate
 		
 		override log(Object it) {
-			if(delegate != null)
+			if(delegate !== null)
 				delegate.log(it)
 			val consoleManager = ConsolePlugin.getDefault.consoleManager
 			val console = consoleManager.consoles.filter(XtextBuildConsole).head

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/javasupport/JdtQueuedBuildData.xtend
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/javasupport/JdtQueuedBuildData.xtend
@@ -56,7 +56,7 @@ class JdtQueuedBuildData implements IQueuedBuildDataContribution {
 			UnconfirmedStructuralChangesDelta: {
 				val project = delta.project
 				var state = javaBuildState.get(project.name)
-				if (state == null) {
+				if (state === null) {
 					javaBuildState.put(project.name, state = project.lastBuiltState)
 				}
 				delta.buildNumber = state.buildNumber
@@ -72,7 +72,7 @@ class JdtQueuedBuildData implements IQueuedBuildDataContribution {
 		val oldState = javaBuildState.get(name)
 		val newState = lastBuiltState
 		newState.doNeedRebuild(
-			if (oldState == null || oldState.lastStructuralBuildTime != newState.lastStructuralBuildTime) {
+			if (oldState === null || oldState.lastStructuralBuildTime != newState.lastStructuralBuildTime) {
 				[
 					val structurallyChangedTypes = newState.structurallyChangedTypes
 					if (getNew.namesIntersect(structurallyChangedTypes) || old.namesIntersect(structurallyChangedTypes)) {
@@ -90,7 +90,7 @@ class JdtQueuedBuildData implements IQueuedBuildDataContribution {
 			val unconfirmed = i.next
 			if (unconfirmed.buildNumber < buildNumber && unconfirmed.project.equals(project)) {
 				i.remove
-				if (processor != null) {
+				if (processor !== null) {
 					processor.apply(unconfirmed)
 				}
 			}
@@ -99,7 +99,7 @@ class JdtQueuedBuildData implements IQueuedBuildDataContribution {
 	}
 
 	protected def namesIntersect(IResourceDescription resourceDescription, Set<QualifiedName> names) {
-		if (resourceDescription == null) {
+		if (resourceDescription === null) {
 			return false
 		}
 		for (objectDescription : resourceDescription.exportedObjects) {

--- a/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/ParallelFileSystemAccess.java
+++ b/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/ParallelFileSystemAccess.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.builder;
 
-import com.google.common.base.Objects;
 import java.io.InputStream;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.emf.common.util.URI;
@@ -48,8 +47,7 @@ public class ParallelFileSystemAccess implements IFileSystemAccess2 {
       if ((this.delegate instanceof EclipseResourceFileSystemAccess2)) {
         ((EclipseResourceFileSystemAccess2)this.delegate).setPostProcessor(this.fileCallback);
       }
-      boolean _notEquals = (!Objects.equal(this.sourceFolder, null));
-      if (_notEquals) {
+      if ((this.sourceFolder != null)) {
         if ((this.delegate instanceof AbstractFileSystemAccess)) {
           ((AbstractFileSystemAccess)this.delegate).setCurrentSource(this.sourceFolder);
         }

--- a/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/debug/XtextBuildConsole.java
+++ b/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/debug/XtextBuildConsole.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.builder.debug;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.inject.Singleton;
@@ -44,8 +43,7 @@ public class XtextBuildConsole extends IOConsole {
     
     @Override
     public void log(final Object it) {
-      boolean _notEquals = (!Objects.equal(XtextBuildConsole.Logger.delegate, null));
-      if (_notEquals) {
+      if ((XtextBuildConsole.Logger.delegate != null)) {
         XtextBuildConsole.Logger.delegate.log(it);
       }
       ConsolePlugin _default = ConsolePlugin.getDefault();

--- a/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/impl/javasupport/JdtQueuedBuildData.java
+++ b/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/impl/javasupport/JdtQueuedBuildData.java
@@ -72,8 +72,7 @@ public class JdtQueuedBuildData implements IQueuedBuildDataContribution {
         final IProject project = ((UnconfirmedStructuralChangesDelta)delta).getProject();
         String _name = project.getName();
         JavaBuilderState state = this.javaBuildState.get(_name);
-        boolean _equals = Objects.equal(state, null);
-        if (_equals) {
+        if ((state == null)) {
           String _name_1 = project.getName();
           JavaBuilderState _lastBuiltState = JavaBuilderState.getLastBuiltState(project);
           JavaBuilderState _state = state = _lastBuiltState;
@@ -100,7 +99,7 @@ public class JdtQueuedBuildData implements IQueuedBuildDataContribution {
       final JavaBuilderState oldState = this.javaBuildState.get(_name);
       final JavaBuilderState newState = JavaBuilderState.getLastBuiltState(it);
       Procedure1<UnconfirmedStructuralChangesDelta> _xifexpression = null;
-      if ((Objects.equal(oldState, null) || (!Objects.equal(oldState.getLastStructuralBuildTime(), newState.getLastStructuralBuildTime())))) {
+      if (((oldState == null) || (!Objects.equal(oldState.getLastStructuralBuildTime(), newState.getLastStructuralBuildTime())))) {
         final Procedure1<UnconfirmedStructuralChangesDelta> _function = (UnconfirmedStructuralChangesDelta it_1) -> {
           final Set<QualifiedName> structurallyChangedTypes = newState.getStructurallyChangedTypes();
           if ((this.namesIntersect(it_1.getNew(), structurallyChangedTypes) || this.namesIntersect(it_1.getOld(), structurallyChangedTypes))) {
@@ -125,8 +124,7 @@ public class JdtQueuedBuildData implements IQueuedBuildDataContribution {
           final UnconfirmedStructuralChangesDelta unconfirmed = i.next();
           if (((unconfirmed.getBuildNumber() < (it.getBuildNumber()).intValue()) && unconfirmed.getProject().equals(it.getProject()))) {
             i.remove();
-            boolean _notEquals = (!Objects.equal(processor, null));
-            if (_notEquals) {
+            if ((processor != null)) {
               processor.apply(unconfirmed);
             }
           }
@@ -141,8 +139,7 @@ public class JdtQueuedBuildData implements IQueuedBuildDataContribution {
   protected boolean namesIntersect(final IResourceDescription resourceDescription, final Set<QualifiedName> names) {
     boolean _xblockexpression = false;
     {
-      boolean _equals = Objects.equal(resourceDescription, null);
-      if (_equals) {
+      if ((resourceDescription == null)) {
         return false;
       }
       Iterable<IEObjectDescription> _exportedObjects = resourceDescription.getExportedObjects();

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.xtend
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.xtend
@@ -54,7 +54,7 @@ class JavaBuilderState {
 
 	static def getLastBuiltState(IJavaElement it) {
 		val javaProject = javaProject
-		if (javaProject == null) {
+		if (javaProject === null) {
 			return null
 		}
 		javaProject.project.lastBuiltState
@@ -69,34 +69,34 @@ class JavaBuilderState {
 	}
 
 	def getLastStructuralBuildTime() {
-		if (lastStructuralBuildTime != null) {
+		if (lastStructuralBuildTime !== null) {
 			return lastStructuralBuildTime
 		}
-		if (state == null) {
+		if (state === null) {
 			return lastStructuralBuildTime = -1l
 		}
 		lastStructuralBuildTime = state.readField("lastStructuralBuildTime", -1l) as Long
 	}
 
 	def getBuildNumber() {
-		if (buildNumber != null) {
+		if (buildNumber !== null) {
 			return buildNumber
 		}
-		if (state == null) {
+		if (state === null) {
 			return buildNumber = -1
 		}
 		buildNumber = state.readField("buildNumber", -1) as Integer
 	}
 
 	def getStructurallyChangedTypes() {
-		if (structurallyChangedTypes != null) {
+		if (structurallyChangedTypes !== null) {
 			return structurallyChangedTypes
 		}
 		structurallyChangedTypes = newHashSet
 		switch types : state?.readField("structurallyChangedTypes", null) {
 			StringSet: {
 				for (name : types.values) {
-					if (name != null) {
+					if (name !== null) {
 						structurallyChangedTypes += QualifiedName.create(name.split("/"))
 					}
 				}
@@ -113,12 +113,12 @@ class JavaBuilderState {
 	def dispatch TypeNames getQualifiedTypeNames(IPackageFragment it) {
 		val qualifiedTypeNames = new TypeNames(javaProject)
 		val references = getReferences
-		if (references == null) {
+		if (references === null) {
 			return qualifiedTypeNames
 		}
 		val packageName = elementName
 		val resource = it.resource
-		if (resource == null)
+		if (resource === null)
 			return qualifiedTypeNames
 		val packagePath = resource.projectRelativePath
 		val srcPathSegmentCount = packageFragmentRoot.resource.projectRelativePath.segmentCount
@@ -159,7 +159,7 @@ class JavaBuilderState {
 		val qualifiedTypeNames = new TypeNames(project)
 		val primaryTypeFqn = getQualifedTypeName(packageName, simpleName)
 		val typeNames = state?.getDefinedTypeNamesFor(typeLocator)
-		if (typeNames == null) {
+		if (typeNames === null) {
 			return new TypeNames(project) => [addTypeName(primaryTypeFqn, primaryTypeFqn)]
 		}
 		
@@ -171,7 +171,7 @@ class JavaBuilderState {
 	}
 
 	private def String getQualifedTypeName(String packageName, String simpleTypeName) {
-		if (packageName == null) {
+		if (packageName === null) {
 			return simpleTypeName
 		}
 		'''«packageName».«simpleTypeName»'''
@@ -194,10 +194,10 @@ class JavaBuilderState {
 	}
 
 	private def SimpleLookupTable getReferences() {
-		if (references != null) {
+		if (references !== null) {
 			return references
 		}
-		if (state == null) {
+		if (state === null) {
 			return null
 		}
 		references = switch references : state.readField("references", null) {
@@ -211,7 +211,7 @@ class JavaBuilderState {
 			val field = instance.class.getDeclaredField(fieldName)
 			field.accessible = true
 			val value = field.get(instance)
-			if (value != null) {
+			if (value !== null) {
 				return value
 			}
 			return defaultValue

--- a/org.eclipse.xtext.common.types.ui/xtend-gen/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.java
+++ b/org.eclipse.xtext.common.types.ui/xtend-gen/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.common.types.ui.notification;
 
-import com.google.common.base.Objects;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -71,8 +70,7 @@ public class JavaBuilderState {
     JavaBuilderState _xblockexpression = null;
     {
       final IJavaProject javaProject = it.getJavaProject();
-      boolean _equals = Objects.equal(javaProject, null);
-      if (_equals) {
+      if ((javaProject == null)) {
         return null;
       }
       IProject _project = javaProject.getProject();
@@ -100,12 +98,10 @@ public class JavaBuilderState {
   public Long getLastStructuralBuildTime() {
     Long _xblockexpression = null;
     {
-      boolean _notEquals = (!Objects.equal(this.lastStructuralBuildTime, null));
-      if (_notEquals) {
+      if ((this.lastStructuralBuildTime != null)) {
         return this.lastStructuralBuildTime;
       }
-      boolean _equals = Objects.equal(this.state, null);
-      if (_equals) {
+      if ((this.state == null)) {
         return this.lastStructuralBuildTime = Long.valueOf((-1l));
       }
       Object _readField = this.readField(this.state, "lastStructuralBuildTime", Long.valueOf((-1l)));
@@ -117,12 +113,10 @@ public class JavaBuilderState {
   public Integer getBuildNumber() {
     Integer _xblockexpression = null;
     {
-      boolean _notEquals = (!Objects.equal(this.buildNumber, null));
-      if (_notEquals) {
+      if ((this.buildNumber != null)) {
         return this.buildNumber;
       }
-      boolean _equals = Objects.equal(this.state, null);
-      if (_equals) {
+      if ((this.state == null)) {
         return this.buildNumber = Integer.valueOf((-1));
       }
       Object _readField = this.readField(this.state, "buildNumber", Integer.valueOf((-1)));
@@ -134,8 +128,7 @@ public class JavaBuilderState {
   public Set<QualifiedName> getStructurallyChangedTypes() {
     Set<QualifiedName> _xblockexpression = null;
     {
-      boolean _notEquals = (!Objects.equal(this.structurallyChangedTypes, null));
-      if (_notEquals) {
+      if ((this.structurallyChangedTypes != null)) {
         return this.structurallyChangedTypes;
       }
       HashSet<QualifiedName> _newHashSet = CollectionLiterals.<QualifiedName>newHashSet();
@@ -149,8 +142,7 @@ public class JavaBuilderState {
       if (types instanceof StringSet) {
         _matched=true;
         for (final String name : ((StringSet)types).values) {
-          boolean _notEquals_1 = (!Objects.equal(name, null));
-          if (_notEquals_1) {
+          if ((name != null)) {
             String[] _split = name.split("/");
             QualifiedName _create = QualifiedName.create(_split);
             this.structurallyChangedTypes.add(_create);
@@ -173,14 +165,12 @@ public class JavaBuilderState {
       IJavaProject _javaProject = it.getJavaProject();
       final TypeNames qualifiedTypeNames = new TypeNames(_javaProject);
       final SimpleLookupTable references = this.getReferences();
-      boolean _equals = Objects.equal(references, null);
-      if (_equals) {
+      if ((references == null)) {
         return qualifiedTypeNames;
       }
       final String packageName = it.getElementName();
       final IResource resource = it.getResource();
-      boolean _equals_1 = Objects.equal(resource, null);
-      if (_equals_1) {
+      if ((resource == null)) {
         return qualifiedTypeNames;
       }
       final IPath packagePath = resource.getProjectRelativePath();
@@ -204,8 +194,8 @@ public class JavaBuilderState {
             IPath _removeLastSegments = qualifiedPath.removeLastSegments(1);
             String _string = _removeLastSegments.toString();
             final String typePackageName = _string.replace("/", ".");
-            boolean _equals_2 = packageName.equals(typePackageName);
-            if (_equals_2) {
+            boolean _equals = packageName.equals(typePackageName);
+            if (_equals) {
               String _lastSegment = qualifiedPath.lastSegment();
               final String simpleTypeName = _lastSegment.toString();
               IJavaProject _javaProject_2 = it.getJavaProject();
@@ -258,8 +248,7 @@ public class JavaBuilderState {
         _definedTypeNamesFor=this.state.getDefinedTypeNamesFor(typeLocator);
       }
       final char[][] typeNames = _definedTypeNamesFor;
-      boolean _equals = Objects.equal(typeNames, null);
-      if (_equals) {
+      if ((typeNames == null)) {
         TypeNames _typeNames = new TypeNames(project);
         final Procedure1<TypeNames> _function = (TypeNames it) -> {
           it.addTypeName(primaryTypeFqn, primaryTypeFqn);
@@ -280,8 +269,7 @@ public class JavaBuilderState {
   private String getQualifedTypeName(final String packageName, final String simpleTypeName) {
     String _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(packageName, null);
-      if (_equals) {
+      if ((packageName == null)) {
         return simpleTypeName;
       }
       StringConcatenation _builder = new StringConcatenation();
@@ -338,12 +326,10 @@ public class JavaBuilderState {
   private SimpleLookupTable getReferences() {
     SimpleLookupTable _xblockexpression = null;
     {
-      boolean _notEquals = (!Objects.equal(this.references, null));
-      if (_notEquals) {
+      if ((this.references != null)) {
         return this.references;
       }
-      boolean _equals = Objects.equal(this.state, null);
-      if (_equals) {
+      if ((this.state == null)) {
         return null;
       }
       SimpleLookupTable _switchResult = null;
@@ -368,8 +354,7 @@ public class JavaBuilderState {
       final Field field = _class.getDeclaredField(fieldName);
       field.setAccessible(true);
       final Object value = field.get(instance);
-      boolean _notEquals = (!Objects.equal(value, null));
-      if (_notEquals) {
+      if ((value != null)) {
         return value;
       }
       return defaultValue;

--- a/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/IdeaPluginGenerator.xtend
+++ b/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/IdeaPluginGenerator.xtend
@@ -368,7 +368,7 @@ class IdeaPluginGenerator extends Xtend2GeneratorFragment {
 	}
 	
 	def getEncoding() {
-		if (encoding != null) {
+		if (encoding !== null) {
 			return encoding;
 		}
 		return System::getProperty("file.encoding");
@@ -836,7 +836,7 @@ class IdeaPluginGenerator extends Xtend2GeneratorFragment {
 				@SuppressWarnings("rawtypes")
 				public PsiElement createElement(ASTNode node) {
 					Boolean hasSemanticElement = node.getUserData(IASTNodeAwareNodeModelBuilder.HAS_SEMANTIC_ELEMENT_KEY);
-					if (hasSemanticElement != null && hasSemanticElement) {
+					if (hasSemanticElement !== null && hasSemanticElement) {
 						IElementType elementType = node.getElementType();
 						«FOR rule : EObjectRules»
 						if (elementType == elementTypeProvider.get«rule.grammarElementIdentifier»ElementType()) {

--- a/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/AntlrGrammarGenerator.xtend
+++ b/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/AntlrGrammarGenerator.xtend
@@ -227,7 +227,7 @@ class AntlrGrammarGenerator extends AbstractAntlrGrammarWithActionsGenerator {
 			}
 			«ENDIF»
 			{
-				$current = forceCreateModelElement«IF feature != null»And«setOrAdd.toFirstUpper»«ENDIF»(
+				$current = forceCreateModelElement«IF feature !== null»And«setOrAdd.toFirstUpper»«ENDIF»(
 					grammarAccess.«grammarElementAccess»,
 					$current);
 			}

--- a/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.xtend
+++ b/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.xtend
@@ -95,9 +95,9 @@ class GrammarAccessExtensions {
 
 	dispatch def mustBeParenthesized(AbstractElement it) { true }
 
-	dispatch def mustBeParenthesized(Keyword it) { predicated() || firstSetPredicated || cardinality != null }
+	dispatch def mustBeParenthesized(Keyword it) { predicated() || firstSetPredicated || cardinality !== null }
 
-	dispatch def mustBeParenthesized(RuleCall it) { predicated() || firstSetPredicated || cardinality != null }
+	dispatch def mustBeParenthesized(RuleCall it) { predicated() || firstSetPredicated || cardinality !== null }
 	
 	dispatch def boolean predicated(AbstractElement it) {
 		predicated
@@ -169,7 +169,7 @@ class GrammarAccessExtensions {
 
 	def toStringLiteral(AbstractElement it) {
 		switch it {
-			RuleCall case rule != null: '''"«rule.name»"'''
+			RuleCall case rule !== null: '''"«rule.name»"'''
 			Keyword: '''"«value.toStringInAntlrAction»"'''
 			default:
 				"null"

--- a/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/XtextIDEAGeneratorExtensions.xtend
+++ b/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/XtextIDEAGeneratorExtensions.xtend
@@ -40,18 +40,18 @@ class XtextIDEAGeneratorExtensions {
 				boolean overwrite,
 				String defaultOutletName,
 				String lineDelimiter) {
-		if (getOutlet(outletName) != null) {
+		if (getOutlet(outletName) !== null) {
 			return
 		}
 		val outlet = new Outlet(outletName)
 		outlet.name = outletName
 		outlet.overwrite = overwrite
-		outlet.fileEncoding = if (encoding != null) {
+		outlet.fileEncoding = if (encoding !== null) {
 			encoding
 		} else {
 			getOutlet(defaultOutletName).fileEncoding
 		}
-		outlet.path = if (pathIdeaPluginProject != null) {
+		outlet.path = if (pathIdeaPluginProject !== null) {
 			pathIdeaPluginProject + projectPath
 		} else {
 			getOutlet(defaultOutletName).path

--- a/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/IdeaPluginGenerator.java
+++ b/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/IdeaPluginGenerator.java
@@ -957,8 +957,7 @@ public class IdeaPluginGenerator extends Xtend2GeneratorFragment {
   }
   
   public String getEncoding() {
-    boolean _notEquals = (!Objects.equal(this.encoding, null));
-    if (_notEquals) {
+    if ((this.encoding != null)) {
       return this.encoding;
     }
     return System.getProperty("file.encoding");
@@ -2466,7 +2465,7 @@ public class IdeaPluginGenerator extends Xtend2GeneratorFragment {
           _builder.newLine();
           _builder.append("\t");
           _builder.append("\t");
-          _builder.append("if (hasSemanticElement != null && hasSemanticElement) {");
+          _builder.append("if (hasSemanticElement !== null && hasSemanticElement) {");
           _builder.newLine();
           _builder.append("\t");
           _builder.append("\t\t");

--- a/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/AntlrGrammarGenerator.java
+++ b/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/AntlrGrammarGenerator.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.generator.parser.antlr;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Singleton;
 import java.util.List;
@@ -599,8 +598,8 @@ public class AntlrGrammarGenerator extends AbstractAntlrGrammarWithActionsGenera
       _builder.append("$current = forceCreateModelElement");
       {
         String _feature = it.getFeature();
-        boolean _notEquals = (!Objects.equal(_feature, null));
-        if (_notEquals) {
+        boolean _tripleNotEquals = (_feature != null);
+        if (_tripleNotEquals) {
           _builder.append("And");
           String _setOrAdd = this._grammarAccessExtensions.setOrAdd(it);
           String _firstUpper = StringExtensions.toFirstUpper(_setOrAdd);

--- a/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.java
+++ b/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.java
@@ -147,11 +147,11 @@ public class GrammarAccessExtensions {
   }
   
   protected boolean _mustBeParenthesized(final Keyword it) {
-    return ((this.predicated(it) || it.isFirstSetPredicated()) || (!Objects.equal(it.getCardinality(), null)));
+    return ((this.predicated(it) || it.isFirstSetPredicated()) || (it.getCardinality() != null));
   }
   
   protected boolean _mustBeParenthesized(final RuleCall it) {
-    return ((this.predicated(it) || it.isFirstSetPredicated()) || (!Objects.equal(it.getCardinality(), null)));
+    return ((this.predicated(it) || it.isFirstSetPredicated()) || (it.getCardinality() != null));
   }
   
   protected boolean _predicated(final AbstractElement it) {
@@ -301,8 +301,8 @@ public class GrammarAccessExtensions {
     boolean _matched = false;
     if (it instanceof RuleCall) {
       AbstractRule _rule = ((RuleCall)it).getRule();
-      boolean _notEquals = (!Objects.equal(_rule, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_rule != null);
+      if (_tripleNotEquals) {
         _matched=true;
         StringConcatenation _builder = new StringConcatenation();
         _builder.append("\"");

--- a/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/XtextIDEAGeneratorExtensions.java
+++ b/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/XtextIDEAGeneratorExtensions.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.idea.generator.parser.antlr;
 
-import com.google.common.base.Objects;
 import com.google.inject.Singleton;
 import org.eclipse.xpand2.XpandExecutionContext;
 import org.eclipse.xpand2.output.Outlet;
@@ -39,16 +38,15 @@ public class XtextIDEAGeneratorExtensions {
   
   protected void installOutlet(final Xtend2ExecutionContext it, final String pathIdeaPluginProject, final String outletName, final String projectPath, final String encoding, final boolean overwrite, final String defaultOutletName, final String lineDelimiter) {
     Outlet _outlet = this.getOutlet(it, outletName);
-    boolean _notEquals = (!Objects.equal(_outlet, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_outlet != null);
+    if (_tripleNotEquals) {
       return;
     }
     final Outlet outlet = new Outlet(outletName);
     outlet.setName(outletName);
     outlet.setOverwrite(overwrite);
     String _xifexpression = null;
-    boolean _notEquals_1 = (!Objects.equal(encoding, null));
-    if (_notEquals_1) {
+    if ((encoding != null)) {
       _xifexpression = encoding;
     } else {
       Outlet _outlet_1 = this.getOutlet(it, defaultOutletName);
@@ -56,8 +54,7 @@ public class XtextIDEAGeneratorExtensions {
     }
     outlet.setFileEncoding(_xifexpression);
     String _xifexpression_1 = null;
-    boolean _notEquals_2 = (!Objects.equal(pathIdeaPluginProject, null));
-    if (_notEquals_2) {
+    if ((pathIdeaPluginProject != null)) {
       _xifexpression_1 = (pathIdeaPluginProject + projectPath);
     } else {
       Outlet _outlet_2 = this.getOutlet(it, defaultOutletName);

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.xtend
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.xtend
@@ -56,7 +56,7 @@ class LoggingTester {
 
 		def assertNumberOfLogEntries(int number, Level level, String... messageParts) {
 			val passed = logEntries.filter [ log |
-				(level == null || log.level == level) && messageParts.forall[log.message.contains(it)]
+				(level === null || log.level == level) && messageParts.forall[log.message.contains(it)]
 			]
 			if (passed.size != number) {
 				Assert.fail(
@@ -68,7 +68,7 @@ class LoggingTester {
 						«ELSE»
 							Expected «number» log entries
 						«ENDIF»
-						«IF level != null»
+						«IF level !== null»
 							with «level» level
 						«ENDIF»
 						containing the phrases «messageParts.join(", ")['"' + it + '"']»
@@ -110,7 +110,7 @@ class LoggingTester {
 
 	private static def appenderHierarchy(Logger logger) {
 		val appenders = newArrayList
-		for (var Category current = logger; current != null; current = current.parent) {
+		for (var Category current = logger; current !== null; current = current.parent) {
 			appenders.addAll(Collections.<Appender>list(current.allAppenders))
 		}
 		appenders
@@ -121,7 +121,7 @@ class LoggingTester {
 			appender.clearFilters
 			appender.addFilter(filter.getNext)
 		} else {
-			for (var current = appender.filter; current != null; current = current.getNext) {
+			for (var current = appender.filter; current !== null; current = current.getNext) {
 				if (current.getNext == filter) {
 					current.setNext(filter.getNext)
 					return

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/util/InMemoryURIHandler.xtend
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/util/InMemoryURIHandler.xtend
@@ -43,7 +43,7 @@ class InMemoryURIHandler implements URIHandler {
 		}
 
 		def InputStream createInputStream() {
-			if (contents == null || !exists) {
+			if (contents === null || !exists) {
 				throw new IOException("File " + uri + " does not exist.")
 			}
 			return new ByteArrayInputStream(contents)
@@ -87,7 +87,7 @@ class InMemoryURIHandler implements URIHandler {
 
 	protected def getInMemoryFile(URI uri) {
 		var result = files.get(uri)
-		if (result == null) {
+		if (result === null) {
 			result = new InMemFile(uri)
 			files.put(uri, result)
 		}

--- a/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/logging/LoggingTester.java
+++ b/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/logging/LoggingTester.java
@@ -68,7 +68,7 @@ public class LoggingTester {
     
     public void assertNumberOfLogEntries(final int number, final Level level, final String... messageParts) {
       final Function1<LoggingTester.LogEntry, Boolean> _function = (LoggingTester.LogEntry log) -> {
-        return Boolean.valueOf(((Objects.equal(level, null) || Objects.equal(log.level, level)) && IterableExtensions.<String>forall(((Iterable<String>)Conversions.doWrapArray(messageParts)), ((Function1<String, Boolean>) (String it) -> {
+        return Boolean.valueOf((((level == null) || Objects.equal(log.level, level)) && IterableExtensions.<String>forall(((Iterable<String>)Conversions.doWrapArray(messageParts)), ((Function1<String, Boolean>) (String it) -> {
           return Boolean.valueOf(log.message.contains(it));
         }))));
       };
@@ -94,8 +94,7 @@ public class LoggingTester {
           }
         }
         {
-          boolean _notEquals_1 = (!Objects.equal(level, null));
-          if (_notEquals_1) {
+          if ((level != null)) {
             _builder.append("with ");
             _builder.append(level, "");
             _builder.append(" level");
@@ -380,7 +379,7 @@ public class LoggingTester {
     ArrayList<Appender> _xblockexpression = null;
     {
       final ArrayList<Appender> appenders = CollectionLiterals.<Appender>newArrayList();
-      for (Category current = logger; (!Objects.equal(current, null)); current = current.getParent()) {
+      for (Category current = logger; (current != null); current = current.getParent()) {
         Enumeration _allAppenders = current.getAllAppenders();
         ArrayList<Appender> _list = Collections.<Appender>list(_allAppenders);
         appenders.addAll(_list);
@@ -398,7 +397,7 @@ public class LoggingTester {
       Filter _next = filter.getNext();
       appender.addFilter(_next);
     } else {
-      for (Filter current = appender.getFilter(); (!Objects.equal(current, null)); current = current.getNext()) {
+      for (Filter current = appender.getFilter(); (current != null); current = current.getNext()) {
         Filter _next_1 = current.getNext();
         boolean _equals_1 = Objects.equal(_next_1, filter);
         if (_equals_1) {

--- a/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/util/InMemoryURIHandler.java
+++ b/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/util/InMemoryURIHandler.java
@@ -54,7 +54,7 @@ public class InMemoryURIHandler implements URIHandler {
     
     public InputStream createInputStream() {
       try {
-        if ((Objects.equal(this.contents, null) || (!this.exists))) {
+        if (((this.contents == null) || (!this.exists))) {
           throw new IOException((("File " + this.uri) + " does not exist."));
         }
         return new ByteArrayInputStream(this.contents);
@@ -142,8 +142,7 @@ public class InMemoryURIHandler implements URIHandler {
   
   protected InMemoryURIHandler.InMemFile getInMemoryFile(final URI uri) {
     InMemoryURIHandler.InMemFile result = this.files.get(uri);
-    boolean _equals = Objects.equal(result, null);
-    if (_equals) {
+    if ((result == null)) {
       InMemoryURIHandler.InMemFile _inMemFile = new InMemoryURIHandler.InMemFile(uri);
       result = _inMemFile;
       this.files.put(uri, result);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.xtend
@@ -43,7 +43,7 @@ class DefaultCopyQualifiedNameService implements CopyQualifiedNameService {
 	}
 
 	def protected <T> toQualifiedNames(List<T> it, (T)=>String toQualifiedNameFunction) {
-		if (it == null || size == 0) {
+		if (it === null || size == 0) {
 			return ""
 		}
 		'''«FOR element : it SEPARATOR ', '»«toQualifiedNameFunction.apply(element)»«ENDFOR»'''
@@ -57,14 +57,14 @@ class DefaultCopyQualifiedNameService implements CopyQualifiedNameService {
 	}
 
 	def protected getFullyQualifiedName(EObject it) {
-		if (it == null) {
+		if (it === null) {
 			return null
 		}
 		qualifiedNameProvider.getFullyQualifiedName(it)
 	}
 
 	def protected toString(EObject it, QualifiedName fullyQualifiedName) {
-		if (fullyQualifiedName == null) {
+		if (fullyQualifiedName === null) {
 			return null
 		}
 		qualifiedNameConverter.toString(fullyQualifiedName)

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.ui.editor.copyqualifiedname;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
@@ -50,7 +49,7 @@ public class DefaultCopyQualifiedNameService implements CopyQualifiedNameService
   protected <T extends Object> CharSequence toQualifiedNames(final List<T> it, final Function1<? super T, ? extends String> toQualifiedNameFunction) {
     CharSequence _xblockexpression = null;
     {
-      if ((Objects.equal(it, null) || (it.size() == 0))) {
+      if (((it == null) || (it.size() == 0))) {
         return "";
       }
       StringConcatenation _builder = new StringConcatenation();
@@ -87,8 +86,7 @@ public class DefaultCopyQualifiedNameService implements CopyQualifiedNameService
   protected QualifiedName getFullyQualifiedName(final EObject it) {
     QualifiedName _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(it, null);
-      if (_equals) {
+      if ((it == null)) {
         return null;
       }
       _xblockexpression = this.qualifiedNameProvider.getFullyQualifiedName(it);
@@ -99,8 +97,7 @@ public class DefaultCopyQualifiedNameService implements CopyQualifiedNameService
   protected String toString(final EObject it, final QualifiedName fullyQualifiedName) {
     String _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(fullyQualifiedName, null);
-      if (_equals) {
+      if ((fullyQualifiedName == null)) {
         return null;
       }
       _xblockexpression = this.qualifiedNameConverter.toString(fullyQualifiedName);

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.xtend
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.xtend
@@ -53,7 +53,7 @@ class InMemoryJavaCompiler {
 				return cache.get(fileName)
 			}
 			val url = classLoader.getResource(fileName)
-			if (url == null) {
+			if (url === null) {
 				cache.put(fileName, null)
 				return null;
 			}
@@ -69,7 +69,7 @@ class InMemoryJavaCompiler {
 				return cache.get(fileName)
 			}
 			val url = classLoader.getResource(fileName)
-			if (url == null) {
+			if (url === null) {
 				cache.put(fileName, null)
 				return null;
 			}
@@ -106,7 +106,7 @@ class InMemoryJavaCompiler {
 			if (path.endsWith(".class")) {
 				val className = path.substring(0, path.length-6).replace("/", ".")
 				val bytes = classMap.get(className)
-				if (bytes != null) {
+				if (bytes !== null) {
 					return new URL("in-memory", null, -1, path, [ 
 						new URLConnection(it) {
 							override void connect() {}

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/Oven.xtend
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/Oven.xtend
@@ -51,15 +51,15 @@ class Oven extends Assert {
 			val file = input.parse
 			val resolvedTypes = typeResolver.resolveTypes(file)
 			assertNotNull(resolvedTypes)
-			if (file != null) {
+			if (file !== null) {
 				for(content: file.eAllContents.toIterable) {
 					switch(content) {
 						XAbstractFeatureCall: {
 							assertExpressionTypeIsResolved(content, resolvedTypes)
-							if (content.implicitReceiver != null) {
+							if (content.implicitReceiver !== null) {
 								assertExpressionTypeIsResolved(content.implicitReceiver, resolvedTypes)
 							}
-							if (content.implicitFirstArgument != null) {
+							if (content.implicitFirstArgument !== null) {
 								assertExpressionTypeIsResolved(content.implicitFirstArgument, resolvedTypes)
 							}
 						}
@@ -98,11 +98,11 @@ class Oven extends Assert {
 			} 
 			default: internalTypes.invoke("getTypeData", expression, Boolean.FALSE) as TypeData
 		}
-		assertTrue("Type is not resolved. Expression: " + expression.toString, if (expression instanceof XAbstractFeatureCall) expression.packageFragment || type != null else type != null)
+		assertTrue("Type is not resolved. Expression: " + expression.toString, if (expression instanceof XAbstractFeatureCall) expression.packageFragment || type !== null else type !== null)
 	}
 	
 	def void assertIdentifiableTypeIsResolved(JvmIdentifiableElement identifiable, IResolvedTypes types) {
-		if (identifiable.simpleName == null)
+		if (identifiable.simpleName === null)
 			return;
 		val type = types.getActualType(identifiable)
 		assertNotNull(identifiable.toString, type)

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.compiler;
 
-import com.google.common.base.Objects;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -75,8 +74,7 @@ public class InMemoryJavaCompiler {
           return this.cache.get(fileName);
         }
         final URL url = this.classLoader.getResource(fileName);
-        boolean _equals = Objects.equal(url, null);
-        if (_equals) {
+        if ((url == null)) {
           this.cache.put(fileName, null);
           return null;
         }
@@ -107,8 +105,7 @@ public class InMemoryJavaCompiler {
           return this.cache.get(fileName);
         }
         final URL url = this.classLoader.getResource(fileName);
-        boolean _equals = Objects.equal(url, null);
-        if (_equals) {
+        if ((url == null)) {
           this.cache.put(fileName, null);
           return null;
         }
@@ -163,8 +160,7 @@ public class InMemoryJavaCompiler {
           String _substring = path.substring(0, _minus);
           final String className = _substring.replace("/", ".");
           final byte[] bytes = this.classMap.get(className);
-          boolean _notEquals = (!Objects.equal(bytes, null));
-          if (_notEquals) {
+          if ((bytes != null)) {
             final URLStreamHandler _function = new URLStreamHandler() {
               @Override
               protected URLConnection openConnection(final URL it) throws IOException {

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/Oven.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/Oven.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.xbase.junit.typesystem;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.lang.reflect.Method;
@@ -66,8 +65,7 @@ public class Oven extends Assert {
       final EObject file = this._parseHelper.parse(input);
       final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(file);
       Assert.assertNotNull(resolvedTypes);
-      boolean _notEquals = (!Objects.equal(file, null));
-      if (_notEquals) {
+      if ((file != null)) {
         TreeIterator<EObject> _eAllContents = file.eAllContents();
         Iterable<EObject> _iterable = IteratorExtensions.<EObject>toIterable(_eAllContents);
         for (final EObject content : _iterable) {
@@ -76,14 +74,14 @@ public class Oven extends Assert {
             _matched=true;
             this.assertExpressionTypeIsResolved(((XExpression)content), resolvedTypes);
             XExpression _implicitReceiver = ((XAbstractFeatureCall)content).getImplicitReceiver();
-            boolean _notEquals_1 = (!Objects.equal(_implicitReceiver, null));
-            if (_notEquals_1) {
+            boolean _tripleNotEquals = (_implicitReceiver != null);
+            if (_tripleNotEquals) {
               XExpression _implicitReceiver_1 = ((XAbstractFeatureCall)content).getImplicitReceiver();
               this.assertExpressionTypeIsResolved(_implicitReceiver_1, resolvedTypes);
             }
             XExpression _implicitFirstArgument = ((XAbstractFeatureCall)content).getImplicitFirstArgument();
-            boolean _notEquals_2 = (!Objects.equal(_implicitFirstArgument, null));
-            if (_notEquals_2) {
+            boolean _tripleNotEquals_1 = (_implicitFirstArgument != null);
+            if (_tripleNotEquals_1) {
               XExpression _implicitFirstArgument_1 = ((XAbstractFeatureCall)content).getImplicitFirstArgument();
               this.assertExpressionTypeIsResolved(_implicitFirstArgument_1, resolvedTypes);
             }
@@ -157,9 +155,9 @@ public class Oven extends Assert {
       String _plus = ("Type is not resolved. Expression: " + _string);
       boolean _xifexpression = false;
       if ((expression instanceof XAbstractFeatureCall)) {
-        _xifexpression = (((XAbstractFeatureCall)expression).isPackageFragment() || (!Objects.equal(type, null)));
+        _xifexpression = (((XAbstractFeatureCall)expression).isPackageFragment() || (type != null));
       } else {
-        _xifexpression = (!Objects.equal(type, null));
+        _xifexpression = (type != null);
       }
       Assert.assertTrue(_plus, _xifexpression);
     } catch (Throwable _e) {
@@ -169,8 +167,8 @@ public class Oven extends Assert {
   
   public void assertIdentifiableTypeIsResolved(final JvmIdentifiableElement identifiable, final IResolvedTypes types) {
     String _simpleName = identifiable.getSimpleName();
-    boolean _equals = Objects.equal(_simpleName, null);
-    if (_equals) {
+    boolean _tripleEquals = (_simpleName == null);
+    if (_tripleEquals) {
       return;
     }
     final LightweightTypeReference type = types.getActualType(identifiable);

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/editor/AbstractXbaseContentAssistBugTest.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/editor/AbstractXbaseContentAssistBugTest.xtend
@@ -44,7 +44,7 @@ class AbstractXbaseContentAssistBugTest extends AbstractXbaseUITestCase implemen
 	}
 	
 	override void tearDown() throws Exception {
-		if (demandCreateProject != null)
+		if (demandCreateProject !== null)
 			deleteProject(demandCreateProject);
 		super.tearDown();
 	}
@@ -56,7 +56,7 @@ class AbstractXbaseContentAssistBugTest extends AbstractXbaseUITestCase implemen
 	override getJavaProject(ResourceSet resourceSet) {
 		val projectName = getProjectName();
 		var javaProject = findJavaProject(projectName);
-		if (javaProject == null || !javaProject.exists()) {
+		if (javaProject === null || !javaProject.exists()) {
 			try {
 				demandCreateProject = AbstractXbaseUITestCase::createPluginProject(projectName);
 				javaProject = findJavaProject(projectName);

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/quickfix/AbstractXbaseQuickfixTest.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/quickfix/AbstractXbaseQuickfixTest.xtend
@@ -32,7 +32,7 @@ abstract class AbstractXbaseQuickfixTest extends AbstractXbaseUITestCase impleme
 	)
 
 	override void tearDown() throws Exception {
-		if (demandCreateProject != null)
+		if (demandCreateProject !== null)
 			deleteProject(demandCreateProject);
 		super.tearDown();
 	}
@@ -40,7 +40,7 @@ abstract class AbstractXbaseQuickfixTest extends AbstractXbaseUITestCase impleme
 	override getJavaProject(ResourceSet resourceSet) {
 		val projectName = getProjectName();
 		var javaProject = findJavaProject(projectName);
-		if (javaProject == null || !javaProject.exists()) {
+		if (javaProject === null || !javaProject.exists()) {
 			try {
 				demandCreateProject = AbstractXbaseUITestCase::createPluginProject(projectName);
 				javaProject = findJavaProject(projectName);

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/refactoring/ExpressionUtilTest.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/refactoring/ExpressionUtilTest.xtend
@@ -203,7 +203,7 @@ class ExpressionUtilTest extends AbstractXbaseTestCase {
 		val selectedExpression = util.findSelectedExpression(expression.eResource as XtextResource, 
 			new TextSelection(selectionOffset, 0))
 		val successor = util.findSuccessorExpressionForVariableDeclaration(selectedExpression)
-		if(expectedSuccessor == null) 
+		if(expectedSuccessor === null) 
 			assertNull(successor)
 		else {
 			assertNotNull(successor)

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/editor/AbstractXbaseContentAssistBugTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/editor/AbstractXbaseContentAssistBugTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.ui.tests.editor;
 
-import com.google.common.base.Objects;
 import com.google.inject.Injector;
 import java.io.InputStream;
 import org.eclipse.core.resources.IProject;
@@ -51,8 +50,7 @@ public class AbstractXbaseContentAssistBugTest extends AbstractXbaseUITestCase i
   
   @Override
   public void tearDown() throws Exception {
-    boolean _notEquals = (!Objects.equal(this.demandCreateProject, null));
-    if (_notEquals) {
+    if ((this.demandCreateProject != null)) {
       JavaProjectSetupUtil.deleteProject(this.demandCreateProject);
     }
     super.tearDown();
@@ -67,7 +65,7 @@ public class AbstractXbaseContentAssistBugTest extends AbstractXbaseUITestCase i
   public IJavaProject getJavaProject(final ResourceSet resourceSet) {
     final String projectName = this.getProjectName();
     IJavaProject javaProject = JavaProjectSetupUtil.findJavaProject(projectName);
-    if ((Objects.equal(javaProject, null) || (!javaProject.exists()))) {
+    if (((javaProject == null) || (!javaProject.exists()))) {
       try {
         IProject _createPluginProject = AbstractXbaseUITestCase.createPluginProject(projectName);
         this.demandCreateProject = _createPluginProject;

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/quickfix/AbstractXbaseQuickfixTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/quickfix/AbstractXbaseQuickfixTest.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.xbase.ui.tests.quickfix;
 
-import com.google.common.base.Objects;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import java.io.InputStream;
@@ -33,8 +32,7 @@ public abstract class AbstractXbaseQuickfixTest extends AbstractXbaseUITestCase 
   
   @Override
   public void tearDown() throws Exception {
-    boolean _notEquals = (!Objects.equal(this.demandCreateProject, null));
-    if (_notEquals) {
+    if ((this.demandCreateProject != null)) {
       JavaProjectSetupUtil.deleteProject(this.demandCreateProject);
     }
     super.tearDown();
@@ -44,7 +42,7 @@ public abstract class AbstractXbaseQuickfixTest extends AbstractXbaseUITestCase 
   public IJavaProject getJavaProject(final ResourceSet resourceSet) {
     final String projectName = this.getProjectName();
     IJavaProject javaProject = JavaProjectSetupUtil.findJavaProject(projectName);
-    if ((Objects.equal(javaProject, null) || (!javaProject.exists()))) {
+    if (((javaProject == null) || (!javaProject.exists()))) {
       try {
         IProject _createPluginProject = AbstractXbaseUITestCase.createPluginProject(projectName);
         this.demandCreateProject = _createPluginProject;

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/refactoring/ExpressionUtilTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/refactoring/ExpressionUtilTest.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.xbase.ui.tests.refactoring;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -239,8 +238,7 @@ public class ExpressionUtilTest extends AbstractXbaseTestCase {
     TextSelection _textSelection = new TextSelection(selectionOffset, 0);
     final XExpression selectedExpression = this.util.findSelectedExpression(((XtextResource) _eResource), _textSelection);
     final XExpression successor = this.util.findSuccessorExpressionForVariableDeclaration(selectedExpression);
-    boolean _equals = Objects.equal(expectedSuccessor, null);
-    if (_equals) {
+    if ((expectedSuccessor == null)) {
       Assert.assertNull(successor);
     } else {
       Assert.assertNotNull(successor);

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.xtend
@@ -47,7 +47,7 @@ class XbaseEditorInputRedirector {
 	 */
 	def IEditorInput findOriginalSourceForOuputFolderCopy(IEditorInput input) {
 		val resource = ResourceUtil.getFile(input)
-		if (resource != null) {
+		if (resource !== null) {
 			// if the given resource is already pointing to a language file
 			if (fileExtensionProvider.isValid(resource.fullPath.fileExtension)) {
 				val project = JavaCore.create(resource.project)
@@ -66,7 +66,7 @@ class XbaseEditorInputRedirector {
 					}
 					// check if it's sitting in one of the output folders set on the source folders
 					for (sourceFolder : project.rawClasspath.filter[entryKind == IClasspathEntry.CPE_SOURCE]) {
-						if (sourceFolder.outputLocation != null
+						if (sourceFolder.outputLocation !== null
 							&& sourceFolder.outputLocation.isPrefixOf(resource.fullPath)) {
 								val relative = resource.fullPath.removeFirstSegments(sourceFolder.outputLocation.segmentCount)
 								val source = project.findPackageFragmentRoots(sourceFolder).head
@@ -85,26 +85,26 @@ class XbaseEditorInputRedirector {
 
 	def IEditorInput findOriginalSource(IEditorInput input) {
 		val resource = ResourceUtil.getFile(input)
-		if (resource != null) {
+		if (resource !== null) {
 			val original = findOriginalSourceForOuputFolderCopy(input)
 			if (original !== input)
 				return original
 
 			val trace = traceInformation.getTraceToSource(resource);
-			if (trace == null)
+			if (trace === null)
 				return input;
 			val allLocations = trace.getAllAssociatedLocations().iterator();
 			var ILocationInEclipseResource sourceInformation = null;
-			while (allLocations.hasNext() && sourceInformation == null) {
+			while (allLocations.hasNext() && sourceInformation === null) {
 				val candidate = allLocations.next();
 				if (languageInfo.equals(candidate.getLanguage())) {
 					sourceInformation = candidate;
 				}
 			}
-			if (sourceInformation == null)
+			if (sourceInformation === null)
 				return input;
 			val originalStorage = sourceInformation.platformResource
-			if (originalStorage != null) {
+			if (originalStorage !== null) {
 				return EditorUtils.createEditorInput(originalStorage)
 			}
 		}

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.xtend
@@ -65,11 +65,11 @@ class XbaseCopyQualifiedNameService extends DefaultCopyQualifiedNameService {
 	protected def toQualifiedName(XExpression it, IResolvedExecutable resolvedExecutable, JvmExecutable executable,
 		extension IResolvedTypes resolvedTypes, List<XExpression> arguments) {
 		val actualType = actualType
-		if (actualType != null && !actualType.any && !actualType.unknown) {
+		if (actualType !== null && !actualType.any && !actualType.unknown) {
 			return actualType.humanReadableName
 		}
 		val index = arguments.indexOf(it)
-		if (resolvedExecutable == null) {
+		if (resolvedExecutable === null) {
 			return executable.parameters.get(index).parameterType.simpleName
 		}
 		return resolvedExecutable.resolvedParameterTypes.get(index).simpleName

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/JvmAnnotationReferencePrinter.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/JvmAnnotationReferencePrinter.xtend
@@ -50,7 +50,7 @@ class JvmAnnotationReferencePrinter {
 		val uri = EcoreUtil.getURI(reference.getAnnotation());
 		buffer.append(createLinkWithLabel(XtextElementLinks.XTEXTDOC_SCHEME, uri, reference.getAnnotation().getSimpleName()));
 		
-		val needsExplicitProperties = reference.explicitValues.size>1 || (reference.explicitValues.head?.operation != null && reference.explicitValues.head.operation.simpleName!="value")
+		val needsExplicitProperties = reference.explicitValues.size>1 || (reference.explicitValues.head?.operation !== null && reference.explicitValues.head.operation.simpleName!="value")
 		if (reference.getExplicitValues().size() > 0) {
 			buffer.append("(");
 			buffer.append(reference.getExplicitValues().map[
@@ -74,7 +74,7 @@ class JvmAnnotationReferencePrinter {
 		buffer.append("@");
 		val uri = EcoreUtil.getURI(reference.annotationType);
 		buffer.append(createLinkWithLabel(XtextElementLinks.XTEXTDOC_SCHEME, uri, reference.annotationType.getSimpleName()));
-		if (reference.value != null) {
+		if (reference.value !== null) {
 			buffer.append("(")
 			buffer.append(reference.value)
 			buffer.append(")");
@@ -96,7 +96,7 @@ class JvmAnnotationReferencePrinter {
 	
 	protected def dispatch String internalToString(JvmAnnotationValue it) {
 		val ref = eClass.getEStructuralFeature('values')
-		if (ref == null) {
+		if (ref === null) {
 			throw new IllegalStateException("Cannot handle "+it)
 		}
 		val EList<?> values = eGet(ref) as EList<?>
@@ -153,13 +153,13 @@ class JvmAnnotationReferencePrinter {
 	}
 	
 	protected def internalHandleAbstractFeatureCall(String prefix, XAbstractFeatureCall o) {
-		val postfix = if (o.feature != null && ! o.feature.eIsProxy) {
+		val postfix = if (o.feature !== null && ! o.feature.eIsProxy) {
 			val uri = EcoreUtil.getURI(o.feature)
 			createLinkWithLabel(XtextElementLinks.XTEXTDOC_SCHEME,uri,o.concreteSyntaxFeatureName) 
 		} else {
 			o.concreteSyntaxFeatureName
 		}
-		if (prefix == null) {
+		if (prefix === null) {
 			return postfix
 		} else {
 			return prefix + '.' + postfix

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/labeling/XbaseImageAdornments.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/labeling/XbaseImageAdornments.xtend
@@ -48,9 +48,9 @@ class XbaseImageAdornments {
 			.or(deprecatedMember, DEPRECATED)
 			.or(native, 0x4000) // JavaElementImageDescription.NATIVE not available before 3.7
 			
-		if(eResource?.resourceSet != null) {
+		if(eResource?.resourceSet !== null) {
 			val overriddenOperation = findOverriddenOperation
-			if(overriddenOperation != null) 
+			if(overriddenOperation !== null) 
 				return adornment.bitwiseOr(getOverrideAdornment(overriddenOperation))
 		}
 		return adornment

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/labeling/XbaseLabelProvider.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/labeling/XbaseLabelProvider.xtend
@@ -130,7 +130,7 @@ class XbaseLabelProvider extends DefaultEObjectLabelProvider {
 
 	protected def String text(JvmFormalParameter parameter) {
 		val parameterType = parameter.parameterType
-		if (parameterType == null)
+		if (parameterType === null)
 			parameter.name
 		else
 			parameterType.getSimpleName + " " + parameter.name
@@ -141,7 +141,7 @@ class XbaseLabelProvider extends DefaultEObjectLabelProvider {
 	}
 
 	protected def String text(XImportDeclaration it) 
-		'''«importedTypeName»«IF wildcard».*«ELSEIF memberName != null».«memberName»«ENDIF»'''
+		'''«importedTypeName»«IF wildcard».*«ELSEIF memberName !== null».«memberName»«ENDIF»'''
 
 	protected def String text(XImportSection importSection) {
 		return "import declarations";
@@ -150,7 +150,7 @@ class XbaseLabelProvider extends DefaultEObjectLabelProvider {
 	protected def String text(XVariableDeclaration variableDeclaration) {
 		val resolvedTypes = typeResolver.resolveTypes(variableDeclaration)
 		val type = resolvedTypes.getActualType(variableDeclaration as JvmIdentifiableElement)
-		if (type != null)
+		if (type !== null)
 			type.humanReadableName + " " + variableDeclaration.name
 		else 
 			variableDeclaration.name
@@ -169,7 +169,7 @@ class XbaseLabelProvider extends DefaultEObjectLabelProvider {
 			null
 		}
 		val owner = new StandardTypeReferenceOwner(services, element);
-		val returnTypeString = if (returnType == null) {
+		val returnTypeString = if (returnType === null) {
 				"void"
 			} else {
 				owner.toLightweightTypeReference(returnType).humanReadableName

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/util/InsertionOffsets.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/util/InsertionOffsets.xtend
@@ -27,7 +27,7 @@ class InsertionOffsets {
 	def inEmpty(EObject element) {
 		val node = NodeModelUtils.findActualNodeFor(element)
 		val openingBraceNode = node.leafNodes.findFirst[text == "{"]
-		if (openingBraceNode != null)
+		if (openingBraceNode !== null)
 			openingBraceNode.offset + 1
 		else
 			node.endOffset

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/validation/ProjectAwareUniqueClassNameValidator.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/validation/ProjectAwareUniqueClassNameValidator.xtend
@@ -119,7 +119,7 @@ class ProjectAwareUniqueClassNameValidator extends UniqueClassNameValidator {
 		
 		val workingCopyPaths = newHashSet
 		var copies = getWorkingCopies(type)
-		if (copies != null) {
+		if (copies !== null) {
 			for (workingCopy: copies) {
 				val path = workingCopy.path
 				if (javaProject.path.isPrefixOf(path) && !isDerived(workingCopy.resource)) {
@@ -138,7 +138,7 @@ class ProjectAwareUniqueClassNameValidator extends UniqueClassNameValidator {
 		// code below is adapted from BasicSearchEnginge.searchAllSecondaryTypes
 		// index is ready, query it for a secondary type 
 		val pattern = new TypeDeclarationPattern(
-			if(packageName == null) CharOperation.NO_CHAR else packageName.toCharArray(), CharOperation.NO_CHAR_CHAR, // top level type - no enclosing type names
+			if(packageName === null) CharOperation.NO_CHAR else packageName.toCharArray(), CharOperation.NO_CHAR_CHAR, // top level type - no enclosing type names
 			typeName.toCharArray(), IIndexConstants.TYPE_SUFFIX,
 			SearchPattern.R_EXACT_MATCH.bitwiseOr(SearchPattern.R_CASE_SENSITIVE))
 		
@@ -178,7 +178,7 @@ class ProjectAwareUniqueClassNameValidator extends UniqueClassNameValidator {
 				return true
 			}
 			val outputConfigurations = context.get(OUTPUT_CONFIGS) as Collection<OutputConfiguration>
-			if (outputConfigurations != null) {
+			if (outputConfigurations !== null) {
 				val projectRelativePath = resource.projectRelativePath
 				for(outputConfiguration: outputConfigurations) {
 					for(dir: outputConfiguration.outputDirectories) {

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.ui.editor;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -68,8 +67,7 @@ public class XbaseEditorInputRedirector {
   public IEditorInput findOriginalSourceForOuputFolderCopy(final IEditorInput input) {
     try {
       final IFile resource = ResourceUtil.getFile(input);
-      boolean _notEquals = (!Objects.equal(resource, null));
-      if (_notEquals) {
+      if ((resource != null)) {
         IPath _fullPath = resource.getFullPath();
         String _fileExtension = _fullPath.getFileExtension();
         boolean _isValid = this.fileExtensionProvider.isValid(_fileExtension);
@@ -117,7 +115,7 @@ public class XbaseEditorInputRedirector {
             };
             Iterable<IClasspathEntry> _filter_1 = IterableExtensions.<IClasspathEntry>filter(((Iterable<IClasspathEntry>)Conversions.doWrapArray(_rawClasspath)), _function_1);
             for (final IClasspathEntry sourceFolder : _filter_1) {
-              if (((!Objects.equal(sourceFolder.getOutputLocation(), null)) && sourceFolder.getOutputLocation().isPrefixOf(resource.getFullPath()))) {
+              if (((sourceFolder.getOutputLocation() != null) && sourceFolder.getOutputLocation().isPrefixOf(resource.getFullPath()))) {
                 IPath _fullPath_3 = resource.getFullPath();
                 IPath _outputLocation_2 = sourceFolder.getOutputLocation();
                 int _segmentCount_1 = _outputLocation_2.segmentCount();
@@ -146,37 +144,33 @@ public class XbaseEditorInputRedirector {
   
   public IEditorInput findOriginalSource(final IEditorInput input) {
     final IFile resource = ResourceUtil.getFile(input);
-    boolean _notEquals = (!Objects.equal(resource, null));
-    if (_notEquals) {
+    if ((resource != null)) {
       final IEditorInput original = this.findOriginalSourceForOuputFolderCopy(input);
       if ((original != input)) {
         return original;
       }
       final IEclipseTrace trace = this.traceInformation.getTraceToSource(resource);
-      boolean _equals = Objects.equal(trace, null);
-      if (_equals) {
+      if ((trace == null)) {
         return input;
       }
       Iterable<? extends ILocationInEclipseResource> _allAssociatedLocations = trace.getAllAssociatedLocations();
       final Iterator<? extends ILocationInEclipseResource> allLocations = _allAssociatedLocations.iterator();
       ILocationInEclipseResource sourceInformation = null;
-      while ((allLocations.hasNext() && Objects.equal(sourceInformation, null))) {
+      while ((allLocations.hasNext() && (sourceInformation == null))) {
         {
           final ILocationInEclipseResource candidate = allLocations.next();
           LanguageInfo _language = candidate.getLanguage();
-          boolean _equals_1 = this.languageInfo.equals(_language);
-          if (_equals_1) {
+          boolean _equals = this.languageInfo.equals(_language);
+          if (_equals) {
             sourceInformation = candidate;
           }
         }
       }
-      boolean _equals_1 = Objects.equal(sourceInformation, null);
-      if (_equals_1) {
+      if ((sourceInformation == null)) {
         return input;
       }
       final IStorage originalStorage = sourceInformation.getPlatformResource();
-      boolean _notEquals_1 = (!Objects.equal(originalStorage, null));
-      if (_notEquals_1) {
+      if ((originalStorage != null)) {
         return EditorUtils.createEditorInput(originalStorage);
       }
     }

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.ui.editor.copyqualifiedname;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
@@ -119,12 +118,11 @@ public class XbaseCopyQualifiedNameService extends DefaultCopyQualifiedNameServi
   
   protected String toQualifiedName(final XExpression it, final IResolvedExecutable resolvedExecutable, final JvmExecutable executable, @Extension final IResolvedTypes resolvedTypes, final List<XExpression> arguments) {
     final LightweightTypeReference actualType = resolvedTypes.getActualType(it);
-    if ((((!Objects.equal(actualType, null)) && (!actualType.isAny())) && (!actualType.isUnknown()))) {
+    if ((((actualType != null) && (!actualType.isAny())) && (!actualType.isUnknown()))) {
       return actualType.getHumanReadableName();
     }
     final int index = arguments.indexOf(it);
-    boolean _equals = Objects.equal(resolvedExecutable, null);
-    if (_equals) {
+    if ((resolvedExecutable == null)) {
       EList<JvmFormalParameter> _parameters = executable.getParameters();
       JvmFormalParameter _get = _parameters.get(index);
       JvmTypeReference _parameterType = _get.getParameterType();

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/hover/JvmAnnotationReferencePrinter.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/hover/JvmAnnotationReferencePrinter.java
@@ -99,16 +99,16 @@ public class JvmAnnotationReferencePrinter {
       if (_head!=null) {
         _operation=_head.getOperation();
       }
-      boolean _notEquals = (!Objects.equal(_operation, null));
-      if (!_notEquals) {
+      boolean _tripleNotEquals = (_operation != null);
+      if (!_tripleNotEquals) {
         _and = false;
       } else {
         EList<JvmAnnotationValue> _explicitValues_2 = reference.getExplicitValues();
         JvmAnnotationValue _head_1 = IterableExtensions.<JvmAnnotationValue>head(_explicitValues_2);
         JvmOperation _operation_1 = _head_1.getOperation();
         String _simpleName_1 = _operation_1.getSimpleName();
-        boolean _notEquals_1 = (!Objects.equal(_simpleName_1, "value"));
-        _and = _notEquals_1;
+        boolean _notEquals = (!Objects.equal(_simpleName_1, "value"));
+        _and = _notEquals;
       }
       _or = _and;
     }
@@ -165,8 +165,8 @@ public class JvmAnnotationReferencePrinter {
     String _createLinkWithLabel = this.createLinkWithLabel(XtextElementLinks.XTEXTDOC_SCHEME, uri, _simpleName);
     buffer.append(_createLinkWithLabel);
     XExpression _value = reference.getValue();
-    boolean _notEquals = (!Objects.equal(_value, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_value != null);
+    if (_tripleNotEquals) {
       buffer.append("(");
       XExpression _value_1 = reference.getValue();
       buffer.append(_value_1);
@@ -217,8 +217,7 @@ public class JvmAnnotationReferencePrinter {
   protected String _internalToString(final JvmAnnotationValue it) {
     EClass _eClass = it.eClass();
     final EStructuralFeature ref = _eClass.getEStructuralFeature("values");
-    boolean _equals = Objects.equal(ref, null);
-    if (_equals) {
+    if ((ref == null)) {
       throw new IllegalStateException(("Cannot handle " + it));
     }
     Object _eGet = it.eGet(ref);
@@ -315,7 +314,7 @@ public class JvmAnnotationReferencePrinter {
   
   protected String internalHandleAbstractFeatureCall(final String prefix, final XAbstractFeatureCall o) {
     String _xifexpression = null;
-    if (((!Objects.equal(o.getFeature(), null)) && (!o.getFeature().eIsProxy()))) {
+    if (((o.getFeature() != null) && (!o.getFeature().eIsProxy()))) {
       String _xblockexpression = null;
       {
         JvmIdentifiableElement _feature = o.getFeature();
@@ -328,8 +327,7 @@ public class JvmAnnotationReferencePrinter {
       _xifexpression = o.getConcreteSyntaxFeatureName();
     }
     final String postfix = _xifexpression;
-    boolean _equals = Objects.equal(prefix, null);
-    if (_equals) {
+    if ((prefix == null)) {
       return postfix;
     } else {
       return ((prefix + ".") + postfix);

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/labeling/XbaseImageAdornments.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/labeling/XbaseImageAdornments.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.xbase.ui.labeling;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -69,11 +68,10 @@ public class XbaseImageAdornments {
     if (_eResource!=null) {
       _resourceSet=_eResource.getResourceSet();
     }
-    boolean _notEquals = (!Objects.equal(_resourceSet, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_resourceSet != null);
+    if (_tripleNotEquals) {
       final JvmOperation overriddenOperation = this._overrideHelper.findOverriddenOperation(it);
-      boolean _notEquals_1 = (!Objects.equal(overriddenOperation, null));
-      if (_notEquals_1) {
+      if ((overriddenOperation != null)) {
         int _overrideAdornment = this.getOverrideAdornment(overriddenOperation);
         return (adornment | _overrideAdornment);
       }

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/labeling/XbaseLabelProvider.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/labeling/XbaseLabelProvider.java
@@ -212,8 +212,7 @@ public class XbaseLabelProvider extends DefaultEObjectLabelProvider {
     {
       final JvmTypeReference parameterType = parameter.getParameterType();
       String _xifexpression = null;
-      boolean _equals = Objects.equal(parameterType, null);
-      if (_equals) {
+      if ((parameterType == null)) {
         _xifexpression = parameter.getName();
       } else {
         String _simpleName = parameterType.getSimpleName();
@@ -241,8 +240,8 @@ public class XbaseLabelProvider extends DefaultEObjectLabelProvider {
         _builder.append(".*");
       } else {
         String _memberName = it.getMemberName();
-        boolean _notEquals = (!Objects.equal(_memberName, null));
-        if (_notEquals) {
+        boolean _tripleNotEquals = (_memberName != null);
+        if (_tripleNotEquals) {
           _builder.append(".");
           String _memberName_1 = it.getMemberName();
           _builder.append(_memberName_1, "");
@@ -262,8 +261,7 @@ public class XbaseLabelProvider extends DefaultEObjectLabelProvider {
       final IResolvedTypes resolvedTypes = this.typeResolver.resolveTypes(variableDeclaration);
       final LightweightTypeReference type = resolvedTypes.getActualType(((JvmIdentifiableElement) variableDeclaration));
       String _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(type, null));
-      if (_notEquals) {
+      if ((type != null)) {
         String _humanReadableName = type.getHumanReadableName();
         String _plus = (_humanReadableName + " ");
         String _name = variableDeclaration.getName();
@@ -297,8 +295,7 @@ public class XbaseLabelProvider extends DefaultEObjectLabelProvider {
     final JvmTypeReference returnType = _xifexpression;
     final StandardTypeReferenceOwner owner = new StandardTypeReferenceOwner(this.services, element);
     String _xifexpression_2 = null;
-    boolean _equals = Objects.equal(returnType, null);
-    if (_equals) {
+    if ((returnType == null)) {
       _xifexpression_2 = "void";
     } else {
       LightweightTypeReference _lightweightTypeReference = owner.toLightweightTypeReference(returnType);

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/util/InsertionOffsets.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/util/InsertionOffsets.java
@@ -45,8 +45,7 @@ public class InsertionOffsets {
       };
       final ILeafNode openingBraceNode = IterableExtensions.<ILeafNode>findFirst(_leafNodes, _function);
       int _xifexpression = (int) 0;
-      boolean _notEquals = (!Objects.equal(openingBraceNode, null));
-      if (_notEquals) {
+      if ((openingBraceNode != null)) {
         int _offset = openingBraceNode.getOffset();
         _xifexpression = (_offset + 1);
       } else {

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/validation/ProjectAwareUniqueClassNameValidator.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/validation/ProjectAwareUniqueClassNameValidator.java
@@ -192,8 +192,7 @@ public class ProjectAwareUniqueClassNameValidator extends UniqueClassNameValidat
     }
     final HashSet<String> workingCopyPaths = CollectionLiterals.<String>newHashSet();
     ICompilationUnit[] copies = this.getWorkingCopies(type);
-    boolean _notEquals = (!Objects.equal(copies, null));
-    if (_notEquals) {
+    if ((copies != null)) {
       for (final ICompilationUnit workingCopy : copies) {
         {
           final IPath path = workingCopy.getPath();
@@ -217,8 +216,7 @@ public class ProjectAwareUniqueClassNameValidator extends UniqueClassNameValidat
       }
     }
     char[] _xifexpression = null;
-    boolean _equals = Objects.equal(packageName, null);
-    if (_equals) {
+    if ((packageName == null)) {
       _xifexpression = CharOperation.NO_CHAR;
     } else {
       _xifexpression = packageName.toCharArray();
@@ -286,8 +284,7 @@ public class ProjectAwareUniqueClassNameValidator extends UniqueClassNameValidat
       Map<Object, Object> _context = this.getContext();
       Object _get = _context.get(ProjectAwareUniqueClassNameValidator.OUTPUT_CONFIGS);
       final Collection<OutputConfiguration> outputConfigurations = ((Collection<OutputConfiguration>) _get);
-      boolean _notEquals = (!Objects.equal(outputConfigurations, null));
-      if (_notEquals) {
+      if ((outputConfigurations != null)) {
         final IPath projectRelativePath = resource.getProjectRelativePath();
         for (final OutputConfiguration outputConfiguration : outputConfigurations) {
           Set<String> _outputDirectories = outputConfiguration.getOutputDirectories();

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.xtend
@@ -44,7 +44,7 @@ class RuleEngineFormatter extends XbaseFormatter {
 		expr.surround[indent]
 		for (child : expr.expressions) {
 			val sem = child.immediatelyFollowing.keyword(";")
-			if (sem != null) {
+			if (sem !== null) {
 				sem.prepend[noSpace]
 				if (child != expr.expressions.last)
 					sem.append[newLine]
@@ -59,29 +59,29 @@ class RuleEngineFormatter extends XbaseFormatter {
 		expr.regionFor.keyword("switch").append[oneSpace]
 		expr.^switch.append[newLine].format
 		for (c : expr.cases) {
-			if (c.typeGuard != null && c.^case != null) {
+			if (c.typeGuard !== null && c.^case !== null) {
 				c.typeGuard.append[oneSpace]
 				c.^case.append[noSpace]
-			} else if (c.typeGuard != null) {
+			} else if (c.typeGuard !== null) {
 				c.typeGuard.append[noSpace]
-			} else if (c.^case != null) {
+			} else if (c.^case !== null) {
 				c.^case.prepend[oneSpace].append[noSpace]
 			}
 			c.regionFor.feature(XCASE_PART__FALL_THROUGH).prepend[noSpace].append[newLine]
 			c.^case.format
-			if (c == expr.cases.last && expr.^default == null)
+			if (c == expr.cases.last && expr.^default === null)
 				c.then.formatBody(true, document)
 			else
 				c.then.formatBodyParagraph(document)
 		}
-		if (expr.^default != null) {
+		if (expr.^default !== null) {
 			expr.regionFor.keyword("default").append[noSpace]
 			expr.^default.formatBody(true, document)
 		}
 	}
 
 	override protected void formatBody(XExpression expr, boolean forceMultiline, extension IFormattableDocument doc) {
-		if (expr == null)
+		if (expr === null)
 			return;
 		if (expr instanceof XBlockExpression) {
 			expr.prepend[newLine]
@@ -95,7 +95,7 @@ class RuleEngineFormatter extends XbaseFormatter {
 
 	override protected void formatBodyInline(XExpression expr, boolean forceMultiline,
 		extension IFormattableDocument doc) {
-		if (expr == null)
+		if (expr === null)
 			return;
 		if (expr instanceof XBlockExpression) {
 			expr.surround[newLine]
@@ -108,7 +108,7 @@ class RuleEngineFormatter extends XbaseFormatter {
 	}
 
 	override protected void formatBodyParagraph(XExpression expr, extension IFormattableDocument doc) {
-		if (expr == null)
+		if (expr === null)
 			return;
 		if (expr instanceof XBlockExpression) {
 			expr.surround[newLine]

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/validation/RuleEngineValidator.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/validation/RuleEngineValidator.xtend
@@ -72,7 +72,7 @@ class RuleEngineValidator extends AbstractRuleEngineValidator {
 	@Check
 	def checkRuleRecursion(XFeatureCall featureCall) {
 		val containingRule = EcoreUtil2.getContainerOfType(featureCall, Rule)
-		if (containingRule != null && featureCall.feature instanceof JvmOperation
+		if (containingRule !== null && featureCall.feature instanceof JvmOperation
 				&& featureCall.concreteSyntaxFeatureName == 'fire'
 				&& featureCall.featureCallArguments.size == 1) {
 			val argument = featureCall.featureCallArguments.head

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.java
@@ -140,16 +140,15 @@ public class RuleEngineFormatter extends XbaseFormatter {
       {
         ISemanticRegionFinder _immediatelyFollowing = this.textRegionExtensions.immediatelyFollowing(child);
         final ISemanticRegion sem = _immediatelyFollowing.keyword(";");
-        boolean _notEquals = (!Objects.equal(sem, null));
-        if (_notEquals) {
+        if ((sem != null)) {
           final Procedure1<IHiddenRegionFormatter> _function_1 = (IHiddenRegionFormatter it) -> {
             it.noSpace();
           };
           document.prepend(sem, _function_1);
           EList<XExpression> _expressions_1 = expr.getExpressions();
           XExpression _last = IterableExtensions.<XExpression>last(_expressions_1);
-          boolean _notEquals_1 = (!Objects.equal(child, _last));
-          if (_notEquals_1) {
+          boolean _notEquals = (!Objects.equal(child, _last));
+          if (_notEquals) {
             final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
               it.newLine();
             };
@@ -158,8 +157,8 @@ public class RuleEngineFormatter extends XbaseFormatter {
         } else {
           EList<XExpression> _expressions_2 = expr.getExpressions();
           XExpression _last_1 = IterableExtensions.<XExpression>last(_expressions_2);
-          boolean _notEquals_2 = (!Objects.equal(child, _last_1));
-          if (_notEquals_2) {
+          boolean _notEquals_1 = (!Objects.equal(child, _last_1));
+          if (_notEquals_1) {
             final Procedure1<IHiddenRegionFormatter> _function_3 = (IHiddenRegionFormatter it) -> {
               it.newLine();
             };
@@ -195,7 +194,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
     EList<XCasePart> _cases = expr.getCases();
     for (final XCasePart c : _cases) {
       {
-        if (((!Objects.equal(c.getTypeGuard(), null)) && (!Objects.equal(c.getCase(), null)))) {
+        if (((c.getTypeGuard() != null) && (c.getCase() != null))) {
           JvmTypeReference _typeGuard = c.getTypeGuard();
           final Procedure1<IHiddenRegionFormatter> _function_3 = (IHiddenRegionFormatter it) -> {
             it.oneSpace();
@@ -208,8 +207,8 @@ public class RuleEngineFormatter extends XbaseFormatter {
           document.<XExpression>append(_case, _function_4);
         } else {
           JvmTypeReference _typeGuard_1 = c.getTypeGuard();
-          boolean _notEquals = (!Objects.equal(_typeGuard_1, null));
-          if (_notEquals) {
+          boolean _tripleNotEquals = (_typeGuard_1 != null);
+          if (_tripleNotEquals) {
             JvmTypeReference _typeGuard_2 = c.getTypeGuard();
             final Procedure1<IHiddenRegionFormatter> _function_5 = (IHiddenRegionFormatter it) -> {
               it.noSpace();
@@ -217,8 +216,8 @@ public class RuleEngineFormatter extends XbaseFormatter {
             document.<JvmTypeReference>append(_typeGuard_2, _function_5);
           } else {
             XExpression _case_1 = c.getCase();
-            boolean _notEquals_1 = (!Objects.equal(_case_1, null));
-            if (_notEquals_1) {
+            boolean _tripleNotEquals_1 = (_case_1 != null);
+            if (_tripleNotEquals_1) {
               XExpression _case_2 = c.getCase();
               final Procedure1<IHiddenRegionFormatter> _function_6 = (IHiddenRegionFormatter it) -> {
                 it.oneSpace();
@@ -243,7 +242,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
         document.append(_prepend_1, _function_9);
         XExpression _case_3 = c.getCase();
         document.<XExpression>format(_case_3);
-        if ((Objects.equal(c, IterableExtensions.<XCasePart>last(expr.getCases())) && Objects.equal(expr.getDefault(), null))) {
+        if ((Objects.equal(c, IterableExtensions.<XCasePart>last(expr.getCases())) && (expr.getDefault() == null))) {
           XExpression _then = c.getThen();
           this.formatBody(_then, true, document);
         } else {
@@ -253,8 +252,8 @@ public class RuleEngineFormatter extends XbaseFormatter {
       }
     }
     XExpression _default = expr.getDefault();
-    boolean _notEquals = (!Objects.equal(_default, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_default != null);
+    if (_tripleNotEquals) {
       ISemanticRegionsFinder _regionFor_1 = this.textRegionExtensions.regionFor(expr);
       ISemanticRegion _keyword_1 = _regionFor_1.keyword("default");
       final Procedure1<IHiddenRegionFormatter> _function_3 = (IHiddenRegionFormatter it) -> {
@@ -268,8 +267,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
   
   @Override
   protected void formatBody(final XExpression expr, final boolean forceMultiline, @Extension final IFormattableDocument doc) {
-    boolean _equals = Objects.equal(expr, null);
-    if (_equals) {
+    if ((expr == null)) {
       return;
     }
     if ((expr instanceof XBlockExpression)) {
@@ -299,8 +297,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
   
   @Override
   protected void formatBodyInline(final XExpression expr, final boolean forceMultiline, @Extension final IFormattableDocument doc) {
-    boolean _equals = Objects.equal(expr, null);
-    if (_equals) {
+    if ((expr == null)) {
       return;
     }
     if ((expr instanceof XBlockExpression)) {
@@ -334,8 +331,7 @@ public class RuleEngineFormatter extends XbaseFormatter {
   
   @Override
   protected void formatBodyParagraph(final XExpression expr, @Extension final IFormattableDocument doc) {
-    boolean _equals = Objects.equal(expr, null);
-    if (_equals) {
+    if ((expr == null)) {
       return;
     }
     if ((expr instanceof XBlockExpression)) {

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/validation/RuleEngineValidator.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/validation/RuleEngineValidator.java
@@ -107,7 +107,7 @@ public class RuleEngineValidator extends AbstractRuleEngineValidator {
   @Check
   public void checkRuleRecursion(final XFeatureCall featureCall) {
     final Rule containingRule = EcoreUtil2.<Rule>getContainerOfType(featureCall, Rule.class);
-    if (((((!Objects.equal(containingRule, null)) && (featureCall.getFeature() instanceof JvmOperation)) && Objects.equal(featureCall.getConcreteSyntaxFeatureName(), "fire")) && (featureCall.getFeatureCallArguments().size() == 1))) {
+    if (((((containingRule != null) && (featureCall.getFeature() instanceof JvmOperation)) && Objects.equal(featureCall.getConcreteSyntaxFeatureName(), "fire")) && (featureCall.getFeatureCallArguments().size() == 1))) {
       EList<XExpression> _featureCallArguments = featureCall.getFeatureCallArguments();
       final XExpression argument = IterableExtensions.<XExpression>head(_featureCallArguments);
       if ((argument instanceof XAbstractFeatureCall)) {


### PR DESCRIPTION
For comparison with null the triple (not) equal operator should be used.
Resolved compiler warnings
