### PR TITLE
[515846] Don't call getTraceToTarget when src project config unavailable

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/TraceForStorageProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/TraceForStorageProvider.java
@@ -164,7 +164,10 @@ public class TraceForStorageProvider extends AbstractTraceForURIProvider<IFile, 
 	public IEclipseTrace getTraceToTarget(IStorage sourceResource) {
 		if (sourceResource instanceof IFile) {
 			IFile file = (IFile) sourceResource;
-			return getTraceToTarget(file, getAbsoluteLocation(file), getProjectConfig(file));
+			IProjectConfig sourceProjectConfig = getProjectConfig(file);
+			if (sourceProjectConfig != null) {
+				return getTraceToTarget(file, getAbsoluteLocation(file), sourceProjectConfig);
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>