### PR TITLE
Don't do indentity edits during organize imports.

### DIFF
--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/imports/OrganizeImportsHandler.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/imports/OrganizeImportsHandler.java
@@ -57,7 +57,7 @@ public class OrganizeImportsHandler extends AbstractHandler {
 				return importOrganizer.getOrganizedImportChanges(state);
 			}
 		});
-		if (result == null)
+		if (result == null || result.isEmpty())
 			return;
 		try {
 			DocumentRewriteSession session = null;


### PR DESCRIPTION
Don't do indentity edits during organize imports.
fixes eclipse/xtext-xtend#130

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>