### PR TITLE
Remove a few warnings

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/debug/XtextBuildConsolePageParticipant.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/debug/XtextBuildConsolePageParticipant.java
@@ -25,8 +25,9 @@ public class XtextBuildConsolePageParticipant implements IConsolePageParticipant
 	
 	private CloseConsoleAction fCloseAction;
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
-	public Object getAdapter(@SuppressWarnings("rawtypes") Class adapter) {
+	public Object getAdapter(Class adapter) {
 		return null;
 	}
 

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/StratumBreakpointAdapterFactory.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/StratumBreakpointAdapterFactory.java
@@ -74,7 +74,7 @@ public class StratumBreakpointAdapterFactory implements IAdapterFactory, IToggle
 	private XbaseBreakpointUtil breakpointUtil;
 
 	@Override
-	@SuppressWarnings({ "rawtypes" })
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public Object getAdapter(Object adaptableObject, Class adapterType) {
 		if (adaptableObject instanceof XtextEditor) {
 			return this;

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
@@ -380,7 +380,6 @@ public class JdtBasedTypeFactory extends AbstractDeclaredTypeFactory implements 
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	private IBinding resolveBindings(IType jdtType, IJavaProject javaProject) {
 		ThreadLocal<Boolean> abortOnMissingSource = JavaModelManager.getJavaModelManager().abortOnMissingSource;
 		Boolean wasAbortOnMissingSource = abortOnMissingSource.get();

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/JavaProjectSetupUtil.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/JavaProjectSetupUtil.java
@@ -338,7 +338,6 @@ public class JavaProjectSetupUtil {
 	}
 	
 	public static void makeJava5Compliant(IJavaProject javaProject) {
-		@SuppressWarnings("unchecked")
 		Map<String, String> options= javaProject.getOptions(false);
 		options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 		options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
@@ -338,7 +338,6 @@ public class JavaProjectSetupUtil {
 	}
 	
 	public static void makeJava5Compliant(IJavaProject javaProject) {
-		@SuppressWarnings("unchecked")
 		Map<String, String> options= javaProject.getOptions(false);
 		options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 		options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -335,7 +335,7 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 		return null;
 	}
 
-	@SuppressWarnings("rawtypes")
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public Object getAdapter(Class adapter) {
 		if (IContentOutlinePage.class.isAssignableFrom(adapter)) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditorErrorTickUpdater.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditorErrorTickUpdater.java
@@ -100,7 +100,6 @@ public class XtextEditorErrorTickUpdater extends IXtextEditorCallback.NullImpl i
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	protected Severity getSeverity(XtextEditor xtextEditor) {
 		if (xtextEditor == null || xtextEditor.getInternalSourceViewer() == null)
 			return null;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
@@ -61,7 +61,6 @@ public class XtextSourceViewer extends ProjectionViewer implements IAdaptable {
 	/**
 	 * copied from org.eclipse.jdt.internal.ui.javaeditor.JavaSourceViewer.prependTextPresentationListener(ITextPresentationListener)
 	 */
-	@SuppressWarnings("unchecked")
 	public void prependTextPresentationListener(ITextPresentationListener listener) {
 		Assert.isNotNull(listener);
 
@@ -86,7 +85,6 @@ public class XtextSourceViewer extends ProjectionViewer implements IAdaptable {
 			// handle plain redraw changes
 			super.updateTextListeners(cmd);
 		} else {
-			@SuppressWarnings("unchecked")
 			List<ITextListener> textListeners= fTextListeners;
 			if (textListeners != null) {
 				textListeners= new ArrayList<ITextListener>(textListeners);
@@ -136,7 +134,7 @@ public class XtextSourceViewer extends ProjectionViewer implements IAdaptable {
 	 * @since 2.3
 	 */
 	@Override
-	@SuppressWarnings("rawtypes")
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public Object getAdapter(Class adapter) {
 		if (IReconciler.class.isAssignableFrom(adapter)) {
 			return fReconciler;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/AbstractContentProposalProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/AbstractContentProposalProvider.java
@@ -19,9 +19,7 @@ import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.conversion.IValueConverterService;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.naming.QualifiedName;
-import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.resource.IEObjectDescription;
-import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.XtextSwitch;
 
 import com.google.inject.Inject;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/folding/DefaultFoldingStructureProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/folding/DefaultFoldingStructureProvider.java
@@ -129,7 +129,6 @@ public class DefaultFoldingStructureProvider implements IFoldingStructureProvide
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	protected Annotation[] mergeFoldingRegions(Collection<FoldedPosition> foldedPositions,
 			ProjectionAnnotationModel projectionAnnotationModel) {
 		List<Annotation> deletions = new ArrayList<Annotation>();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/html/DefaultEObjectHoverProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/html/DefaultEObjectHoverProvider.java
@@ -38,7 +38,6 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/occurrences/OccurrenceMarker.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/occurrences/OccurrenceMarker.java
@@ -155,7 +155,6 @@ public class OccurrenceMarker {
 			return null;
 		}
 
-		@SuppressWarnings("unchecked")
 		protected Annotation[] getExistingOccurrenceAnnotations(IAnnotationModel annotationModel) {
 			Set<Annotation> removeSet = newHashSet();
 			for (Iterator<Annotation> annotationIter = annotationModel.getAnnotationIterator(); annotationIter

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/AbstractOutlineNode.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/AbstractOutlineNode.java
@@ -192,7 +192,7 @@ public abstract class AbstractOutlineNode implements IOutlineNode, IOutlineNode.
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public Object getAdapter(Class adapterType) {
 		return Platform.getAdapterManager().getAdapter(this, adapterType);
 	}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/MarkerResolutionGenerator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/MarkerResolutionGenerator.java
@@ -103,7 +103,6 @@ public class MarkerResolutionGenerator extends AbstractIssueResolutionProviderAd
 		return getAdaptedResolutions(Lists.newArrayList(resolutions));
 	}
 
-	@SuppressWarnings("unchecked")
 	public boolean isMarkerStillValid(final IMarker marker, final IAnnotationModel annotationModel) {
 		Iterator<Annotation> iterator = annotationModel.getAnnotationIterator();
 		return Iterators.any(iterator, new Predicate<Annotation>() {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/AnnotationIssueProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/AnnotationIssueProcessor.java
@@ -105,7 +105,6 @@ public class AnnotationIssueProcessor implements IValidationIssueProcessor, IAnn
 		if (monitor.isCanceled() || annotationModel == null) {
 			return Lists.newArrayList();
 		}
-		@SuppressWarnings("unchecked")
 		Iterator<Annotation> annotationIterator = annotationModel.getAnnotationIterator();
 		List<Annotation> toBeRemoved = Lists.newArrayList();
 		while (annotationIterator.hasNext()) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DisplayChangeWrapper.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DisplayChangeWrapper.java
@@ -96,7 +96,7 @@ public class DisplayChangeWrapper {
 			return delegate.getAffectedObjects();
 		}
 	
-		@SuppressWarnings("rawtypes")
+		@SuppressWarnings({ "rawtypes", "unchecked" })
 		@Override
 		public Object getAdapter(Class adapter) {
 			return delegate.getAdapter(adapter);
@@ -200,7 +200,7 @@ public class DisplayChangeWrapper {
 			return delegate.getAffectedObjects();
 		}
 
-		@SuppressWarnings("rawtypes")
+		@SuppressWarnings({ "rawtypes", "unchecked" })
 		@Override
 		public Object getAdapter(Class adapter) {
 			return delegate.getAdapter(adapter);
@@ -254,7 +254,7 @@ public class DisplayChangeWrapper {
 			delegate.addTextEditGroup(group);
 		}
 
-		@SuppressWarnings("rawtypes")
+		@SuppressWarnings({ "rawtypes", "unchecked" })
 		@Override
 		public boolean hasOneGroupCategory(List groupCategories) {
 			return delegate.hasOneGroupCategory(groupCategories);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagConfigurationBlock.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagConfigurationBlock.java
@@ -187,7 +187,6 @@ public class TaskTagConfigurationBlock extends OptionsConfigurationBlock {
 	}
 
 	private static class TaskTagSorter extends ViewerComparator {
-		@SuppressWarnings("unchecked")
 		@Override
 		public int compare(Viewer viewer, Object e1, Object e2) {
 			return getComparator().compare(((TaskTag) e1).getName(), ((TaskTag) e2).getName());

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/FeatureProjectFactory.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/FeatureProjectFactory.xtend
@@ -60,7 +60,6 @@ class FeatureProjectFactory extends ProjectFactory {
 		return this;
 	}
 	
-	@Override
 	override protected void enhanceProject(IProject project, SubMonitor subMonitor, Shell shell) throws CoreException {
 		super.enhanceProject(project, subMonitor, shell);
 		createManifest(project, subMonitor.newChild(1));

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverDocumentationProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverDocumentationProvider.java
@@ -776,7 +776,6 @@ public class XbaseHoverDocumentationProvider implements IEObjectHoverDocumentati
 			@SuppressWarnings("all")
 			ASTParser parser = ASTParser.newParser(AST.JLS3);
 			parser.setProject(javaProject);
-			@SuppressWarnings("unchecked")
 			Map<String, String> options = javaProject.getOptions(true);
 			options.put(JavaCore.COMPILER_DOC_COMMENT_SUPPORT, JavaCore.ENABLED); // workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=212207
 			parser.setCompilerOptions(options);

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseInformationControl.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseInformationControl.java
@@ -41,7 +41,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.graphics.TextLayout;
 import org.eclipse.swt.graphics.TextStyle;

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegate.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegate.java
@@ -86,8 +86,9 @@ public class JavaElementDelegate implements IAdaptable {
 		this.resource = resource;
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
-	public Object getAdapter(@SuppressWarnings("rawtypes") Class adapter) {
+	public Object getAdapter(Class adapter) {
 		if (IJavaElement.class.equals(adapter)) {
 			if (editor != null) {
 				IJavaElement javaMethod = getJavaElementForXtextEditor(editor);

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateAdapterFactory.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateAdapterFactory.java
@@ -30,6 +30,7 @@ public class JavaElementDelegateAdapterFactory implements IAdapterFactory {
 	@Inject
 	private Provider<JavaElementDelegateMainLaunch> mainDelegateProvider;
 	
+	@SuppressWarnings("unchecked")
 	@Override
 	public Object getAdapter(Object adaptableObject, @SuppressWarnings("rawtypes")  Class adapterType) {
 		if (adaptableObject instanceof JavaElementDelegate) {
@@ -61,7 +62,7 @@ public class JavaElementDelegateAdapterFactory implements IAdapterFactory {
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public Class[] getAdapterList() {
 		return new Class[] { JavaElementDelegate.class };
 	}


### PR DESCRIPTION
I had too many warnings in my workspace so I removed a few.

The pattern `(MyClass) getAdapter(MyClass.class);` was repeated so often I was wondering if we need this for backwards compatibility?!