### PR TITLE
Fixed NPE in ShowQuickOutlineActionHandler

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/ShowQuickOutlineActionHandler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/ShowQuickOutlineActionHandler.java
@@ -40,7 +40,9 @@ public class ShowQuickOutlineActionHandler extends AbstractHandler {
 					final QuickOutlinePopup quickOutlinePopup = createPopup(xtextEditor.getEditorSite().getShell());
 					quickOutlinePopup.setEditor(xtextEditor);
 					quickOutlinePopup.setInput(document);
-					quickOutlinePopup.setEvent((Event) event.getTrigger());
+					if (event.getTrigger() != null) {
+						quickOutlinePopup.setEvent((Event) event.getTrigger());
+					}
 					quickOutlinePopup.open();
 				}
 			});


### PR DESCRIPTION
Can be triggered by opening "Quick Outline" in an Xtend file through the quick access.

Signed-off-by: Titouan Vervack <titouan.vervack@sigasi.com>