### PR TITLE
[477917] Fixed NullPointerException in DisplayChangeWrapper.getModifiedElement

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/DisplayChangeWrapperTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/DisplayChangeWrapperTest.java
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.ui.tests.refactoring;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.Document;
 import org.eclipse.ltk.core.refactoring.Change;
@@ -43,5 +44,21 @@ public class DisplayChangeWrapperTest extends AbstractXtextTests {
 		assertEquals(change, ((DisplayChangeWrapper.Wrapper) wrapped).getDelegate());
 		Change undo = wrapped.perform(new NullProgressMonitor());
 		assertTrue(undo instanceof DisplayChangeWrapper.Wrapper);
+	}
+	
+	@Test 
+	public void testNoUndoChange() throws CoreException {
+		Change change = new NullChange("my no undo change") {
+			@Override
+			public Change perform(IProgressMonitor pm) throws CoreException {
+				return null;
+			}
+		};
+		Change wrapped = DisplayChangeWrapper.wrap(change);
+		assertFalse(wrapped instanceof TextEditBasedChange);
+		assertTrue(wrapped instanceof DisplayChangeWrapper.Wrapper);
+		assertEquals(change, ((DisplayChangeWrapper.Wrapper) wrapped).getDelegate());
+		Change undo = wrapped.perform(new NullProgressMonitor());
+		assertNull(undo);
 	}
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DisplayChangeWrapper.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DisplayChangeWrapper.java
@@ -34,8 +34,10 @@ public class DisplayChangeWrapper {
 	public static Change wrap(Change delegate) {
 		if(delegate instanceof TextEditBasedChange) {
 			return new TextEditBased((TextEditBasedChange) delegate);
-		} else {
+		} else if (delegate != null) {
 			return new Generic(delegate);
+		} else {
+			return null;
 		}
 	}
 	


### PR DESCRIPTION
[477917] Fixed NullPointerException in DisplayChangeWrapper.getModifiedElement

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>