### PR TITLE
fixed content assist tests after changes to collection literals

### DIFF
--- a/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/AbstractXbaseContentAssistTest.java
+++ b/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/AbstractXbaseContentAssistTest.java
@@ -165,13 +165,21 @@ public abstract class AbstractXbaseContentAssistTest extends Assert implements R
 		"newImmutableList()",
 		"newImmutableSet()",
 		"newImmutableMap()",
+		"newArrayList",
 		"newArrayList()",
+		"newLinkedList",
 		"newLinkedList()",
+		"newHashSet",
 		"newHashSet()",
+		"newLinkedHashSet",
 		"newLinkedHashSet()",
 		"newTreeSet()",
+		"newTreeSet()",
 		"newHashMap()",
+		"newHashMap",
 		"newLinkedHashMap()",
+		"newLinkedHashMap",
+		"newTreeMap()",
 		"newTreeMap()",
 		// InputOutput,
 		"print()",
@@ -676,7 +684,7 @@ public abstract class AbstractXbaseContentAssistTest extends Assert implements R
 	}
 	
 	@Test public void testCamelCase_01() throws Exception {
-		newBuilder().append("newLLis").assertText("newLinkedList()");
+		newBuilder().append("newLLis").assertText("newLinkedList","newLinkedList()");
 	}
 	
 	@Test public void testCamelCase_02() throws Exception {


### PR DESCRIPTION
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>