### PR TITLE
fixed autoedit in copyright comments.

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/autoedit/DefaultAutoEditStrategyProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/autoedit/DefaultAutoEditStrategyProvider.java
@@ -63,6 +63,8 @@ public class DefaultAutoEditStrategyProvider extends AbstractEditStrategyProvide
 
 	protected void configureMultilineComments(IEditStrategyAcceptor acceptor) {
 		acceptor.accept(singleLineTerminals.newInstance("/*", " */"),IDocument.DEFAULT_CONTENT_TYPE);
+		acceptor.accept(multiLineTerminals.newInstance("/***"," * ", " ***/"),IDocument.DEFAULT_CONTENT_TYPE);
+		acceptor.accept(multiLineTerminals.newInstance("/***"," * ", " ***/"),TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
 		acceptor.accept(multiLineTerminals.newInstance("/*"," * ", " */"),IDocument.DEFAULT_CONTENT_TYPE);
 		acceptor.accept(multiLineTerminals.newInstance("/*"," * ", " */"),TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
 	}

--- a/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/editor/autoedit/XtextAutoEditStrategyTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/editor/autoedit/XtextAutoEditStrategyTest.java
@@ -264,7 +264,46 @@ public class XtextAutoEditStrategyTest extends AbstractCStyleLanguageAutoEditTes
 				"\t|\n" +
 				";" , editor);
 	}
-
+	
+	@Test public void testXtendIssue163() throws Exception {
+		XtextEditor editor = openEditor(
+				"/*******************************************************************************\n" +
+				" * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.\n" +
+				" * All rights reserved. This program and the accompanying materials\n" +
+				" * are made available under the terms of the Eclipse Public License v1.0\n" +
+				" * which accompanies this distribution, and is available at\n" +
+				" * http://www.eclipse.org/legal/epl-v10.html|\n" +
+				" *******************************************************************************/\n" +
+				"grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals\n" +
+				"\n" +
+				"/*\n" +
+				" * this is a comment\n" +
+				" */\n" +
+				"generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"\n" +
+				"\n" +
+				"A: name=ID\n" +
+				"\n");
+		pressKey(editor, '\n');
+		assertState(
+				"/*******************************************************************************\n" +
+				" * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.\n" +
+				" * All rights reserved. This program and the accompanying materials\n" +
+				" * are made available under the terms of the Eclipse Public License v1.0\n" +
+				" * which accompanies this distribution, and is available at\n" +
+				" * http://www.eclipse.org/legal/epl-v10.html\n" +
+				" * |\n" +
+				" *******************************************************************************/\n" +
+				"grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals\n" +
+				"\n" +
+				"/*\n" +
+				" * this is a comment\n" +
+				" */\n" +
+				"generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"\n" +
+				"\n" +
+				"A: name=ID\n" +
+				"\n" , editor);
+	}
+	
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();


### PR DESCRIPTION
fixed autoedit in copyright comments.
https://github.com/eclipse/xtext-xtend/issues/163

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>