### PR TITLE
[472992] Add null guard when position could be retrieved for annotation

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AnnotationWithQuickFixesHover.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AnnotationWithQuickFixesHover.java
@@ -693,8 +693,8 @@ public class AnnotationWithQuickFixesHover extends AbstractProblemHover {
 		List<Annotation> annotations = getAnnotations(lineNumber, offset);
 		if (annotations != null) {
 			for (Annotation annotation : annotations) {
-				if (annotation.getText() != null) {
-					Position position = getAnnotationModel().getPosition(annotation);
+				Position position = getAnnotationModel().getPosition(annotation);
+				if (annotation.getText() != null && position != null) {
 					final QuickAssistInvocationContext invocationContext = new QuickAssistInvocationContext(sourceViewer, position.getOffset(), position.getLength(), true);
 					CompletionProposalRunnable runnable = new CompletionProposalRunnable(invocationContext);	
 					// Note: the resolutions have to be retrieved from the UI thread, otherwise

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/QuickAssistCompletionProposal.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/QuickAssistCompletionProposal.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.editor.quickfix;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IInformationControlCreator;
 import org.eclipse.jface.text.Position;
@@ -23,6 +24,8 @@ public class QuickAssistCompletionProposal implements ICompletionProposal, IComp
 	private Image image;
 
 	public QuickAssistCompletionProposal(Position pos, IssueResolution resolution, Image image) {
+		Assert.isNotNull(pos);
+		Assert.isNotNull(resolution);
 		this.pos = pos;
 		this.resolution = resolution;
 		this.image = image;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/XtextQuickAssistProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/XtextQuickAssistProcessor.java
@@ -145,10 +145,10 @@ public class XtextQuickAssistProcessor extends AbstractIssueResolutionProviderAd
 				}
 			} else {
 				final Issue issue = issueUtil.getIssueFromAnnotation(annotation);
-				if (issue != null) {
+				Position pos = annotationModel.getPosition(annotation);
+				if (issue != null && pos != null) {
 					Iterable<IssueResolution> resolutions = getResolutions(issue, xtextDocument);
 					if (resolutions.iterator().hasNext()) {
-						Position pos = annotationModel.getPosition(annotation);
 						for (IssueResolution resolution : resolutions) {
 							result.add(create(pos, resolution));
 						}


### PR DESCRIPTION
IAnnotationModel.getPosition() might return null. This would later lead
to invalid proposals with null position and to NPE when accessing them.
Also guarded arguments to QuickAssistCompletionProposal.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>