### PR TITLE
[516391] Fixed NPE in JavaBreakPointProvider

### DIFF
--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/debug/JavaBreakPointProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/debug/JavaBreakPointProvider.java
@@ -117,6 +117,9 @@ public class JavaBreakPointProvider {
 			if (rootTraceRegion == null)
 				return -1;
 			List<LineMapping> lineMappings = lineMappingProvider.getLineMapping(rootTraceRegion);
+			if (lineMappings == null) {
+				return -1;
+			}
 			for (LineMapping lineMapping : lineMappings) {
 				if (lineMapping.sourceStartLine == breakpoint.getLineNumber()) {
 					return lineMapping.targetEndLine + 1;


### PR DESCRIPTION
[516391] Fixed NPE in JavaBreakPointProvider

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>