### PR TITLE
[477446] Added Null Guard to OutlineWithEditorLinker.findBestNode

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/actions/OutlineWithEditorLinker.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/actions/OutlineWithEditorLinker.java
@@ -143,8 +143,8 @@ public class OutlineWithEditorLinker implements IPropertyChangeListener {
 			for (IOutlineNode child : input.getChildren()) {
 				IOutlineNode candidate = findBestNode(child, selectedTextRegion);
 				if (candidate != null
-						&& (currentBestNode.getFullTextRegion() == null || currentBestNode.getFullTextRegion()
-								.getLength() >= candidate.getFullTextRegion().getLength())) {
+						&& (currentBestNode.getFullTextRegion() == null || candidate.getFullTextRegion() != null
+								&& currentBestNode.getFullTextRegion().getLength() >= candidate.getFullTextRegion().getLength())) {
 					currentBestNode = candidate;
 				}
 			}


### PR DESCRIPTION
[477446] Added Null Guard to OutlineWithEditorLinker.findBestNode

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>