### PR TITLE
Configure build tasks

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -75,6 +75,14 @@
     <description>Github user password</description>
   </setupTask>
   <setupTask
+      xsi:type="setup:VariableTask"
+      id="jenkins.url"
+      type="URI"
+      name="jenkins.url"
+      value="http://services.typefox.io/open-source/jenkins">
+    <description>Base URL of Jenkins build server</description>
+  </setupTask>
+  <setupTask
       xsi:type="setup:CompoundTask"
       name="Workspace Preferences">
     <setupTask
@@ -406,7 +414,7 @@
               project="org.eclipse.xtext"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -482,7 +490,7 @@
               project="org.eclipse.xtext.xbase.lib"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -556,7 +564,7 @@
               project="org.eclipse.xtext.xbase"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -824,7 +832,7 @@
               project="org.eclipse.xtext.tycho.parent"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2 //@projects[name='eclipse']/@setupTasks.4/@workingSets.1"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2 //@projects[name='eclipse']/@setupTasks.4/@workingSets.1"/>
         </predicate>
       </workingSet>
       <workingSet
@@ -836,7 +844,7 @@
               project="org.eclipse.xtext.tycho.parent"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0 //@projects[name='eclipse']/@setupTasks.4/@workingSets.2"/>
           <operand
               xsi:type="predicates:NaturePredicate"
               nature="org.eclipse.pde.FeatureNature"/>
@@ -851,7 +859,7 @@
               project="org.eclipse.xtext.tycho.parent"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
           <operand
               xsi:type="predicates:NamePredicate"
               pattern=".*\.example\..*"/>
@@ -948,7 +956,7 @@
               project="org.eclipse.xtext.core.idea.tests"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -1024,7 +1032,7 @@
               project="org.eclipse.xtext.web"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -1095,7 +1103,7 @@
               project="org.eclipse.xtext.maven.plugin"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -1187,7 +1195,7 @@
               project="org.eclipse.xtend.core"/>
           <operand
               xsi:type="workingsets:ExclusionPredicate"
-              excludedWorkingSet="//@setupTasks.14/@workingSets.0"/>
+              excludedWorkingSet="//@setupTasks.15/@workingSets.0"/>
         </predicate>
       </workingSet>
     </setupTask>
@@ -1236,8 +1244,6 @@
         licenseConfirmationDisabled="true">
       <requirement
           name="org.eclipse.mylyn.bugzilla_feature.feature.group"/>
-      <requirement
-          name="org.eclipse.mylyn.builds.feature.group"/>
       <requirement
           name="org.eclipse.mylyn.context_feature.feature.group"/>
       <requirement
@@ -1764,6 +1770,77 @@
       </setupTask>
     </stream>
     <description>Add Mylyn integration and Bugzilla/GitHub issues</description>
+  </project>
+  <project name="build"
+      label="Xtext Build Tasks">
+    <setupTask
+        xsi:type="mylyn:MylynBuildsTask"
+        id="build.xtext-core"
+        serverURL="${jenkins.url}/job/xtext-core/">
+      <buildPlan
+          name="${xtext.git.branch}"/>
+      <description>xtext-core Jenkins Build Job</description>
+    </setupTask>
+    <setupTask
+        xsi:type="mylyn:MylynBuildsTask"
+        id="build.xtext-lib"
+        serverURL="${jenkins.url}/job/xtext-lib/">
+      <buildPlan
+          name="${xtext.git.branch}"/>
+      <description>xtext-lib Jenkins Build Job</description>
+    </setupTask>
+    <setupTask
+        xsi:type="mylyn:MylynBuildsTask"
+        id="build.xtext-extras"
+        serverURL="${jenkins.url}/job/xtext-extras/">
+      <buildPlan
+          name="${xtext.git.branch}"/>
+      <description>xtext-extras Jenkins Build Job</description>
+    </setupTask>
+    <setupTask
+        xsi:type="mylyn:MylynBuildsTask"
+        id="build.xtext-eclipse"
+        serverURL="${jenkins.url}/job/xtext-eclipse/">
+      <buildPlan
+          name="${xtext.git.branch}"/>
+      <description>xtext-eclipse Jenkins Build Job</description>
+    </setupTask>
+    <setupTask
+        xsi:type="mylyn:MylynBuildsTask"
+        id="build.xtext-idea"
+        serverURL="${jenkins.url}/job/xtext-idea/">
+      <buildPlan
+          name="${xtext.git.branch}"/>
+      <description>xtext-idea Jenkins Build Job</description>
+    </setupTask>
+    <setupTask
+        xsi:type="mylyn:MylynBuildsTask"
+        id="build.xtext-web"
+        serverURL="${jenkins.url}/job/xtext-web/"
+        userID="">
+      <buildPlan
+          name="${xtext.git.branch}"/>
+      <description>xtext-web Jenkins Build Job</description>
+    </setupTask>
+    <setupTask
+        xsi:type="mylyn:MylynBuildsTask"
+        id="build.xtext-maven"
+        serverURL="${jenkins.url}/job/xtext-maven/">
+      <buildPlan
+          name="${xtext.git.branch}"/>
+      <description>xtext-maven Jenkins Build Job</description>
+    </setupTask>
+    <setupTask
+        xsi:type="mylyn:MylynBuildsTask"
+        id="build.xtext-xtend"
+        serverURL="${jenkins.url}/job/xtext-xtend/">
+      <buildPlan
+          name="${xtext.git.branch}"/>
+      <description>xtext-xtend Jenkins Build Job</description>
+    </setupTask>
+    <stream
+        name="master"/>
+    <description>Adds the Mylyn Build Integration feature and populates the &quot;Builds&quot; view with the Xtext related Jenkins build jobs</description>
   </project>
   <logicalProjectContainer
       xsi:type="setup:ProjectCatalog"


### PR DESCRIPTION
This change will add build task configuration per sub project. When using Eclipse for Committers as base setup (recommended) the Mylyn Build feature is already available.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>