### PR TITLE
Generate locations.properties for use from gradle composite build.

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -365,6 +365,15 @@
     <description></description>
   </setupTask>
   <setupTask
+      xsi:type="setup:ResourceCreationTask"
+      id="generateLocationProperties"
+      excludedTriggers="BOOTSTRAP"
+      content="git.clone.xtext.lib.location=gitclonextextliblocationprototype&#xD;&#xA;git.clone.xtext.core.location=gitclonextextcorelocationprototype&#xD;&#xA;git.clone.xtext.extras.location=gitclonextextextraslocationprototype&#xD;&#xA;git.clone.xtext.idea.location=gitclonextextidealocationprototype&#xD;&#xA;git.clone.xtext.xtend.location=gitclonextextxtendlocationprototype&#xD;&#xA;git.clone.xtext.web.location=gitclonextextweblocationprototype"
+      targetURL="file://${git.clone.xtext.umbrella.location}/locations.properties"
+      encoding="UTF-8">
+    <description>Generates a Properties File of all Git Clone Locations</description>
+  </setupTask>
+  <setupTask
       xsi:type="projects:ProjectsImportTask">
     <sourceLocator
         rootFolder="${git.clone.xtext.umbrella.location}"
@@ -395,6 +404,17 @@
         </detail>
       </annotation>
       <description>${scope.project.label}</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:TextModifyTask"
+        id="adaptLocationPropertiesForCore"
+        excludedTriggers="BOOTSTRAP"
+        url="file://${git.clone.xtext.umbrella.location}/locations.properties"
+        encoding="UTF-8">
+      <modification
+          pattern="(gitclonextextcorelocationprototype)">
+        <substitution>${git.clone.xtext.core.location}</substitution>
+      </modification>
     </setupTask>
     <setupTask
         xsi:type="setup:StringSubstitutionTask"
@@ -468,6 +488,17 @@
         </detail>
       </annotation>
       <description>${scope.project.label}</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:TextModifyTask"
+        id="adaptLocationPropertiesForLib"
+        excludedTriggers="BOOTSTRAP"
+        url="file://${git.clone.xtext.umbrella.location}/locations.properties"
+        encoding="UTF-8">
+      <modification
+          pattern="(gitclonextextliblocationprototype)">
+        <substitution>${git.clone.xtext.lib.location}</substitution>
+      </modification>
     </setupTask>
     <setupTask
         xsi:type="setup:StringSubstitutionTask"
@@ -545,6 +576,17 @@
         </detail>
       </annotation>
       <description>${scope.project.label}</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:TextModifyTask"
+        id="adaptLocationPropertiesForExtras"
+        excludedTriggers="BOOTSTRAP"
+        url="file://${git.clone.xtext.umbrella.location}/locations.properties"
+        encoding="UTF-8">
+      <modification
+          pattern="(gitclonextextextraslocationprototype)">
+        <substitution>${git.clone.xtext.extras.location}</substitution>
+      </modification>
     </setupTask>
     <setupTask
         xsi:type="setup:StringSubstitutionTask"
@@ -963,6 +1005,17 @@
       <description>${scope.project.label}</description>
     </setupTask>
     <setupTask
+        xsi:type="setup:TextModifyTask"
+        id="adaptLocationPropertiesForIdea"
+        excludedTriggers="BOOTSTRAP"
+        url="file://${git.clone.xtext.umbrella.location}/locations.properties"
+        encoding="UTF-8">
+      <modification
+          pattern="(gitclonextextidealocationprototype)">
+        <substitution>${git.clone.xtext.idea.location}</substitution>
+      </modification>
+    </setupTask>
+    <setupTask
         xsi:type="setup:StringSubstitutionTask"
         name="git.xtext.idea.location"
         value="${git.clone.xtext.idea.location}">
@@ -1037,6 +1090,17 @@
         </detail>
       </annotation>
       <description>${scope.project.label}</description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:TextModifyTask"
+        id="adaptLocationPropertiesForWeb"
+        excludedTriggers="BOOTSTRAP"
+        url="file://${git.clone.xtext.umbrella.location}/locations.properties"
+        encoding="UTF-8">
+      <modification
+          pattern="(gitclonextextweblocationprototype)">
+        <substitution>${git.clone.xtext.web.location}</substitution>
+      </modification>
     </setupTask>
     <setupTask
         xsi:type="setup:StringSubstitutionTask"
@@ -1190,6 +1254,17 @@
         name="git.xtext.xtend.location"
         value="${git.clone.xtext.xtend.location}">
       <description></description>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:TextModifyTask"
+        id="adaptLocationPropertiesForXtend"
+        excludedTriggers="BOOTSTRAP"
+        url="file://${git.clone.xtext.umbrella.location}/locations.properties"
+        encoding="UTF-8">
+      <modification
+          pattern="(gitclonextextxtendlocationprototype)">
+        <substitution>${git.clone.xtext.xtend.location}</substitution>
+      </modification>
     </setupTask>
     <setupTask
         xsi:type="launching:LaunchTask"


### PR DESCRIPTION
Generate locations.properties for use from gradle composite build. Helps to fix https://github.com/eclipse/xtext-umbrella/issues/18

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>