### PR TITLE
[QuickFix] #findOtherMarkers() must not return primary marker

### DIFF
--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/ui/quickfix/QuickfixCrossrefTestLanguageQuickfixProvider.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/ui/quickfix/QuickfixCrossrefTestLanguageQuickfixProvider.java
@@ -1,11 +1,8 @@
 
 package org.eclipse.xtext.ui.tests.quickfix.ui.quickfix;
 
-import static com.google.common.collect.Lists.*;
-
 import java.util.List;
 
-import org.eclipse.emf.common.util.ECollections;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.ui.editor.model.edit.ICompositeModificationContext;
 import org.eclipse.xtext.ui.editor.model.edit.IModificationContext;
@@ -14,7 +11,6 @@ import org.eclipse.xtext.ui.editor.quickfix.DefaultQuickfixProvider;
 import org.eclipse.xtext.ui.editor.quickfix.Fix;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionAcceptor;
 import org.eclipse.xtext.ui.tests.quickfix.quickfixCrossref.Element;
-import org.eclipse.xtext.ui.tests.quickfix.quickfixCrossref.Main;
 import org.eclipse.xtext.ui.tests.quickfix.quickfixCrossref.QuickfixCrossrefFactory;
 import org.eclipse.xtext.ui.tests.quickfix.validation.QuickfixCrossrefTestLanguageValidator;
 import org.eclipse.xtext.validation.Issue;
