### PR TITLE
[#194] Cast to ITextSelection instead of TextSelection

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/StratumBreakpointAdapterFactory.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/StratumBreakpointAdapterFactory.java
@@ -34,7 +34,6 @@ import org.eclipse.jdt.internal.ui.javaeditor.IClassFileEditorInput;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextSelection;
-import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IWorkbenchPart;
@@ -107,7 +106,7 @@ public class StratumBreakpointAdapterFactory implements IAdapterFactory, IToggle
 			final IEditorInput editorInput = xtextEditor.getEditorInput();
 			final IResource breakpointResource = breakpointUtil.getBreakpointResource(editorInput);
 			final SourceRelativeURI breakpointUri = breakpointUtil.getBreakpointURI(editorInput);
-			final int offset = ((TextSelection) selection).getOffset();
+			final int offset = ((ITextSelection) selection).getOffset();
 			final int line = xtextEditor.getDocument().getLineOfOffset(offset) + 1;
 			
 			Data data = xtextEditor.getDocument().readOnly(new IUnitOfWork<Data, XtextResource>() {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/bracketmatching/GoToMatchingBracketAction.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/bracketmatching/GoToMatchingBracketAction.java
@@ -9,7 +9,7 @@ package org.eclipse.xtext.ui.editor.bracketmatching;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.text.IRegion;
-import org.eclipse.jface.text.TextSelection;
+import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.source.ICharacterPairMatcher;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.xtext.ui.editor.XtextEditor;
@@ -37,8 +37,8 @@ public class GoToMatchingBracketAction extends Action implements IActionContribu
 	public void run() {
 		IXtextDocument document = editor.getDocument();
 		ISelection selection = editor.getSelectionProvider().getSelection();
-		if (selection instanceof TextSelection) {
-			TextSelection textSelection = (TextSelection) selection;
+		if (selection instanceof ITextSelection) {
+			ITextSelection textSelection = (ITextSelection) selection;
 			if (textSelection.getLength()==0) {
 				IRegion region = matcher.match(document, textSelection.getOffset());
 				if (region != null) {


### PR DESCRIPTION
Change GoToMatchingBracketAction and StratumBreakpointAdapterFactory to
do cast to ITextSelection instead of TextSelection to allow editors wrap
TextSelection into some extended selection while still implementing
ITextSelection.

Signed-off-by: Roman Mitin <roman.mitin@gmail.com>