### PR TITLE
[#278] OutlineView flickers on every Keystroke

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
@@ -297,6 +297,7 @@ public class OutlinePage extends ContentOutlinePage implements ISourceViewerAwar
 				try {
 					TreeViewer treeViewer = getTreeViewer();
 					if (!treeViewer.getTree().isDisposed()) {
+						getTreeViewer().getTree().setRedraw(false);
 						if (treeViewer.getLabelProvider() != labelProvider) {
 							if (treeViewer.getInput() != null && treeViewer.getContentProvider() != null)
 								treeViewer.setInput(null);
@@ -318,6 +319,8 @@ public class OutlinePage extends ContentOutlinePage implements ISourceViewerAwar
 					}
 				} catch (Throwable t) {
 					LOG.error("Error refreshing outline", t);
+				}finally{
+					getTreeViewer().getTree().setRedraw(true);
 				}
 			}
 		});

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
@@ -319,7 +319,7 @@ public class OutlinePage extends ContentOutlinePage implements ISourceViewerAwar
 					}
 				} catch (Throwable t) {
 					LOG.error("Error refreshing outline", t);
-				}finally{
+				} finally {
 					getTreeViewer().getTree().setRedraw(true);
 				}
 			}


### PR DESCRIPTION
Set redraw(false) before refreshing the treeviewer to avoid flickering.
Reset to redraw(true) after refresh.

Signed-off-by: HBuender <hendrik.buender@gmail.com>