### PR TITLE
Refactoring: Remove warnings

### DIFF
--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
@@ -391,6 +391,7 @@ public class JdtBasedTypeFactory extends AbstractDeclaredTypeFactory implements 
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	private IBinding resolveBindings(IType jdtType, IJavaProject javaProject) {
 		ThreadLocal<Boolean> abortOnMissingSource = JavaModelManager.getJavaModelManager().abortOnMissingSource;
 		Boolean wasAbortOnMissingSource = abortOnMissingSource.get();

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/JavaProjectSetupUtil.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/JavaProjectSetupUtil.java
@@ -96,6 +96,7 @@ public class JavaProjectSetupUtil {
 		}
 	}
 	
+	@SafeVarargs
 	public static InputStream jarInputStream(Pair<String, InputStream> ...entries) {
 		try {
 			ByteArrayOutputStream out2 = new ByteArrayOutputStream();
@@ -337,6 +338,7 @@ public class JavaProjectSetupUtil {
 		}
 	}
 	
+	@SuppressWarnings("unchecked")
 	public static void makeJava5Compliant(IJavaProject javaProject) {
 		Map<String, String> options= javaProject.getOptions(false);
 		options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
@@ -337,6 +337,7 @@ public class JavaProjectSetupUtil {
 		}
 	}
 	
+	@SuppressWarnings("unchecked")
 	public static void makeJava5Compliant(IJavaProject javaProject) {
 		Map<String, String> options= javaProject.getOptions(false);
 		options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/ui/quickfix/QuickfixCrossrefTestLanguageQuickfixProvider.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/ui/quickfix/QuickfixCrossrefTestLanguageQuickfixProvider.java
@@ -46,11 +46,11 @@ public class QuickfixCrossrefTestLanguageQuickfixProvider extends DefaultQuickfi
 		});
 	}
 
