### PR TITLE
Try to make falky test more robust

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/resource/AbstractScopeResourceDescriptionsTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/resource/AbstractScopeResourceDescriptionsTest.java
@@ -144,7 +144,7 @@ public abstract class AbstractScopeResourceDescriptionsTest {
 	}
 
 	protected void assertLiveModelScopeLocal(boolean enabled) throws IOException {
-		final URI resourceURI = URI.createPlatformResourceURI("test/test." + fileExt.getPrimaryFileExtension(), true);
+		final URI resourceURI = URI.createPlatformResourceURI("test/assertLiveModelScopeLocal." + fileExt.getPrimaryFileExtension(), true);
 		Resource resource = resourceSet.createResource(resourceURI);
 		resource.load(new StringInputStream("stuff foo"), null);
 		Stuff stuffFoo = ((File) resource.getContents().get(0)).getStuff().get(0);
@@ -165,6 +165,7 @@ public abstract class AbstractScopeResourceDescriptionsTest {
 		IProject project = createProject("test");
 		addNature(project, XtextProjectHelper.NATURE_ID);
 		resourceSet = createResourceSet(workspace.getRoot().getProject("test"));
+		waitForBuild();
 	}
 
 	protected abstract ResourceSet createResourceSet(IProject project);


### PR DESCRIPTION
Since the test asserts the contents of the "Index" (ClusteringBuilderState) and I don't see explicit invocation of the Eclipse Builder - maybe the test is flaky because autobuild *sometimes* is late.

It adds to the situation that multiple tests create test files with the same name and one test asserts that this file isn't in the index.

Anyway, this is just a guess, since I can't reproduce the failure locally.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>