### PR TITLE
Improved XtextQuickAssistProcessor.getApplicableAnnotations(..)

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/XtextAnnotation.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/XtextAnnotation.java
@@ -91,4 +91,12 @@ public class XtextAnnotation extends Annotation implements IAnnotationPresentati
 		return isQuickfixable ? XtextPluginImages.getAnnotationImagesFixable() : XtextPluginImages.getAnnotationImagesNonfixable();
 	}
 	
+	@Override
+	public String toString() {
+		if (issue.getSeverity() != null && issue.getMessage() != null)
+			return issue.getSeverity() + ": " + issue.getMessage();
+		else
+			return super.toString();
+	}
+	
 }


### PR DESCRIPTION
Fixes eclipse/xtext-core#124.

Behavior before this change:

 * If there is at least one annotation left of the cursor position, choose the nearest one with respect to the start offset. Quick fixes are shown for all annotations with exactly same range as the chosen one.
 * If there is at least one annotation right of the cursor position, choose the one with the smallest offset. Quick fixes are shown for all annotations with exactly same range as the chosen one.

Behavior after this change:

 * If there is at least one annotation that includes the cursor position, quick fixes are shown for all annotations that include the cursor position.
 * If there is at least one annotation left of the cursor position, choose the nearest one with respect to the end offset. Quick fixes are shown for all annotations with the same end offset as the chosen one.
 * If there is at least one annotation right of the cursor position, choose the one with the smallest offset. Quick fixes are shown for all annotations with the same offset as the chosen one.

The change also fixes another bug: The selection is supposed to be set to the range of the annotations for which quick fixes are displayed. This was prevented by a wrong condition in the respective method.