### PR TITLE
[475431] Provide better error reporting on initialization failure

### DIFF
--- a/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/Access.java
+++ b/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/Access.java
@@ -41,10 +41,14 @@ public class Access {
 
 		@Override
 		public T get() {
-			if (Activator.getDefault()==null) {
+			Activator activator = Activator.getDefault();
+			if (activator==null) {
 				throw new IllegalStateException("The bundle has not been started!");
 			}
-			return Activator.getDefault().getInjector().getInstance(clazz);
+			if (activator.getInjector()==null) {
+				throw new IllegalStateException("The bundle was not initialized properly!");
+			}
+			return activator.getInjector().getInstance(clazz);
 		}
 	}
 	

--- a/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/Activator.java
+++ b/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/Activator.java
@@ -7,20 +7,31 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.shared.internal;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.log4j.Logger;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
 import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.xtext.common.types.ui.notification.TypeResourceUnloader;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -29,6 +40,10 @@ import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
 public class Activator extends Plugin {
+	private static final String PLUGIN_ID_JDT_UI = "org.eclipse.jdt.ui";
+	private static final String PLUGIN_ID_XTEXT_RT = "org.eclipse.xtext";
+	private static final String PLUGIN_ID_XTEXT_UI = "org.eclipse.xtext.ui";
+	private static final String PLUGIN_ID_XTEND_RT = "org.eclipse.xtend";
 
 	private static final Logger log = Logger.getLogger(Activator.class);
 
@@ -49,7 +64,7 @@ public class Activator extends Plugin {
 		return injector;
 	}
 
-	protected void initializeInjector(BundleContext context) {
+	protected void initializeInjector(BundleContext context) throws CoreException {
 		IExtensionPoint point = Platform.getExtensionRegistry().getExtensionPoint(PLUGIN_ID + ".overridingGuiceModule");
 		IExtension[] extensions = point.getExtensions();
 		Module module = new SharedModule(context);
@@ -72,14 +87,93 @@ public class Activator extends Plugin {
 			}
 		}
 
-		injector = Guice.createInjector(module);
-		injector.createChildInjector(new Module() {
-			@Override
-			public void configure(Binder binder) {
-				binder.bind(EagerContributionInitializer.class);
-			}
-		}).injectMembers(this);
+		try {
+			injector = Guice.createInjector(module);
+			injector.createChildInjector(new Module() {
+				@Override
+				public void configure(Binder binder) {
+					binder.bind(EagerContributionInitializer.class);
+				}
+			}).injectMembers(this);
+		} catch (Throwable t) {
+			handleGuiceInitializationError(t);
+		}
 	}
+
+	/**
+	 * Analyze the occured error during Guice initialization and give hints to check the configuration error.
+	 * @throws CoreException Will be thrown in any case
+	 * @since 2.13
+	 */
+	protected void handleGuiceInitializationError(Throwable t) throws CoreException {
+		Bundle bundleXtextRuntime = Platform.getBundle(PLUGIN_ID_XTEXT_RT);
+		Bundle bundleXtextIde = Platform.getBundle("org.eclipse.xtext.ide");
+		Bundle bundleXtextUi = Platform.getBundle(PLUGIN_ID_XTEXT_UI);
+		Bundle bundleXtextUiShared = Platform.getBundle(PLUGIN_ID);
+
+		StringBuilder msg = new StringBuilder();
+		msg.append("Xtext configuration error!\n");
+		msg.append("This error might indicate missing version constraints of installed Xtext based bundles.\n");
+		
+		msg.append("The following bundles were detected that require Xtext UI:\n");
+		
+		getBundlesRequiringXtextUi()
+			.forEach((bundle) -> msg.append("- "+getBundleInfo(bundle) +"\n"));
+		
+		msg.append("The installed Xtext bundle versions are:\n");
+		Lists.newArrayList(bundleXtextRuntime, bundleXtextIde, bundleXtextUi, bundleXtextUiShared)
+			.forEach(
+				(bundle) -> msg.append("- "+getBundleInfo(bundle) + "\n")
+			);
+
+		if (bundleXtextRuntime.getVersion().compareTo(bundleXtextUiShared.getVersion()) > 0) {
+			msg.append("Runtime bundle is NEWER than UI bundles! Please make sure that both bundles are installed with the same version!\n");
+		}
+		throw new CoreException(new Status(IStatus.ERROR, getBundle().getSymbolicName(), msg.toString(), t));
+	}
+	
+	private String getBundleInfo (Bundle bundle) {
+		String state = null;
+		switch (bundle.getState()) {
+			case Bundle.UNINSTALLED: state = "UNINSTALLED"; break;
+			case Bundle.INSTALLED: state = "INSTALLED"; break;
+			case Bundle.RESOLVED: state = "RESOLVED"; break;
+			case Bundle.STARTING: state = "STARTING"; break;
+			case Bundle.STOPPING: state = "STOPPING"; break;
+			case Bundle.ACTIVE: state = "ACTIVE"; break;
+		}
+		return bundle.getSymbolicName() + " " + bundle.getVersion() + " ["+state+"]";
+	}
+
+	/**
+	 * Retrieves all bundles that declare a RequireBundle dependency on org.eclipse.xtext.ui, excluding bundles from Xtext itself.
+	 * @since 2.13
+	 */
+	public List<Bundle> getBundlesRequiringXtextUi() {
+		return Arrays.asList(getBundle().getBundleContext().getBundles()).stream()
+			.filter((bundle)-> // exclude Xtext's own bundles
+				!Arrays.stream(new String[] {PLUGIN_ID_XTEXT_RT,PLUGIN_ID_XTEND_RT}).anyMatch((s)->bundle.getSymbolicName().startsWith(s))
+			)
+			.filter(
+				(bundle) -> {
+				try {
+					ManifestElement[] requireBundle = ManifestElement.parseHeader(Constants.REQUIRE_BUNDLE, bundle.getHeaders().get(Constants.REQUIRE_BUNDLE));
+					if (requireBundle == null)
+						return false;
+					Stream<ManifestElement> requireElements = Arrays.stream(requireBundle);
+					return requireElements
+						.map((e)->e.getValueComponents())
+						.flatMap((e)->Arrays.stream(e))
+						.anyMatch((bundleName) -> {
+							return PLUGIN_ID_XTEXT_UI.equals(bundleName);
+						})
+						;
+				} catch (BundleException e) {}
+				return false;
+			}
+		).collect(Collectors.toList());
+	}
+	
 
 	public static boolean isJavaEnabled() {
 		try {
@@ -90,7 +184,7 @@ public class Activator extends Plugin {
 			if (Display.getCurrent() == null) {
 				Bundle[] bundles = plugin.getBundle().getBundleContext().getBundles();
 				for (Bundle bundle :bundles) {
-					if ("org.eclipse.jdt.ui".equals(bundle.getSymbolicName())) {
+					if (PLUGIN_ID_JDT_UI.equals(bundle.getSymbolicName())) {
 						return true;
 					}
 				}
@@ -113,6 +207,8 @@ public class Activator extends Plugin {
 			plugin = this;
 			initializeInjector(context);
 			initializer.initialize();
+		} catch (CoreException e) {
+			throw e;
 		} catch (Exception e) {
 			log.error("Error initializing " + PLUGIN_ID + ":" + e.getMessage(), e);
 		}

--- a/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/ExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/ExecutableExtensionFactory.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.shared.internal;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
 
@@ -16,12 +17,12 @@ public class ExecutableExtensionFactory extends AbstractGuiceAwareExecutableExte
 
 	@Override
 	protected Bundle getBundle() {
-		return Activator.getDefault().getBundle();
+		return Platform.getBundle(Activator.PLUGIN_ID);
 	}
 
 	@Override
 	protected Injector getInjector() {
-		return Activator.getDefault().getInjector();
+		return Activator.getDefault() != null ? Activator.getDefault().getInjector() : null;
 	}
 
 }


### PR DESCRIPTION
When initialization fails during creation of the Guice injector, an
analysis of the installed bundles and versions is performed. This is
done to create a detailed error report which should help to identify the
issue.

Changed Access and ExecutableExtensionFactory to be better prepared to
the fact that the bundle was not properly started and injector might be
unavailable.

The error message could be for example:
```
Caused by: org.eclipse.core.runtime.CoreException: Xtext configuration error!
This error might indicate missing version constraints of installed Xtext based bundles.
The following bundles were detected that require Xtext UI:
- org.eclipse.emf.mwe2.language.ui 2.9.1.201706191249 [STARTING]
- org.xtext.example.mydsl.ui 1.0.0.qualifier [STARTING]
The installed Xtext bundle versions are:
- org.eclipse.xtext 2.13.0.qualifier [STARTING]
- org.eclipse.xtext.ide 2.13.0.qualifier [STARTING]
- org.eclipse.xtext.ui 2.8.0.qualifier [ACTIVE]
- org.eclipse.xtext.ui.shared 2.13.0.qualifier [STARTING]
Runtime bundle is NEWER than UI bundles! Please make sure that both bundles are installed with the same version!

	at org.eclipse.xtext.ui.shared.internal.Activator.handleGuiceInitializationError(Activator.java:122)
	at org.eclipse.xtext.ui.shared.internal.Activator.initializeInjector(Activator.java:96)
	at org.eclipse.xtext.ui.shared.internal.Activator.start(Activator.java:182)
```
