### PR TITLE
Refactoring: Cleaning up warnings

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/debug/XtextBuildConsolePageParticipant.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/debug/XtextBuildConsolePageParticipant.java
@@ -25,7 +25,7 @@ public class XtextBuildConsolePageParticipant implements IConsolePageParticipant
 	
 	private CloseConsoleAction fCloseAction;
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings({ "rawtypes" })
 	@Override
 	public Object getAdapter(Class adapter) {
 		return null;

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MockMarker.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MockMarker.java
@@ -45,7 +45,7 @@ final class MockMarker implements IMarker {
 	}
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes" })
 	public Object getAdapter(Class adapter) {
 		return null;
 	}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -335,7 +335,7 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 		return null;
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes" })
 	@Override
 	public Object getAdapter(Class adapter) {
 		if (IContentOutlinePage.class.isAssignableFrom(adapter)) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
@@ -134,7 +134,7 @@ public class XtextSourceViewer extends ProjectionViewer implements IAdaptable {
 	 * @since 2.3
 	 */
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes" })
 	public Object getAdapter(Class adapter) {
 		if (IReconciler.class.isAssignableFrom(adapter)) {
 			return fReconciler;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/AbstractOutlineNode.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/AbstractOutlineNode.java
@@ -192,7 +192,7 @@ public abstract class AbstractOutlineNode implements IOutlineNode, IOutlineNode.
 	}
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes" })
 	public Object getAdapter(Class adapterType) {
 		return Platform.getAdapterManager().getAdapter(this, adapterType);
 	}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DisplayChangeWrapper.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DisplayChangeWrapper.java
@@ -98,7 +98,7 @@ public class DisplayChangeWrapper {
 			return delegate.getAffectedObjects();
 		}
 	
-		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@SuppressWarnings({ "rawtypes" })
 		@Override
 		public Object getAdapter(Class adapter) {
 			return delegate.getAdapter(adapter);
@@ -202,7 +202,7 @@ public class DisplayChangeWrapper {
 			return delegate.getAffectedObjects();
 		}
 
-		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@SuppressWarnings({ "rawtypes" })
 		@Override
 		public Object getAdapter(Class adapter) {
 			return delegate.getAdapter(adapter);
@@ -256,7 +256,7 @@ public class DisplayChangeWrapper {
 			delegate.addTextEditGroup(group);
 		}
 
-		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@SuppressWarnings({ "rawtypes" })
 		@Override
 		public boolean hasOneGroupCategory(List groupCategories) {
 			return delegate.hasOneGroupCategory(groupCategories);

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverDocumentationProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverDocumentationProvider.java
@@ -22,7 +22,6 @@ import java.util.Set;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -68,7 +67,6 @@ import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.scoping.IScope;
 import org.eclipse.xtext.scoping.IScopeProvider;
-import org.eclipse.xtext.ui.containers.JavaProjectsStateHelper;
 import org.eclipse.xtext.ui.editor.hover.html.IEObjectHoverDocumentationProvider;
 import org.eclipse.xtext.ui.editor.hover.html.XtextElementLinks;
 import org.eclipse.xtext.util.Strings;

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegate.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegate.java
@@ -86,7 +86,7 @@ public class JavaElementDelegate implements IAdaptable {
 		this.resource = resource;
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings({ "rawtypes" })
 	@Override
 	public Object getAdapter(Class adapter) {
 		if (IJavaElement.class.equals(adapter)) {

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateAdapterFactory.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateAdapterFactory.java
@@ -30,7 +30,6 @@ public class JavaElementDelegateAdapterFactory implements IAdapterFactory {
 	@Inject
 	private Provider<JavaElementDelegateMainLaunch> mainDelegateProvider;
 	
-	@SuppressWarnings("unchecked")
 	@Override
 	public Object getAdapter(Object adaptableObject, @SuppressWarnings("rawtypes")  Class adapterType) {
 		if (adaptableObject instanceof JavaElementDelegate) {
@@ -62,7 +61,7 @@ public class JavaElementDelegateAdapterFactory implements IAdapterFactory {
 	}
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes" })
 	public Class[] getAdapterList() {
 		return new Class[] { JavaElementDelegate.class };
 	}

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/GrammarLinkingInWorkspaceTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/GrammarLinkingInWorkspaceTest.java
@@ -26,7 +26,6 @@ import com.google.inject.Injector;
 /**
  * @author Sven Efftinge - Initial contribution and API
  */
-@SuppressWarnings("restriction")
 public class GrammarLinkingInWorkspaceTest {
 	
 	@Test 


### PR DESCRIPTION
Removed several unnecessary @SuppressWarnings annotations and two unused
imports.

Signed-off-by: Florian Stolte <fstolte@itemis.de>