### PR TITLE
add null check to FindReferencesHandler.getQueryExecutor. Fixes #224

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/FindReferencesHandler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/FindReferencesHandler.java
@@ -67,6 +67,9 @@ public class FindReferencesHandler extends AbstractHandler {
 	}
 
 	protected ReferenceQueryExecutor getQueryExecutor(EObject target) {
+		if (target == null) {
+			return null;
+		}
 		URI targetURI = EcoreUtil2.getPlatformResourceOrNormalizedURI(target);
 		if(targetURI != null) {
 			ReferenceQueryExecutor queryExecutor = globalServiceProvider.findService(targetURI.trimFragment(), ReferenceQueryExecutor.class);


### PR DESCRIPTION
add null check to FindReferencesHandler.getQueryExecutor. Fixes #224

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>