### PR TITLE
fixed #425 [RenameFileRefactoring] Exceptions in Preview Dialog

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
@@ -77,8 +77,8 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 	}
 
 	protected def void doConvert(IEmfResourceChange change) {
-		handleUriChange(change)
 		handleReplacements(change)
+		handleUriChange(change)
 	}
 
 	protected def dispatch void handleReplacements(IEmfResourceChange change) {
@@ -97,7 +97,7 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 	
 	protected def dispatch void handleReplacements(ITextDocumentChange change) {
 		if(change.replacements.size > 0) {
-			val file = change.newURI.toFile
+			val file = change.oldURI.toFile
 			if (!file.canWrite) 
 				issues.add(Severity.FATAL, '''Affected file '«file.fullPath»' is read-only''')
 			file.checkDerived

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/participant/XtextMoveResourceParticipant.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/participant/XtextMoveResourceParticipant.xtend
@@ -38,6 +38,10 @@ class XtextMoveResourceParticipant extends MoveParticipant implements ISharableP
 	}
 
 	override createChange(IProgressMonitor pm) throws CoreException, OperationCanceledException {
+		return null
+	}
+	
+	override createPreChange(IProgressMonitor pm) throws CoreException, OperationCanceledException {
 		return change
 	}
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/participant/XtextRenameResourceParticipant.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/participant/XtextRenameResourceParticipant.xtend
@@ -36,7 +36,11 @@ class XtextRenameResourceParticipant extends RenameParticipant implements IShara
 	}
 
 	override createChange(IProgressMonitor pm) throws CoreException, OperationCanceledException {
-		return change 
+		return null 
+	}
+	
+	override createPreChange(IProgressMonitor pm) throws CoreException, OperationCanceledException {
+		return change
 	}
 
 	override getName() {

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
@@ -111,8 +111,8 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
   }
   
   protected void doConvert(final IEmfResourceChange change) {
-    this.handleUriChange(change);
     this.handleReplacements(change);
+    this.handleUriChange(change);
   }
   
   protected void _handleReplacements(final IEmfResourceChange change) {
@@ -146,7 +146,7 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
     int _size = change.getReplacements().size();
     boolean _greaterThan = (_size > 0);
     if (_greaterThan) {
-      final IFile file = this.resourceUriConverter.toFile(change.getNewURI());
+      final IFile file = this.resourceUriConverter.toFile(change.getOldURI());
       boolean _canWrite = this.canWrite(file);
       boolean _not = (!_canWrite);
       if (_not) {

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/participant/XtextMoveResourceParticipant.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/participant/XtextMoveResourceParticipant.java
@@ -49,6 +49,11 @@ public class XtextMoveResourceParticipant extends MoveParticipant implements ISh
   
   @Override
   public Change createChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
+    return null;
+  }
+  
+  @Override
+  public Change createPreChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
     return this.change;
   }
   

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/participant/XtextRenameResourceParticipant.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/participant/XtextRenameResourceParticipant.java
@@ -47,6 +47,11 @@ public class XtextRenameResourceParticipant extends RenameParticipant implements
   
   @Override
   public Change createChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
+    return null;
+  }
+  
+  @Override
+  public Change createPreChange(final IProgressMonitor pm) throws CoreException, OperationCanceledException {
     return this.change;
   }
   


### PR DESCRIPTION
Text changes must...
- occur before file rename changes when part of a composite change
- use the pre-rename file name to load file contents.

Otherwise the Eclipse Refactoring Preview Dialog can not display a
Comparison View for the changes.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>