### PR TITLE
fixed wrong treatment of ^ as first character in prefix for xbase proposals

### DIFF
--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/contentassist/XbaseProposalProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/contentassist/XbaseProposalProvider.java
@@ -596,7 +596,11 @@ public class XbaseProposalProvider extends AbstractXbaseProposalProvider impleme
 		String prefix = contentAssistContext.getPrefix();
 		if (prefix.length() > 0) {
 			if (!Character.isJavaIdentifierStart(prefix.charAt(0))) {
-				return;
+				if (prefix.length() > 1) {
+					if (prefix.charAt(0) == '^' && !Character.isJavaIdentifierStart(prefix.charAt(1))) {
+						return;
+					}
+				}
 			}
 		}
 		


### PR DESCRIPTION
fixed wrong treatment of ^ as first character in prefix for xbase proposals
 https://github.com/eclipse/xtext-xtend/issues/242

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>