### PR TITLE
Bug#438625 [EclipseResourceFileSystemAccess2] fileBasedTraceInformation should be of type ITraceForStorageProvider

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/EclipseResourceFileSystemAccess2.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/EclipseResourceFileSystemAccess2.java
@@ -26,7 +26,6 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IStorage;
-import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -41,7 +40,7 @@ import org.eclipse.xtext.generator.trace.ILocationData;
 import org.eclipse.xtext.generator.trace.ITraceRegionProvider;
 import org.eclipse.xtext.generator.trace.SourceRelativeURI;
 import org.eclipse.xtext.generator.trace.TraceRegionSerializer;
-import org.eclipse.xtext.ui.generator.trace.TraceForStorageProvider;
+import org.eclipse.xtext.ui.generator.trace.ITraceForStorageProvider;
 import org.eclipse.xtext.ui.generator.trace.TraceMarkers;
 import org.eclipse.xtext.ui.resource.ProjectByResourceProvider;
 import org.eclipse.xtext.util.RuntimeIOException;
@@ -89,11 +88,8 @@ public class EclipseResourceFileSystemAccess2 extends AbstractFileSystemAccess2 
 	private TraceMarkers traceMarkers;
 
 	@Inject
-	private TraceForStorageProvider fileBasedTraceInformation;
+	private ITraceForStorageProvider fileBasedTraceInformation;
 
-	@Inject
-	private IWorkspace workspace;
-	
 	@Inject
 	private ProjectByResourceProvider projectProvider;
 	

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/ITraceForStorageProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/ITraceForStorageProvider.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.generator.trace;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.xtext.generator.trace.internal.IPlatformSpecificTraceProvider;
 
@@ -19,6 +20,20 @@ import org.eclipse.xtext.generator.trace.internal.IPlatformSpecificTraceProvider
  * @since 2.9
  */
 public interface ITraceForStorageProvider extends IPlatformSpecificTraceProvider<IStorage, IEclipseTrace> {
+	/**
+	 * @since 2.13
+	 */
+	default IFile getTraceFile(IFile generatedFile) {
+		return null;
+	}
+
+	/**
+	 * @since 2.13
+	 */
+	default boolean isTraceFile(IStorage storage) {
+		return false;
+	}
+	
 	
 	class Null extends org.eclipse.xtext.generator.trace.internal.NoTraces<IStorage, IEclipseTrace> implements ITraceForStorageProvider {
 	}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/TraceForStorageProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/TraceForStorageProvider.java
@@ -180,12 +180,14 @@ public class TraceForStorageProvider extends AbstractTraceForURIProvider<IFile, 
 	/**
 	 * @since 2.3
 	 */
+	@Override
 	public IFile getTraceFile(IFile generatedFile) {
 		String originLastSegment = generatedFile.getFullPath().lastSegment();
 		IFile traceFile = generatedFile.getParent().getFile(new Path(getTraceFileNameProvider().getTraceFromJava(originLastSegment)));
 		return traceFile;
 	}
 
+	@Override
 	public boolean isTraceFile(IStorage storage) {
 		if (!(storage instanceof IFile)) {
 			return false;


### PR DESCRIPTION
EclipseResourceFileSystemAccess was injecting the implementation class
TraceForStorageProvider and could not inject the interface, since 2
methods on the implementation class were used that are not part of the
interface. For these methods ITraceForStorageProviderExtension was
created.

This allows disabling writing trace files by binding
ITraceForStorageProvider.Null (usually performance reason when no trace
is required).

Also cleaned up unused field `workspace`.