### PR TITLE
[RenameElementDialog] Fix NPE when refactoring runs in own thread.

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
@@ -27,6 +27,7 @@ import org.eclipse.xtext.ide.refactoring.RefactoringIssueAcceptor.Severity
 import org.eclipse.xtext.ide.serializer.IEmfResourceChange
 import org.eclipse.xtext.ide.serializer.ITextDocumentChange
 import org.eclipse.xtext.ui.refactoring.impl.EditorDocumentChange
+import org.eclipse.xtext.ui.util.DisplayRunnableWithResult
 import org.eclipse.xtext.util.IAcceptor
 
 import static org.eclipse.xtext.ui.refactoring2.TryWithResource.*
@@ -152,13 +153,17 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 	}
 	
 	protected def ITextEditor findOpenEditor(IFile file) {
-		val editorInput = new FileEditorInput(file)
-		return workbench	
-			.activeWorkbenchWindow
-			.activePage
-			.editorReferences
-			.map[ getEditor(false) ]
-			.filter(ITextEditor)
-			.findFirst[ it.editorInput == editorInput ]
+		new DisplayRunnableWithResult<ITextEditor>() {
+			override protected run() throws Exception {
+				val editorInput = new FileEditorInput(file)
+				return workbench	
+					.activeWorkbenchWindow
+					.activePage
+					.editorReferences
+					.map[ getEditor(false) ]
+					.filter(ITextEditor)
+					.findFirst[ it.editorInput == editorInput ]
+			}
+		}.syncExec()
 	}
 }

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
@@ -43,6 +43,7 @@ import org.eclipse.xtext.ui.refactoring.impl.EditorDocumentChange;
 import org.eclipse.xtext.ui.refactoring2.ReplaceFileContentChange;
 import org.eclipse.xtext.ui.refactoring2.ResourceURIConverter;
 import org.eclipse.xtext.ui.refactoring2.TryWithResource;
+import org.eclipse.xtext.ui.util.DisplayRunnableWithResult;
 import org.eclipse.xtext.util.IAcceptor;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -248,15 +249,20 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
   }
   
   protected ITextEditor findOpenEditor(final IFile file) {
-    final FileEditorInput editorInput = new FileEditorInput(file);
-    final Function1<IEditorReference, IEditorPart> _function = (IEditorReference it) -> {
-      return it.getEditor(false);
-    };
-    final Function1<ITextEditor, Boolean> _function_1 = (ITextEditor it) -> {
-      IEditorInput _editorInput = it.getEditorInput();
-      return Boolean.valueOf(Objects.equal(_editorInput, editorInput));
-    };
-    return IterableExtensions.<ITextEditor>findFirst(Iterables.<ITextEditor>filter(ListExtensions.<IEditorReference, IEditorPart>map(((List<IEditorReference>)Conversions.doWrapArray(this.workbench.getActiveWorkbenchWindow().getActivePage().getEditorReferences())), _function), ITextEditor.class), _function_1);
+    return new DisplayRunnableWithResult<ITextEditor>() {
+      @Override
+      protected ITextEditor run() throws Exception {
+        final FileEditorInput editorInput = new FileEditorInput(file);
+        final Function1<IEditorReference, IEditorPart> _function = (IEditorReference it) -> {
+          return it.getEditor(false);
+        };
+        final Function1<ITextEditor, Boolean> _function_1 = (ITextEditor it) -> {
+          IEditorInput _editorInput = it.getEditorInput();
+          return Boolean.valueOf(Objects.equal(_editorInput, editorInput));
+        };
+        return IterableExtensions.<ITextEditor>findFirst(Iterables.<ITextEditor>filter(ListExtensions.<IEditorReference, IEditorPart>map(((List<IEditorReference>)Conversions.doWrapArray(ChangeConverter.this.workbench.getActiveWorkbenchWindow().getActivePage().getEditorReferences())), _function), ITextEditor.class), _function_1);
+      }
+    }.syncExec();
   }
   
   protected void handleReplacements(final IEmfResourceChange change) {


### PR DESCRIPTION
NPE:
```
java.lang.NullPointerException
at org.eclipse.xtext.ui.refactoring2.ChangeConverter.findOpenEditor(ChangeConverter.java:259)
at org.eclipse.xtext.ui.refactoring2.ChangeConverter._handleReplacements(ChangeConverter.java:169)
at org.eclipse.xtext.ui.refactoring2.ChangeConverter.handleReplacements(ChangeConverter.java:264)
at org.eclipse.xtext.ui.refactoring2.ChangeConverter.doConvert(ChangeConverter.java:114)
at org.eclipse.xtext.ui.refactoring2.ChangeConverter.accept(ChangeConverter.java:99)
at org.eclipse.xtext.ui.refactoring2.ChangeConverter.accept(ChangeConverter.java:1)
at org.eclipse.xtext.ide.serializer.impl.RecordingXtextResourceUpdater.applyChange(RecordingXtextResourceUpdater.java:90)
at org.eclipse.xtext.ide.serializer.impl.ChangeSerializer.endRecordChanges(ChangeSerializer.java:136)
at org.eclipse.xtext.ide.serializer.impl.ChangeSerializer.applyModifications(ChangeSerializer.java:75)
at org.eclipse.xtext.ui.refactoring2.participant.ResourceRelocationProcessor.createChange(ResourceRelocationProcessor.java:98)
at org.eclipse.xtext.ui.refactoring2.participant.XtextRenameResourceParticipant.checkConditions(XtextRenameResourceParticipant.java:41)
at org.eclipse.ltk.core.refactoring.participants.ProcessorBasedRefactoring.checkFinalConditions(ProcessorBasedRefactoring.java:257)
at org.eclipse.ltk.core.refactoring.CheckConditionsOperation.run(CheckConditionsOperation.java:85)
at org.eclipse.ltk.core.refactoring.CreateChangeOperation.run(CreateChangeOperation.java:121)
at org.eclipse.ltk.core.refactoring.PerformChangeOperation.run(PerformChangeOperation.java:209)
at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2241)
at org.eclipse.ltk.internal.ui.refactoring.WorkbenchRunnableAdapter.run(WorkbenchRunnableAdapter.java:87)
at org.eclipse.jface.operation.ModalContext$ModalContextThread.run(ModalContext.java:119)
```

The Thread is spawned here:
```
Thread [main] (Suspended (breakpoint at line 346 in ModalContext))
    ModalContext.run(IRunnableWithProgress, boolean, IProgressMonitor,
Display) line: 346
    RefactoringWizardDialog2.run(boolean, boolean,
IRunnableWithProgress) line: 319
    DefaultRenameSupport$1(RefactoringWizard).internalPerformFinish(InternalAPI,
PerformChangeOperation) line: 636
    RenameElementWizard$UserInputPage(UserInputWizardPage).performFinish()
line: 145
    RenameElementWizard$UserInputPage.performFinish() line: 119
    DefaultRenameSupport$1(RefactoringWizard).performFinish() line: 710
    RefactoringWizardDialog2.okPressed() line: 445
    RefactoringWizardDialog2(Dialog).buttonPressed(int) line: 466
```