### PR TITLE
[#119] UX improvements for Generic IDE Support option

### DIFF
--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.xtext.xtext.ui.wizard.project
 
+import org.eclipse.jface.fieldassist.ControlDecoration
+import org.eclipse.jface.fieldassist.FieldDecorationRegistry
 import org.eclipse.jface.wizard.WizardPage
 import org.eclipse.swt.SWT
 import org.eclipse.swt.events.SelectionAdapter
@@ -74,6 +76,16 @@ class AdvancedNewProjectPage extends WizardPage {
 				createWebProject = CheckBox [
 					text = AdvancedNewProjectPage_projWeb
 					enabled = true
+					val decRegistry = FieldDecorationRegistry.getDefault()
+					val infoField = decRegistry.getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION)
+					new ControlDecoration(it, SWT.TOP + SWT.RIGHT) => [
+						image = infoField.image
+						descriptionText = "Creates an additional project for the integration in web applications.\nSee <a href=\"https://eclipse.org/Xtext/documentation/330_web_support.html\">https://eclipse.org/Xtext/documentation/330_web_support.html</a> for details."
+						showHover = true
+					]
+					val gridData = new GridData(SWT.NONE, SWT.CENTER, true, false)
+					// gridData.horizontalIndent = decRegistry.maximumDecorationWidth
+					it.layoutData = gridData
 				]
 				createIdeProject = CheckBox [
 					text = AdvancedNewProjectPage_projIde

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
@@ -76,20 +76,11 @@ class AdvancedNewProjectPage extends WizardPage {
 				createWebProject = CheckBox [
 					text = AdvancedNewProjectPage_projWeb
 					enabled = true
-					val decRegistry = FieldDecorationRegistry.getDefault()
-					val infoField = decRegistry.getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION)
-					new ControlDecoration(it, SWT.TOP + SWT.RIGHT) => [
-						image = infoField.image
-						descriptionText = "Creates an additional project for the integration in web applications.\nSee <a href=\"https://eclipse.org/Xtext/documentation/330_web_support.html\">https://eclipse.org/Xtext/documentation/330_web_support.html</a> for details."
-						showHover = true
-					]
-					val gridData = new GridData(SWT.NONE, SWT.CENTER, true, false)
-					// gridData.horizontalIndent = decRegistry.maximumDecorationWidth
-					it.layoutData = gridData
 				]
 				createIdeProject = CheckBox [
 					text = AdvancedNewProjectPage_projIde
 					enabled = false
+					it.InfoDecoration(AdvancedNewProjectPage_projIde_description)
 				]
 				createTestProject = CheckBox [
 					text = Messages.WizardNewXtextProjectCreationPage_TestingSupport
@@ -300,6 +291,17 @@ class AdvancedNewProjectPage extends WizardPage {
 			layoutData = new GridData(GridData.FILL_HORIZONTAL)
 			config.apply(it)
 		]
+	}
+	
+	def protected InfoDecoration(Control control, String text) {
+		val infoField = FieldDecorationRegistry.getDefault().getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION)
+		new ControlDecoration(control, SWT.TOP + SWT.RIGHT) => [
+			image = infoField.image
+			descriptionText = text
+			showHover = true
+		]
+		val gridData = new GridData(SWT.NONE, SWT.CENTER, true, false)
+		control.layoutData = gridData
 	}
 
 	def protected setDefaults() {

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/Messages.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/Messages.java
@@ -35,6 +35,7 @@ public class Messages extends NLS {
 	public static String AdvancedNewProjectPage_projEclipseSDKFeature;
 	public static String AdvancedNewProjectPage_projEclipseP2;
 	public static String AdvancedNewProjectPage_projIde;
+	public static String AdvancedNewProjectPage_projIde_description;
 	public static String AdvancedNewProjectPage_projIdea;
 	public static String AdvancedNewProjectPage_projWeb;
 	public static String AdvancedNewProjectPage_srcLayout;

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/messages.properties
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/messages.properties
@@ -38,6 +38,7 @@ AdvancedNewProjectPage_projEclipse=Eclipse Plugin
 AdvancedNewProjectPage_projEclipseSDKFeature=Create Feature
 AdvancedNewProjectPage_projEclipseP2=Create Update Site
 AdvancedNewProjectPage_projIde=Generic IDE Support
+AdvancedNewProjectPage_projIde_description=This option is mandatory for any IDE integration or for use as a language server.\nAn additional project with suffix .ide will be created.
 AdvancedNewProjectPage_projIdea=IntelliJ IDEA Plugin
 AdvancedNewProjectPage_projWeb=Web Integration
 AdvancedNewProjectPage_srcLayout=Source Layout

--- a/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
+++ b/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
@@ -108,22 +108,12 @@ public class AdvancedNewProjectPage extends WizardPage {
         final Procedure1<Button> _function_5 = (Button it_2) -> {
           it_2.setText(Messages.AdvancedNewProjectPage_projWeb);
           it_2.setEnabled(true);
-          final FieldDecorationRegistry decRegistry = FieldDecorationRegistry.getDefault();
-          final FieldDecoration infoField = decRegistry.getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION);
-          ControlDecoration _controlDecoration = new ControlDecoration(it_2, (SWT.TOP + SWT.RIGHT));
-          final Procedure1<ControlDecoration> _function_6 = (ControlDecoration it_3) -> {
-            it_3.setImage(infoField.getImage());
-            it_3.setDescriptionText("Creates an additional project for the integration in web applications.\nSee <a href=\"https://eclipse.org/Xtext/documentation/330_web_support.html\">https://eclipse.org/Xtext/documentation/330_web_support.html</a> for details.");
-            it_3.setShowHover(true);
-          };
-          ObjectExtensions.<ControlDecoration>operator_doubleArrow(_controlDecoration, _function_6);
-          final GridData gridData = new GridData(SWT.NONE, SWT.CENTER, true, false);
-          it_2.setLayoutData(gridData);
         };
         this.createWebProject = this.CheckBox(it_1, _function_5);
         final Procedure1<Button> _function_6 = (Button it_2) -> {
           it_2.setText(Messages.AdvancedNewProjectPage_projIde);
           it_2.setEnabled(false);
+          this.InfoDecoration(it_2, Messages.AdvancedNewProjectPage_projIde_description);
         };
         this.createIdeProject = this.CheckBox(it_1, _function_6);
         final Procedure1<Button> _function_7 = (Button it_2) -> {
@@ -447,6 +437,19 @@ public class AdvancedNewProjectPage extends WizardPage {
       config.apply(it);
     };
     return ObjectExtensions.<Combo>operator_doubleArrow(_combo, _function);
+  }
+  
+  protected void InfoDecoration(final Control control, final String text) {
+    final FieldDecoration infoField = FieldDecorationRegistry.getDefault().getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION);
+    ControlDecoration _controlDecoration = new ControlDecoration(control, (SWT.TOP + SWT.RIGHT));
+    final Procedure1<ControlDecoration> _function = (ControlDecoration it) -> {
+      it.setImage(infoField.getImage());
+      it.setDescriptionText(text);
+      it.setShowHover(true);
+    };
+    ObjectExtensions.<ControlDecoration>operator_doubleArrow(_controlDecoration, _function);
+    final GridData gridData = new GridData(SWT.NONE, SWT.CENTER, true, false);
+    control.setLayoutData(gridData);
   }
   
   protected void setDefaults() {

--- a/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
+++ b/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
@@ -11,6 +11,9 @@ import com.google.common.base.Objects;
 import java.util.Collections;
 import java.util.List;
 import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.jface.fieldassist.ControlDecoration;
+import org.eclipse.jface.fieldassist.FieldDecoration;
+import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -105,6 +108,17 @@ public class AdvancedNewProjectPage extends WizardPage {
         final Procedure1<Button> _function_5 = (Button it_2) -> {
           it_2.setText(Messages.AdvancedNewProjectPage_projWeb);
           it_2.setEnabled(true);
+          final FieldDecorationRegistry decRegistry = FieldDecorationRegistry.getDefault();
+          final FieldDecoration infoField = decRegistry.getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION);
+          ControlDecoration _controlDecoration = new ControlDecoration(it_2, (SWT.TOP + SWT.RIGHT));
+          final Procedure1<ControlDecoration> _function_6 = (ControlDecoration it_3) -> {
+            it_3.setImage(infoField.getImage());
+            it_3.setDescriptionText("Creates an additional project for the integration in web applications.\nSee <a href=\"https://eclipse.org/Xtext/documentation/330_web_support.html\">https://eclipse.org/Xtext/documentation/330_web_support.html</a> for details.");
+            it_3.setShowHover(true);
+          };
+          ObjectExtensions.<ControlDecoration>operator_doubleArrow(_controlDecoration, _function_6);
+          final GridData gridData = new GridData(SWT.NONE, SWT.CENTER, true, false);
+          it_2.setLayoutData(gridData);
         };
         this.createWebProject = this.CheckBox(it_1, _function_5);
         final Procedure1<Button> _function_6 = (Button it_2) -> {

--- a/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
+++ b/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
@@ -10,7 +10,6 @@ package org.eclipse.xtext.xtext.ui.wizard.project;
 import com.google.common.base.Objects;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
@@ -65,6 +64,8 @@ public class AdvancedNewProjectPage extends WizardPage {
   
   private StatusWidget statusWidget;
   
+  private boolean autoSelectIdeProject;
+  
   public AdvancedNewProjectPage(final String pageName) {
     super(pageName);
     this.setTitle(Messages.AdvancedNewProjectPage_WindowTitle);
@@ -108,7 +109,7 @@ public class AdvancedNewProjectPage extends WizardPage {
         this.createWebProject = this.CheckBox(it_1, _function_5);
         final Procedure1<Button> _function_6 = (Button it_2) -> {
           it_2.setText(Messages.AdvancedNewProjectPage_projIde);
-          it_2.setEnabled(true);
+          it_2.setEnabled(false);
         };
         this.createIdeProject = this.CheckBox(it_1, _function_6);
         final Procedure1<Button> _function_7 = (Button it_2) -> {
@@ -157,6 +158,33 @@ public class AdvancedNewProjectPage extends WizardPage {
         AdvancedNewProjectPage.this.validate(e);
       }
     };
+    final List<Button> uiButtons = Collections.<Button>unmodifiableList(CollectionLiterals.<Button>newArrayList(this.createUiProject, this.createIdeaProject, this.createWebProject));
+    final SelectionAdapter selectionControlUi = new SelectionAdapter() {
+      @Override
+      public void widgetSelected(final SelectionEvent e) {
+        Object _source = e.getSource();
+        boolean _selection = ((Button) _source).getSelection();
+        if (_selection) {
+          boolean _selection_1 = AdvancedNewProjectPage.this.createIdeProject.getSelection();
+          boolean _not = (!_selection_1);
+          if (_not) {
+            AdvancedNewProjectPage.this.autoSelectIdeProject = true;
+          }
+          AdvancedNewProjectPage.this.createIdeProject.setSelection(true);
+          AdvancedNewProjectPage.this.createIdeProject.setEnabled(false);
+        } else {
+          final Function1<Button, Boolean> _function = (Button it) -> {
+            boolean _selection_2 = it.getSelection();
+            return Boolean.valueOf((!_selection_2));
+          };
+          boolean _forall = IterableExtensions.<Button>forall(uiButtons, _function);
+          if (_forall) {
+            AdvancedNewProjectPage.this.createIdeProject.setEnabled(true);
+          }
+        }
+        AdvancedNewProjectPage.this.validate(e);
+      }
+    };
     this.createUiProject.addSelectionListener(new SelectionAdapter() {
       @Override
       public void widgetSelected(final SelectionEvent e) {
@@ -170,9 +198,9 @@ public class AdvancedNewProjectPage extends WizardPage {
     this.sourceLayout.addSelectionListener(selectionControl);
     this.createTestProject.addSelectionListener(selectionControl);
     this.preferredBuildSystem.addSelectionListener(selectionControl);
-    this.createUiProject.addSelectionListener(selectionControl);
-    this.createIdeaProject.addSelectionListener(selectionControl);
-    this.createWebProject.addSelectionListener(selectionControl);
+    this.createUiProject.addSelectionListener(selectionControlUi);
+    this.createIdeaProject.addSelectionListener(selectionControlUi);
+    this.createWebProject.addSelectionListener(selectionControlUi);
     this.createIdeProject.addSelectionListener(selectionControl);
     this.createSDKProject.addSelectionListener(selectionControl);
     this.createP2Project.addSelectionListener(selectionControl);
@@ -308,57 +336,21 @@ public class AdvancedNewProjectPage extends WizardPage {
           this.<Control>reportIssue(IMessageProvider.ERROR, _builder_5.toString(), _function_5);
         }
       }
-      final List<Button> dependend = Collections.<Button>unmodifiableList(CollectionLiterals.<Button>newArrayList(this.createUiProject, this.createIdeaProject, this.createWebProject));
       Procedure0 _xifexpression = null;
-      if (((!this.createIdeProject.getSelection()) && IterableExtensions.<Button>exists(dependend, ((Function1<Button, Boolean>) (Button it) -> {
-        return Boolean.valueOf(it.getSelection());
-      })))) {
+      if (this.autoSelectIdeProject) {
         Procedure0 _xblockexpression_1 = null;
         {
-          final Function1<Button, Boolean> _function_6 = (Button it) -> {
-            return Boolean.valueOf(it.getSelection());
-          };
-          final Function1<Button, CharSequence> _function_7 = (Button it) -> {
-            return it.getText();
-          };
-          final String affectedProjects = IterableExtensions.<Button>join(IterableExtensions.<Button>filter(dependend, _function_6), ", ", _function_7);
-          Procedure0 _xifexpression_1 = null;
-          if ((this.createIdeProject == source)) {
-            StringConcatenation _builder_6 = new StringConcatenation();
-            _builder_6.append("Frontend projects like \'");
-            _builder_6.append(affectedProjects);
-            _builder_6.append("\' depends on \'");
-            String _text_6 = this.createIdeProject.getText();
-            _builder_6.append(_text_6);
-            _builder_6.append("\' project.");
-            _builder_6.newLineIfNotEmpty();
-            _builder_6.append("Please <a>deselect</a> these.");
-            final Procedure0 _function_8 = () -> {
-              final Consumer<Button> _function_9 = (Button it) -> {
-                it.setSelection(false);
-              };
-              dependend.forEach(_function_9);
-            };
-            _xifexpression_1 = this.<Control>reportIssue(IMessageProvider.ERROR, _builder_6.toString(), _function_8);
-          } else {
-            StringConcatenation _builder_7 = new StringConcatenation();
-            _builder_7.append("Projects like \'");
-            _builder_7.append(affectedProjects);
-            _builder_7.append("\' depends on \'");
-            String _text_7 = this.createIdeProject.getText();
-            _builder_7.append(_text_7);
-            _builder_7.append("\' project.");
-            _builder_7.newLineIfNotEmpty();
-            _builder_7.append("Please <a>enable \'");
-            String _text_8 = this.createIdeProject.getText();
-            _builder_7.append(_text_8);
-            _builder_7.append("\'</a> project.");
-            final Procedure0 _function_9 = () -> {
-              this.createIdeProject.setSelection(true);
-            };
-            _xifexpression_1 = this.<Control>reportIssue(IMessageProvider.ERROR, _builder_7.toString(), _function_9);
-          }
-          _xblockexpression_1 = _xifexpression_1;
+          this.autoSelectIdeProject = false;
+          StringConcatenation _builder_6 = new StringConcatenation();
+          _builder_6.append("\'");
+          String _text_6 = this.createIdeProject.getText();
+          _builder_6.append(_text_6);
+          _builder_6.append("\' project was automatically selected as option \'");
+          String _text_7 = ((Button) source).getText();
+          _builder_6.append(_text_7);
+          _builder_6.append("\' requires it.");
+          _builder_6.newLineIfNotEmpty();
+          _xblockexpression_1 = this.<Control>reportIssue(IMessageProvider.INFORMATION, _builder_6.toString());
         }
         _xifexpression = _xblockexpression_1;
       }


### PR DESCRIPTION
The "Generic IDE Support"  option is disabled whenever a UI plugin is selected. If
it was not enabled before, it will be selected automatically and an
information about this will be reported to the status widget.

Initial page: "Generic IDE Support" is disabled, since Eclipse Plugin is preselected.
![screenshot 20](https://cloud.githubusercontent.com/assets/265597/21592013/ea1611d0-d109-11e6-921f-6ccede73e887.png)

The option becomes enabled when Eclipse Plugin is deseleted.
![screenshot 21](https://cloud.githubusercontent.com/assets/265597/21592025/ff129e00-d109-11e6-8d2a-3491e5e0b9df.png)

The option is deselected manually:
![screenshot 22](https://cloud.githubusercontent.com/assets/265597/21592031/0fd711a8-d10a-11e6-99ef-5c9af6b917b5.png)

The option "Web Support" is selected. The user is informed about the automatic selection of the "Generic IDE Support" option.
![screenshot 23](https://cloud.githubusercontent.com/assets/265597/21592034/1c9252f4-d10a-11e6-9180-122349e9ebeb.png)
