### PR TITLE
Improved UiToIdeContentProposalProvider

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.xtend
@@ -25,6 +25,9 @@ import org.eclipse.xtext.ui.editor.contentassist.AbstractContentProposalProvider
 import org.eclipse.xtext.util.TextRegion
 
 /**
+ * Delegates to the generic IDE content proposal provider. Use this Implementation to share the same content assist
+ * code between Eclipse and other editors for your DSL.
+ * 
  * @author Titouan Vervack - Initial contribution and API
  * 
  * @since 2.13
@@ -53,15 +56,6 @@ class UiToIdeContentProposalProvider extends AbstractContentProposalProvider {
 			uiAcceptor.accept(proposal)
 		]
 	}
-    
-    override completeAssignment(Assignment object, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-    }
-    
-    override completeKeyword(Keyword object, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-    }
-    
-    override completeRuleCall(RuleCall object, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-    }
 	
 	protected def int getMaxProposals() {
 		1000
@@ -102,6 +96,24 @@ class UiToIdeContentProposalProvider extends AbstractContentProposalProvider {
             EObject:
                 getImage(source)
         }
+    }
+    
+    /**
+     * This method does nothing and should not be used.
+     */
+    override final completeAssignment(Assignment object, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
+    }
+    
+    /**
+     * This method does nothing and should not be used.
+     */
+    override final completeKeyword(Keyword object, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
+    }
+    
+    /**
+     * This method does nothing and should not be used.
+     */
+    override final completeRuleCall(RuleCall object, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
     }
     
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.xtend
@@ -41,7 +41,8 @@ class UiToIdeContentProposalProvider extends AbstractContentProposalProvider {
 		val entries = new ArrayList<Pair<ContentAssistEntry, Integer>>
         val ideAcceptor = new IIdeContentProposalAcceptor {
             override accept(ContentAssistEntry entry, int priority) {
-                entries += entry -> priority
+                if (entry !== null)
+                    entries += entry -> priority
             }
             override canAcceptMoreProposals() {
                 entries.size < maxProposals

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.java
@@ -36,6 +36,9 @@ import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
 import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
+ * Delegates to the generic IDE content proposal provider. Use this Implementation to share the same content assist
+ * code between Eclipse and other editors for your DSL.
+ * 
  * @author Titouan Vervack - Initial contribution and API
  * 
  * @since 2.13
@@ -74,18 +77,6 @@ public class UiToIdeContentProposalProvider extends AbstractContentProposalProvi
       uiAcceptor.accept(proposal);
     };
     IterableExtensions.<Pair<ContentAssistEntry, Integer>>forEach(entries, _function);
-  }
-  
-  @Override
-  public void completeAssignment(final Assignment object, final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
-  }
-  
-  @Override
-  public void completeKeyword(final Keyword object, final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
-  }
-  
-  @Override
-  public void completeRuleCall(final RuleCall object, final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
   }
   
   protected int getMaxProposals() {
@@ -144,5 +135,26 @@ public class UiToIdeContentProposalProvider extends AbstractContentProposalProvi
       }
     }
     return _switchResult;
