### PR TITLE
Bug472993

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/LanguageRootPreferencePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/LanguageRootPreferencePage.java
@@ -19,6 +19,10 @@ import com.google.inject.Inject;
  */
 public class LanguageRootPreferencePage extends AbstractPreferencePage {
 	private @Inject ResetPromptDialogSettingsField resetPromptDialogSettings;
+	
+	public LanguageRootPreferencePage () {
+		noDefaultAndApplyButton();
+	}
 
 	@Override
 	protected void createFieldEditors() {
@@ -35,5 +39,4 @@ public class LanguageRootPreferencePage extends AbstractPreferencePage {
 	protected IPreferenceStore doGetPreferenceStore() {
 		return super.doGetPreferenceStore();
 	}
-
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/preferences/ResetPromptDialogSettingsField.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/preferences/ResetPromptDialogSettingsField.java
@@ -32,6 +32,10 @@ public class ResetPromptDialogSettingsField extends FieldEditor {
 	private Group dontAskGroup;
 	private @Inject DontAskAgainDialogs dialogs;
 	private @Inject LanguageInfo languageInfo;
+	
+	public ResetPromptDialogSettingsField () {
+		init("resetPromptDialog", "Reset Prompt Dialog");
+	}
 
 	@Override
 	public int getNumberOfControls() {


### PR DESCRIPTION
This will make the "Restore Defaults" and "Apply" button on the language root page invisible, since there is nothing to reset or apply here. The ResetPromptDialogSettingsField on the page must be initialized correctly by calling init().