### PR TITLE
Get rid of warnings in Examples.

### DIFF
--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
@@ -228,7 +228,7 @@ public class InMemoryJavaCompiler {
     InMemoryJavaCompiler.ClassLoaderBasedNameEnvironment _classLoaderBasedNameEnvironment = new InMemoryJavaCompiler.ClassLoaderBasedNameEnvironment(parent);
     this.nameEnv = _classLoaderBasedNameEnvironment;
     this.parentClassLoader = parent;
-    Map _map = compilerOptions.getMap();
+    Map<String, String> _map = compilerOptions.getMap();
     CompilerOptions _compilerOptions = new CompilerOptions(_map);
     this.compilerOptions = _compilerOptions;
   }

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.java
@@ -47,7 +47,7 @@ public class XbaseEditorInputRedirector {
   public ITypeRoot getTypeRoot(final IEditorInput it) {
     ITypeRoot _xblockexpression = null;
     {
-      final Object adapter = it.getAdapter(IJavaElement.class);
+      final IJavaElement adapter = it.<IJavaElement>getAdapter(IJavaElement.class);
       ITypeRoot _xifexpression = null;
       if ((adapter instanceof ITypeRoot)) {
         _xifexpression = ((ITypeRoot)adapter);

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics.tests; singleton:=tru
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.arithmetics,
  org.junit;bundle-version="4.7.0",
- org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtext.testing,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics.ui.tests; singleton:=
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.arithmetics.ui,
  org.junit;bundle-version="4.7.0",
- org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/Arithmetics.xtext
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/Arithmetics.xtext
@@ -51,5 +51,6 @@ PrimaryExpression returns Expression:
 terminal NUMBER returns ecore::EBigDecimal:
 	('0'..'9')* ('.' ('0'..'9')+)?;
 
+@Override 
 terminal INT returns ecore::EInt:
 	'this one has been deactivated';

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/validation/ArithmeticsValidator.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/validation/ArithmeticsValidator.xtend
@@ -44,7 +44,7 @@ class ArithmeticsValidator extends AbstractArithmeticsValidator {
 		if (expr instanceof NumberLiteral || expr instanceof FunctionCall) 
 			return;
 		// ignore evaluations
-		if (EcoreUtil2.getContainerOfType(expr, Evaluation)!=null)
+		if (EcoreUtil2.getContainerOfType(expr, Evaluation)!==null)
 			return;
 		
 		val contents = expr.eAllContents

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/validation/ArithmeticsValidator.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/validation/ArithmeticsValidator.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.example.arithmetics.validation;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.math.BigDecimal;
 import org.eclipse.emf.common.util.TreeIterator;
@@ -52,8 +51,8 @@ public class ArithmeticsValidator extends AbstractArithmeticsValidator {
       return;
     }
     Evaluation _containerOfType = EcoreUtil2.<Evaluation>getContainerOfType(expr, Evaluation.class);
-    boolean _notEquals = (!Objects.equal(_containerOfType, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_containerOfType != null);
+    if (_tripleNotEquals) {
       return;
     }
     final TreeIterator<EObject> contents = expr.eAllContents();

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 2.12.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.domainmodel.ui.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.domainmodel.ui,
- org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.xtext.testing,
  org.eclipse.core.runtime,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.xtext.example.homeautomation,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide,
  org.antlr.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.ide.contentassist.antlr,
  org.eclipse.xtext.example.homeautomation.ide.contentassist.antlr.internal,
  org.eclipse.xtext.example.homeautomation.ide.contentassist.antlr.lexer

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/build.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/build.properties
@@ -1,4 +1,5 @@
 source.. = src/,\
-           src-gen/
+           src-gen/,\
+           xtend-gen/
 bin.includes = .,\
                META-INF/

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/META-INF/MANIFEST.MF
@@ -7,13 +7,12 @@ Bundle-SymbolicName: org.eclipse.xtext.example.homeautomation.tests; singleton:=
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.homeautomation,
  org.junit;bundle-version="4.7.0",
- org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit,
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.tests;x-internal=true
 Import-Package: org.junit.runners;version="4.5.0",
  org.junit.runners.model;version="4.5.0",

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/src/org/eclipse/xtext/example/homeautomation/tests/FormatterTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/src/org/eclipse/xtext/example/homeautomation/tests/FormatterTest.xtend
@@ -1,11 +1,11 @@
 package org.eclipse.xtext.example.homeautomation.tests
 
 import com.google.inject.Inject
-import org.eclipse.xtext.junit4.formatter.FormatterTester
+import org.eclipse.xtext.testing.formatter.FormatterTestHelper
 
 class FormatterTest extends AbstractTest {
 
-	@Inject extension FormatterTester
+	@Inject extension FormatterTestHelper
 
 	override protected test(CharSequence document) {
 		assertFormatted[

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/src/org/eclipse/xtext/example/homeautomation/tests/ParserTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/src/org/eclipse/xtext/example/homeautomation/tests/ParserTest.xtend
@@ -2,8 +2,8 @@ package org.eclipse.xtext.example.homeautomation.tests
 
 import com.google.inject.Inject
 import org.eclipse.xtext.example.homeautomation.ruleEngine.Model
-import org.eclipse.xtext.junit4.util.ParseHelper
-import org.eclipse.xtext.junit4.validation.ValidationTestHelper
+import org.eclipse.xtext.testing.util.ParseHelper
+import org.eclipse.xtext.testing.validation.ValidationTestHelper
 
 class ParserTest extends AbstractTest {
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/tests/FormatterTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/tests/FormatterTest.java
@@ -2,8 +2,8 @@ package org.eclipse.xtext.example.homeautomation.tests;
 
 import com.google.inject.Inject;
 import org.eclipse.xtext.example.homeautomation.tests.AbstractTest;
-import org.eclipse.xtext.junit4.formatter.FormatterTestRequest;
-import org.eclipse.xtext.junit4.formatter.FormatterTester;
+import org.eclipse.xtext.testing.formatter.FormatterTestHelper;
+import org.eclipse.xtext.testing.formatter.FormatterTestRequest;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 
@@ -11,13 +11,13 @@ import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 public class FormatterTest extends AbstractTest {
   @Inject
   @Extension
-  private FormatterTester _formatterTester;
+  private FormatterTestHelper _formatterTestHelper;
   
   @Override
   protected void test(final CharSequence document) {
     final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
       it.setToBeFormatted(document);
     };
-    this._formatterTester.assertFormatted(_function);
+    this._formatterTestHelper.assertFormatted(_function);
   }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/tests/ParserTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/tests/ParserTest.java
@@ -3,8 +3,8 @@ package org.eclipse.xtext.example.homeautomation.tests;
 import com.google.inject.Inject;
 import org.eclipse.xtext.example.homeautomation.ruleEngine.Model;
 import org.eclipse.xtext.example.homeautomation.tests.AbstractTest;
-import org.eclipse.xtext.junit4.util.ParseHelper;
-import org.eclipse.xtext.junit4.validation.ValidationTestHelper;
+import org.eclipse.xtext.testing.util.ParseHelper;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.xtext.example.homeautomation,
  org.eclipse.xtext.xbase.ui,
  org.eclipse.xtext.builder
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.ui.contentassist,
  org.eclipse.xtext.example.homeautomation.ui.quickfix,
  org.eclipse.xtext.example.homeautomation.ui.internal

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.emf.common,
  org.eclipse.xtext.common.types,
  org.eclipse.xtext.xbase.lib
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.ruleEngine.util,
  org.eclipse.xtext.example.homeautomation.ruleEngine,
  org.eclipse.xtext.example.homeautomation.ruleEngine.impl,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/RuleEngine.xtext
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/RuleEngine.xtext
@@ -29,12 +29,14 @@ Rule:
 		'then' thenPart=XBlockExpression;
 
 // We modify the concrete syntax of two Xbase expressions and make them indentation-aware
+@Override 
 XBlockExpression returns xbase::XExpression: 
 	{xbase::XBlockExpression}
 	BEGIN
 		(expressions+=XExpressionOrVarDeclaration ';'?)*
 	END;
 
+@Override 
 XSwitchExpression returns xbase::XExpression:
 	{xbase::XSwitchExpression}
 	'switch' (=>('(' declaredParam=JvmFormalParameter ':') switch=XExpression ')'


### PR DESCRIPTION
Get rid of warnings in Examples.
Set BREE to Java 1.8

Fixes #164 and #174

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>