### PR TITLE
[475431] Add version constraint on org.eclipse.xtext

### DIFF
--- a/org.eclipse.xtext.ui.shared/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.shared/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 2.13.0.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.xtext.ui.shared.internal.Activator
 Bundle-Vendor: Eclipse Xtext
-Require-Bundle: org.eclipse.xtext.ui;resolution:=optional;x-installation:=greedy,
+Require-Bundle: org.eclipse.xtext.ui;bundle-version="[0.0.0,2.14.0)";resolution:=optional;x-installation:=greedy,
  org.eclipse.xtext.builder;resolution:=optional;x-installation:=greedy,
  org.eclipse.jdt.core;bundle-version="3.6.0";resolution:=optional;x-installation:=greedy,
  org.eclipse.jdt.ui;bundle-version="3.6.0";resolution:=optional;x-installation:=greedy,

--- a/org.eclipse.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.4.0";visibility:=reex
  org.eclipse.ui.editors;bundle-version="3.4.0";visibility:=reexport,
  org.eclipse.jface.text;bundle-version="3.4.0";visibility:=reexport,
  org.eclipse.ui.ide;bundle-version="3.4.0",
- org.eclipse.xtext;visibility:=reexport,
+ org.eclipse.xtext;bundle-version="[0.0.0,2.14.0)";visibility:=reexport,
  org.eclipse.ui.views;bundle-version="3.3.0",
  org.eclipse.emf.edit.ui;bundle-version="2.10.2";visibility:=reexport,
  org.eclipse.ui.workbench.texteditor;bundle-version="3.4.0",


### PR DESCRIPTION
UI plugin is likely to fail with a newer runtime bundle