@@ -46,7 +42,7 @@ public class QuickfixCrossrefTestLanguageQuickfixProvider extends DefaultQuickfi
 	@Fix(QuickfixCrossrefTestLanguageValidator.MULTIFIXABLE_ISSUE_2)
 	public void addDocumentation2(final Issue issue, IssueResolutionAcceptor acceptor) {
 		acceptor.acceptMulti(issue, "Multi fix 2", "Multi fix 2", null, (Element eObj) -> {
-			eObj.setDoc("Even Better documentation");
+			eObj.setDoc("not " + eObj.getDoc());
 		});
 	}
 

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
@@ -50,13 +50,14 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Injector;
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
  */
 public abstract class AbstractQuickfixTest extends AbstractWorkbenchTest {
-	
+
 	private static boolean WAS_AUTOBUILD;
 
 	@BeforeClass
@@ -152,13 +153,16 @@ public abstract class AbstractQuickfixTest extends AbstractWorkbenchTest {
 
 	protected void applyQuickfixOnMultipleMarkers(IMarker[] markers) {
 		MarkerResolutionGenerator generator = getInjector().getInstance(MarkerResolutionGenerator.class);
-		IMarkerResolution[] resolutions = generator.getResolutions(markers[0]);
+		IMarker primaryMarker = markers[0];
+		IMarkerResolution[] resolutions = generator.getResolutions(primaryMarker);
 		Assert.assertEquals(1, resolutions.length);
 		assertTrue(resolutions[0] instanceof WorkbenchMarkerResolutionAdapter);
 		WorkbenchMarkerResolutionAdapter resolution = (WorkbenchMarkerResolutionAdapter) resolutions[0];
-		IMarker[] others = resolution.findOtherMarkers(markers);
-		assertEquals(markers.length, others.length);
-		resolution.run(others, new NullProgressMonitor());
+		List<IMarker> others = Lists.newArrayList(resolution.findOtherMarkers(markers));
+		assertFalse(others.contains(primaryMarker));
+		assertEquals(markers.length - 1, others.size());
+		others.add(primaryMarker);
+		resolution.run(others.toArray(new IMarker[others.size()]), new NullProgressMonitor());
 	}
 
 	protected void applyQuickfixOnSingleMarkers(IMarker marker) {

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
@@ -36,11 +36,11 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 
 		applyQuickfixOnMultipleMarkers(markers)
 		assertContentsAndMarkers(resource, '''
-			"Even Better documentation"
+			"not bad doc"
 			Foo { ref Bor }
-			"Even Better documentation"
+			"not bad doc"
 			Bor { }
-			---------------------------
+			---------------
 			(no markers found)
 		''')
 	}
@@ -66,11 +66,11 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 		val firstMarker = markers.sortBy[it.getAttribute(IMarker.CHAR_START) as Integer].head
 		applyQuickfixOnSingleMarkers(firstMarker)
 		assertContentsAndMarkers(resource, '''
-			"Even Better documentation"
+			"not bad doc"
 			Foo { ref Bor }
 			<0<"bad doc">0>
 			Bor { }
-			---------------------------
+			---------------
 			0: message=multiFixableIssue2
 		''')
 	}
@@ -87,7 +87,7 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 		assertEquals('''Multi fix 2'''.toString, proposals.map[displayString].join("\n"))
 		proposals.head.apply(editor.document)
 		assertEquals('''
-			"Even Better documentation"
+			"not bad doc"
 			Foo { ref Bor }
 			"bad doc"
 			Bor { }

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
@@ -60,15 +60,15 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     this.assertContentsAndMarkers(resource, markers, _builder_1);
     this.applyQuickfixOnMultipleMarkers(markers);
     StringConcatenation _builder_2 = new StringConcatenation();
-    _builder_2.append("\"Even Better documentation\"");
+    _builder_2.append("\"not bad doc\"");
     _builder_2.newLine();
     _builder_2.append("Foo { ref Bor }");
     _builder_2.newLine();
-    _builder_2.append("\"Even Better documentation\"");
+    _builder_2.append("\"not bad doc\"");
     _builder_2.newLine();
     _builder_2.append("Bor { }");
     _builder_2.newLine();
-    _builder_2.append("---------------------------");
+    _builder_2.append("---------------");
     _builder_2.newLine();
     _builder_2.append("(no markers found)");
     _builder_2.newLine();
@@ -116,7 +116,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     final IMarker firstMarker = IterableExtensions.<IMarker>head(IterableExtensions.<IMarker, Integer>sortBy(((Iterable<IMarker>)Conversions.doWrapArray(markers)), _function));
     this.applyQuickfixOnSingleMarkers(firstMarker);
     StringConcatenation _builder_2 = new StringConcatenation();
-    _builder_2.append("\"Even Better documentation\"");
+    _builder_2.append("\"not bad doc\"");
     _builder_2.newLine();
     _builder_2.append("Foo { ref Bor }");
     _builder_2.newLine();
@@ -124,7 +124,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder_2.newLine();
     _builder_2.append("Bor { }");
     _builder_2.newLine();
-    _builder_2.append("---------------------------");
+    _builder_2.append("---------------");
     _builder_2.newLine();
     _builder_2.append("0: message=multiFixableIssue2");
     _builder_2.newLine();
@@ -153,7 +153,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     Assert.assertEquals(_builder_1.toString(), IterableExtensions.join(ListExtensions.<ICompletionProposal, String>map(((List<ICompletionProposal>)Conversions.doWrapArray(proposals)), _function), "\n"));
     IterableExtensions.<ICompletionProposal>head(((Iterable<ICompletionProposal>)Conversions.doWrapArray(proposals))).apply(editor.getDocument());
     StringConcatenation _builder_2 = new StringConcatenation();
-    _builder_2.append("\"Even Better documentation\"");
+    _builder_2.append("\"not bad doc\"");
     _builder_2.newLine();
     _builder_2.append("Foo { ref Bor }");
     _builder_2.newLine();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/WorkbenchMarkerResolutionAdapter.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/WorkbenchMarkerResolutionAdapter.xtend
@@ -52,7 +52,7 @@ class WorkbenchMarkerResolutionAdapter extends WorkbenchMarkerResolution {
 	@Accessors IMarker primaryMarker
 
 	override findOtherMarkers(IMarker[] markers) {
-		markers.filter[issueUtil.getCode(primaryMarker) == issueUtil.getCode(it)]
+		markers.filter[it != primaryMarker && issueUtil.getCode(primaryMarker) == issueUtil.getCode(it)]
 	}
 
 	override String getLabel() {

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/quickfix/WorkbenchMarkerResolutionAdapter.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/quickfix/WorkbenchMarkerResolutionAdapter.java
@@ -77,9 +77,7 @@ public class WorkbenchMarkerResolutionAdapter extends WorkbenchMarkerResolution 
   @Override
   public IMarker[] findOtherMarkers(final IMarker[] markers) {
     final Function1<IMarker, Boolean> _function = (IMarker it) -> {
-      String _code = this.issueUtil.getCode(this.primaryMarker);
-      String _code_1 = this.issueUtil.getCode(it);
-      return Boolean.valueOf(Objects.equal(_code, _code_1));
+      return Boolean.valueOf(((!Objects.equal(it, this.primaryMarker)) && Objects.equal(this.issueUtil.getCode(this.primaryMarker), this.issueUtil.getCode(it))));
     };
     return ((IMarker[])Conversions.unwrapArray(IterableExtensions.<IMarker>filter(((Iterable<IMarker>)Conversions.doWrapArray(markers)), _function), IMarker.class));
   }


### PR DESCRIPTION
This bug causes two marker resolutions being offered for the primary
marker. If the user doens't de-select it, the resolution for the primary
marker will be executed twice.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>