### PR TITLE
Oomph: bugzilla query for Xtend bugs

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -1403,6 +1403,9 @@
         <query
             summary="Xtext Bugs"
             url="https://bugs.eclipse.org/bugs/buglist.cgi?product=TMF&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
+        <query
+            summary="Xtend Bugs"
+            url="https://bugs.eclipse.org/bugs/buglist.cgi?product=Xtend&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
       </setupTask>
       <setupTask
           xsi:type="mylyn:MylynQueriesTask"
@@ -1701,6 +1704,9 @@
         <query
             summary="Xtext Bugs"
             url="https://bugs.eclipse.org/bugs/buglist.cgi?product=TMF&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
+        <query
+            summary="Xtend Bugs"
+            url="https://bugs.eclipse.org/bugs/buglist.cgi?product=Xtend&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
       </setupTask>
     </stream>
     <stream

--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -1402,10 +1402,7 @@
           password="${eclipse.user.password}">
         <query
             summary="Xtext Bugs"
-            url="https://bugs.eclipse.org/bugs/buglist.cgi?product=TMF&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
-        <query
-            summary="Xtend Bugs"
-            url="https://bugs.eclipse.org/bugs/buglist.cgi?product=Xtend&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
+            url="https://bugs.eclipse.org/bugs/buglist.cgi?product=TMF&amp;product=Xtend&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
       </setupTask>
       <setupTask
           xsi:type="mylyn:MylynQueriesTask"
@@ -1703,10 +1700,7 @@
           password="${eclipse.user.password}">
         <query
             summary="Xtext Bugs"
-            url="https://bugs.eclipse.org/bugs/buglist.cgi?product=TMF&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
-        <query
-            summary="Xtend Bugs"
-            url="https://bugs.eclipse.org/bugs/buglist.cgi?product=Xtend&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
+            url="https://bugs.eclipse.org/bugs/buglist.cgi?product=TMF&amp;product=Xtend&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=ASSIGNED&amp;bug_status=REOPENED"/>
       </setupTask>
     </stream>
     <stream


### PR DESCRIPTION
Currently there was a mylyn bugzilla query only for Xtext, not for
Xtend.

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>