+	@SuppressWarnings("unchecked")
 	@Fix(QuickfixCrossrefTestLanguageValidator.BAD_NAME_IN_SUBELEMENTS)
 	public void fixBadNames(final Issue issue, IssueResolutionAcceptor acceptor) {
 		acceptor.acceptMulti(issue, "Fix Bad Names", "Fix Bad Names", null, (Element main, ICompositeModificationContext<Element> ctx) -> {
 			ctx.addModification(main.eContainer(), c -> {
-				@SuppressWarnings("unchecked")
 				List<Element> siblings = (List<Element>) main.eContainer().eGet(main.eContainmentFeature());
 				int index = siblings.indexOf(main);
 				Element newEle = QuickfixCrossrefFactory.eINSTANCE.createElement();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditorErrorTickUpdater.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditorErrorTickUpdater.java
@@ -100,6 +100,7 @@ public class XtextEditorErrorTickUpdater extends IXtextEditorCallback.NullImpl i
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	protected Severity getSeverity(XtextEditor xtextEditor) {
 		if (xtextEditor == null || xtextEditor.getInternalSourceViewer() == null)
 			return null;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
@@ -61,6 +61,7 @@ public class XtextSourceViewer extends ProjectionViewer implements IAdaptable {
 	/**
 	 * copied from org.eclipse.jdt.internal.ui.javaeditor.JavaSourceViewer.prependTextPresentationListener(ITextPresentationListener)
 	 */
+	@SuppressWarnings("unchecked")
 	public void prependTextPresentationListener(ITextPresentationListener listener) {
 		Assert.isNotNull(listener);
 
@@ -79,6 +80,7 @@ public class XtextSourceViewer extends ProjectionViewer implements IAdaptable {
 	 *
 	 * @param cmd the widget command translated into a text event sent to all text listeners
 	 */
+	@SuppressWarnings("unchecked")
 	@Override
 	protected void updateTextListeners(WidgetCommand cmd) {
 		if (cmd.event == null && cmd.length == 0 && cmd.start == 0 && cmd.text == null) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/folding/DefaultFoldingStructureProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/folding/DefaultFoldingStructureProvider.java
@@ -129,6 +129,7 @@ public class DefaultFoldingStructureProvider implements IFoldingStructureProvide
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	protected Annotation[] mergeFoldingRegions(Collection<FoldedPosition> foldedPositions,
 			ProjectionAnnotationModel projectionAnnotationModel) {
 		List<Annotation> deletions = new ArrayList<Annotation>();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/occurrences/OccurrenceMarker.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/occurrences/OccurrenceMarker.java
@@ -155,6 +155,7 @@ public class OccurrenceMarker {
 			return null;
 		}
 
+		@SuppressWarnings("unchecked")
 		protected Annotation[] getExistingOccurrenceAnnotations(IAnnotationModel annotationModel) {
 			Set<Annotation> removeSet = newHashSet();
 			for (Iterator<Annotation> annotationIter = annotationModel.getAnnotationIterator(); annotationIter

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/AnnotationIssueProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/AnnotationIssueProcessor.java
@@ -101,6 +101,7 @@ public class AnnotationIssueProcessor implements IValidationIssueProcessor, IAnn
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	protected List<Annotation> getAnnotationsToRemove(IProgressMonitor monitor) {
 		if (monitor.isCanceled() || annotationModel == null) {
 			return Lists.newArrayList();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagConfigurationBlock.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagConfigurationBlock.java
@@ -185,6 +185,7 @@ public class TaskTagConfigurationBlock extends OptionsConfigurationBlock {
 
 	}
 
+	@SuppressWarnings("unchecked")
 	private static class TaskTagSorter extends ViewerComparator {
 		@Override
 		public int compare(Viewer viewer, Object e1, Object e2) {

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/CompilationTestHelper.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/CompilationTestHelper.java
@@ -245,6 +245,7 @@ public class CompilationTestHelper {
 	 * @return a ResourceSet, containing the given resources.
 	 * @throws IOException if the resource loading fails 
 	 */
+	@SuppressWarnings("unchecked")
 	public ResourceSet resourceSet(Pair<String,? extends CharSequence> ...resources ) throws IOException {
 		XtextResourceSet result = resourceSetProvider.get();
 		result.setClasspathURIContext(classpathUriContext);
@@ -290,6 +291,7 @@ public class CompilationTestHelper {
 	/**
 	 * same as {@link #resourceSet(Pair...)} but without actually loading the created resources.
 	 */
+	@SuppressWarnings("unchecked")
 	public ResourceSet unLoadedResourceSet(Pair<String,? extends CharSequence> ...resources ) throws IOException {
 		XtextResourceSet result = resourceSetProvider.get();
 		for (Pair<String, ? extends CharSequence> entry : resources) {

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/OnTheFlyJavaCompiler.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/OnTheFlyJavaCompiler.java
@@ -296,6 +296,7 @@ public class OnTheFlyJavaCompiler {
 		parent.mkdirs();
 	}
 
+	@SuppressWarnings("unchecked")
 	protected Pair<String, String> createFullCode(String statementCode,
 			Type returnType, Pair<Type, String>... params) {
 		String className = "_$GeneratedClass";
@@ -394,6 +395,7 @@ public class OnTheFlyJavaCompiler {
 				errorStream)), false /* systemExit */, null /* options */, null);
 	}
 
+	@SuppressWarnings("unchecked")
 	protected Object internalCreateFunction(String code, Type returnType,
 			Pair<Type, String>... params) {
 		Pair<String, String> fullCode = createFullCode(code, returnType, params);

--- a/org.eclipse.xtext.xbase.junit/testdata/testdata/ClassWithVarArgs.java
+++ b/org.eclipse.xtext.xbase.junit/testdata/testdata/ClassWithVarArgs.java
@@ -47,10 +47,12 @@ public class ClassWithVarArgs {
 		return result;
 	}
 	
+	@SuppressWarnings("unchecked")
 	public <T> List<T> toList(T... args) {
 		return Lists.newArrayList(args);
 	}
 	
+	@SuppressWarnings("unchecked")
 	public <T extends Number> List<T> toNumberList(T... args) {
 		return Lists.newArrayList(args);
 	}

--- a/org.eclipse.xtext.xbase.junit/testdata/testdata/ClosureClient.java
+++ b/org.eclipse.xtext.xbase.junit/testdata/testdata/ClosureClient.java
@@ -118,6 +118,7 @@ public class ClosureClient {
 	/**
 	 * @since 2.3
 	 */
+	@SuppressWarnings("unchecked")
 	public String concatStrings(Functions.Function0<String>... functions) {
 		StringBuilder result = new StringBuilder("varArgs:");
 		for(Functions.Function0<String> function: functions) {

--- a/org.eclipse.xtext.xbase.junit/testdata/testdata/ClosureClient2.java
+++ b/org.eclipse.xtext.xbase.junit/testdata/testdata/ClosureClient2.java
@@ -17,6 +17,7 @@ public class ClosureClient2 {
 
 	private String value;
 
+	@SafeVarargs
 	public ClosureClient2(Functions.Function0<String>... functions) {
 		StringBuilder builder = new StringBuilder("varArgs:");
 		for(Functions.Function0<String> function: functions) {

--- a/org.eclipse.xtext.xbase.junit/testdata/testdata/GenericType2.java
+++ b/org.eclipse.xtext.xbase.junit/testdata/testdata/GenericType2.java
@@ -15,6 +15,7 @@ public class GenericType2<T extends Number> {
 	
 	private T[] array;
 	
+	@SafeVarargs
 	public GenericType2(T... values) {
 		this.array = values;
 	}

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverDocumentationProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverDocumentationProvider.java
@@ -781,6 +781,7 @@ public class XbaseHoverDocumentationProvider implements IEObjectHoverDocumentati
 		buffer.append("</dt>"); //$NON-NLS-1$
 	}
 
+	@SuppressWarnings("unchecked")
 	public Javadoc getJavaDoc() {
 		if (context == null || context.eResource() == null || context.eResource().getResourceSet() == null)
 			return null;


### PR DESCRIPTION
Added several @SuppressWarnings("unchecked") and @SafeVarargs
annotations to get rid of unnecessary warnings.


Signed-off-by: Florian Stolte <fstolte@itemis.de>