+  }
+  
+  /**
+   * This method does nothing and should not be used.
+   */
+  @Override
+  public final void completeAssignment(final Assignment object, final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
+  }
+  
+  /**
+   * This method does nothing and should not be used.
+   */
+  @Override
+  public final void completeKeyword(final Keyword object, final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
+  }
+  
+  /**
+   * This method does nothing and should not be used.
+   */
+  @Override
+  public final void completeRuleCall(final RuleCall object, final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
   }
 }

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.java
@@ -57,8 +57,10 @@ public class UiToIdeContentProposalProvider extends AbstractContentProposalProvi
     final IIdeContentProposalAcceptor ideAcceptor = new IIdeContentProposalAcceptor() {
       @Override
       public void accept(final ContentAssistEntry entry, final int priority) {
-        Pair<ContentAssistEntry, Integer> _mappedTo = Pair.<ContentAssistEntry, Integer>of(entry, Integer.valueOf(priority));
-        entries.add(_mappedTo);
+        if ((entry != null)) {
+          Pair<ContentAssistEntry, Integer> _mappedTo = Pair.<ContentAssistEntry, Integer>of(entry, Integer.valueOf(priority));
+          entries.add(_mappedTo);
+        }
       }
       
       @Override

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/contentassist/UiToIdeContentProposalProvider.java
@@ -10,67 +10,86 @@ package org.eclipse.xtext.ui.editor.contentassist;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import java.util.ArrayList;
 import java.util.Collections;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.text.Region;
-import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.Assignment;
+import org.eclipse.xtext.Keyword;
+import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.ide.editor.contentassist.ContentAssistContext;
 import org.eclipse.xtext.ide.editor.contentassist.ContentAssistEntry;
-import org.eclipse.xtext.ide.editor.contentassist.IdeContentProposalAcceptor;
+import org.eclipse.xtext.ide.editor.contentassist.IIdeContentProposalAcceptor;
 import org.eclipse.xtext.ide.editor.contentassist.IdeContentProposalProvider;
+import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.ui.editor.contentassist.AbstractContentProposalProvider;
+import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal;
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor;
 import org.eclipse.xtext.util.TextRegion;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure2;
+import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
  * @author Titouan Vervack - Initial contribution and API
  * 
- * @since 2.12
+ * @since 2.13
  */
 @SuppressWarnings("all")
-public abstract class UiToIdeContentProposalProvider extends AbstractContentProposalProvider {
+public class UiToIdeContentProposalProvider extends AbstractContentProposalProvider {
   @Inject
   private IdeContentProposalProvider ideProvider;
   
   @Inject
   private Provider<ContentAssistContext.Builder> builderProvider;
   
-  @Inject
-  private Provider<IdeContentProposalAcceptor> acceptorProvider;
-  
   @Override
   public void createProposals(final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
-    final IdeContentProposalAcceptor ideAcceptor = this.acceptorProvider.get();
+    final ArrayList<Pair<ContentAssistEntry, Integer>> entries = new ArrayList<Pair<ContentAssistEntry, Integer>>();
+    final IIdeContentProposalAcceptor ideAcceptor = new IIdeContentProposalAcceptor() {
+      @Override
+      public void accept(final ContentAssistEntry entry, final int priority) {
+        Pair<ContentAssistEntry, Integer> _mappedTo = Pair.<ContentAssistEntry, Integer>of(entry, Integer.valueOf(priority));
+        entries.add(_mappedTo);
+      }
+      
+      @Override
+      public boolean canAcceptMoreProposals() {
+        int _size = entries.size();
+        int _maxProposals = UiToIdeContentProposalProvider.this.getMaxProposals();
+        return (_size < _maxProposals);
+      }
+    };
     ContentAssistContext _ideContext = this.getIdeContext(context);
     this.ideProvider.createProposals(Collections.<ContentAssistContext>unmodifiableList(CollectionLiterals.<ContentAssistContext>newArrayList(_ideContext)), ideAcceptor);
     final AbstractContentProposalProvider.NullSafeCompletionProposalAcceptor uiAcceptor = new AbstractContentProposalProvider.NullSafeCompletionProposalAcceptor(acceptor);
-    final Iterable<ContentAssistEntry> entries = ideAcceptor.getEntries();
-    final Procedure2<ContentAssistEntry, Integer> _function = (ContentAssistEntry entry, Integer idx) -> {
-      final int priority = this.computePriority(entries, (idx).intValue());
-      String _elvis = null;
-      String _label = entry.getLabel();
-      if (_label != null) {
-        _elvis = _label;
-      } else {
-        String _proposal = entry.getProposal();
-        _elvis = _proposal;
-      }
-      StyledString _styledString = new StyledString(_elvis);
-      final ICompletionProposal proposal = this.createCompletionProposal(entry.getProposal(), _styledString, 
-        this.getImage(entry), priority, entry.getPrefix(), context);
+    final Procedure2<Pair<ContentAssistEntry, Integer>, Integer> _function = (Pair<ContentAssistEntry, Integer> p, Integer idx) -> {
+      final ContentAssistEntry entry = p.getKey();
+      final ConfigurableCompletionProposal proposal = this.doCreateProposal(entry.getProposal(), this.getDisplayString(entry), this.getImage(entry), (p.getValue()).intValue(), context);
       uiAcceptor.accept(proposal);
     };
-    IterableExtensions.<ContentAssistEntry>forEach(entries, _function);
+    IterableExtensions.<Pair<ContentAssistEntry, Integer>>forEach(entries, _function);
   }
   
-  protected int computePriority(final Iterable<ContentAssistEntry> entries, final int index) {
-    int _size = IterableExtensions.size(entries);
-    return (_size - index);
+  @Override
+  public void completeAssignment(final Assignment object, final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
+  }
+  
+  @Override
+  public void completeKeyword(final Keyword object, final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
+  }
+  
+  @Override
+  public void completeRuleCall(final RuleCall object, final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext context, final ICompletionProposalAcceptor acceptor) {
+  }
+  
+  protected int getMaxProposals() {
+    return 1000;
   }
   
   private ContentAssistContext getIdeContext(final org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext c) {
@@ -88,5 +107,42 @@ public abstract class UiToIdeContentProposalProvider extends AbstractContentProp
     return builder.toContext();
   }
   
-  protected abstract Image getImage(final ContentAssistEntry entry);
+  protected StyledString getDisplayString(final ContentAssistEntry entry) {
+    String _elvis = null;
+    String _label = entry.getLabel();
+    if (_label != null) {
+      _elvis = _label;
+    } else {
+      String _proposal = entry.getProposal();
+      _elvis = _proposal;
+    }
+    final StyledString result = new StyledString(_elvis);
+    boolean _isNullOrEmpty = StringExtensions.isNullOrEmpty(entry.getDescription());
+    boolean _not = (!_isNullOrEmpty);
+    if (_not) {
+      String _description = entry.getDescription();
+      String _plus = (" \u2013 " + _description);
+      StyledString _styledString = new StyledString(_plus, StyledString.QUALIFIER_STYLER);
+      result.append(_styledString);
+    }
+    return result;
+  }
+  
+  protected Image getImage(final ContentAssistEntry entry) {
+    Image _switchResult = null;
+    Object _source = entry.getSource();
+    final Object source = _source;
+    boolean _matched = false;
+    if (source instanceof IEObjectDescription) {
+      _matched=true;
+      _switchResult = this.getImage(((IEObjectDescription)source));
+    }
+    if (!_matched) {
+      if (source instanceof EObject) {
+        _matched=true;
+        _switchResult = this.getImage(((EObject)source));
+      }
+    }
+    return _switchResult;
+  }
 }


### PR DESCRIPTION
 * The way how priorities were handled was wrong because `createProposals` can be invoked multiple times with different contexts. The modified version retains the priorities computed by the IdeContentProposalProvider.
 * Use `doCreateProposal` instead of `createCompletionProposal` so the validation of proposals is skipped. Validation can already be done in IdeContentProposalProvider, so we don't need to repeat it.
 * Added empty implementations of `completeAssignment`, `completeKeyword`, and `completeRuleCall` to satisfy the abstract superclass (they are not used in this implementation).
 * Added `getDisplayString(ContentAssistEntry)` with a default implementation that includes the `label` and the `description` properties.
 * Added a default implementation for `getImage(ContentAssistEntry)` that delegates to `getImage(IEObjectDescription) ` and `getImage(EObject)` with the `source` property as input. This property is transient, so it's not transmitted to clients in the web or LSP scenarios, but can be used internally by Xtext.
 * Removed the `abstract` class modifier.