### PR TITLE
177: Reintroduce dep to org.eclipse.xtext.junit4

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics.ui.tests; singleton:=
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.arithmetics.ui,
  org.junit;bundle-version="4.7.0",
+ org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-Version: 2.12.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.domainmodel.ui.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.domainmodel.ui,
+ org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.xtext.testing,
  org.eclipse.core.runtime,


### PR DESCRIPTION
This is still the bundle containing classes for UI testing.

Closes #177

Task-Url: https://github.com/eclipse/xtext-extras/issues/177
Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>