### PR TITLE
[Refactoring] do rename before text replacements

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/participant/ChangeConverter.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/participant/ChangeConverter.xtend
@@ -56,8 +56,8 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 	}
 
 	protected def void doConvert(IEmfResourceChange change) {
-		handleReplacements(change)
 		handleUriChange(change)
+		handleReplacements(change)
 	}
 
 	protected def dispatch void handleReplacements(IEmfResourceChange change) {

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring/participant/ChangeConverter.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring/participant/ChangeConverter.java
@@ -85,8 +85,8 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
   }
   
   protected void doConvert(final IEmfResourceChange change) {
-    this.handleReplacements(change);
     this.handleUriChange(change);
+    this.handleReplacements(change);
   }
   
   protected void _handleReplacements(final IEmfResourceChange change) {


### PR DESCRIPTION
...because text replacements are applied on the new URI

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>