### PR TITLE
[xtext-core] GH-524 use Modules2.mixin() to combine runtime and IDE modules

### DIFF
--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/bracketmatching/ide/BmTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/bracketmatching/ide/BmTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.bracketmatching.BmTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.bracketmatching.BmTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class BmTestLanguageIdeSetup extends BmTestLanguageStandaloneSetup {
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new BmTestLanguageRuntimeModule(), new BmTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new BmTestLanguageRuntimeModule(), new BmTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/BacktrackingContentAssistTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/BacktrackingContentAssistTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.BacktrackingContentAssistTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.BacktrackingContentAssistTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class BacktrackingContentAssistTestLanguageIdeSetup extends BacktrackingC
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new BacktrackingContentAssistTestLanguageRuntimeModule(), new BacktrackingContentAssistTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new BacktrackingContentAssistTestLanguageRuntimeModule(), new BacktrackingContentAssistTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug286935TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug286935TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug286935TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug286935TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug286935TestLanguageIdeSetup extends Bug286935TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug286935TestLanguageRuntimeModule(), new Bug286935TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug286935TestLanguageRuntimeModule(), new Bug286935TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug287941TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug287941TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug287941TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug287941TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug287941TestLanguageIdeSetup extends Bug287941TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug287941TestLanguageRuntimeModule(), new Bug287941TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug287941TestLanguageRuntimeModule(), new Bug287941TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug288734TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug288734TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug288734TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug288734TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug288734TestLanguageIdeSetup extends Bug288734TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug288734TestLanguageRuntimeModule(), new Bug288734TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug288734TestLanguageRuntimeModule(), new Bug288734TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug288760TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug288760TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug288760TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug288760TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug288760TestLanguageIdeSetup extends Bug288760TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug288760TestLanguageRuntimeModule(), new Bug288760TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug288760TestLanguageRuntimeModule(), new Bug288760TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug289187TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug289187TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug289187TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug289187TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug289187TestLanguageIdeSetup extends Bug289187TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug289187TestLanguageRuntimeModule(), new Bug289187TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug289187TestLanguageRuntimeModule(), new Bug289187TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug291022TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug291022TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug291022TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug291022TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug291022TestLanguageIdeSetup extends Bug291022TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug291022TestLanguageRuntimeModule(), new Bug291022TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug291022TestLanguageRuntimeModule(), new Bug291022TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug303200TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug303200TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug303200TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug303200TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug303200TestLanguageIdeSetup extends Bug303200TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug303200TestLanguageRuntimeModule(), new Bug303200TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug303200TestLanguageRuntimeModule(), new Bug303200TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug304681TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug304681TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug304681TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug304681TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug304681TestLanguageIdeSetup extends Bug304681TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug304681TestLanguageRuntimeModule(), new Bug304681TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug304681TestLanguageRuntimeModule(), new Bug304681TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug307519TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug307519TestLanguageIdeSetup.java
@@ -3,10 +3,12 @@
  */
 package org.eclipse.xtext.ui.tests.editor.contentassist.ide;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug307519TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug307519TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +17,6 @@ public class Bug307519TestLanguageIdeSetup extends Bug307519TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug307519TestLanguageRuntimeModule(), new Bug307519TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug307519TestLanguageRuntimeModule(), new Bug307519TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug309949TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug309949TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug309949TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug309949TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug309949TestLanguageIdeSetup extends Bug309949TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug309949TestLanguageRuntimeModule(), new Bug309949TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug309949TestLanguageRuntimeModule(), new Bug309949TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug332217TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug332217TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug332217TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug332217TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug332217TestLanguageIdeSetup extends Bug332217TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug332217TestLanguageRuntimeModule(), new Bug332217TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug332217TestLanguageRuntimeModule(), new Bug332217TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug347012TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug347012TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug347012TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug347012TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug347012TestLanguageIdeSetup extends Bug347012TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug347012TestLanguageRuntimeModule(), new Bug347012TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug347012TestLanguageRuntimeModule(), new Bug347012TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug348199TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug348199TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug348199TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug348199TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug348199TestLanguageIdeSetup extends Bug348199TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug348199TestLanguageRuntimeModule(), new Bug348199TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug348199TestLanguageRuntimeModule(), new Bug348199TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug348427TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug348427TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug348427TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug348427TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug348427TestLanguageIdeSetup extends Bug348427TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug348427TestLanguageRuntimeModule(), new Bug348427TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug348427TestLanguageRuntimeModule(), new Bug348427TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug360834TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug360834TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug360834TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug360834TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug360834TestLanguageIdeSetup extends Bug360834TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug360834TestLanguageRuntimeModule(), new Bug360834TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug360834TestLanguageRuntimeModule(), new Bug360834TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug377311TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug377311TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug377311TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug377311TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug377311TestLanguageIdeSetup extends Bug377311TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug377311TestLanguageRuntimeModule(), new Bug377311TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug377311TestLanguageRuntimeModule(), new Bug377311TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug381381TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/Bug381381TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug381381TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.Bug381381TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class Bug381381TestLanguageIdeSetup extends Bug381381TestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new Bug381381TestLanguageRuntimeModule(), new Bug381381TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new Bug381381TestLanguageRuntimeModule(), new Bug381381TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/ContentAssistContextTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/ContentAssistContextTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.ContentAssistContextTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.ContentAssistContextTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class ContentAssistContextTestLanguageIdeSetup extends ContentAssistConte
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new ContentAssistContextTestLanguageRuntimeModule(), new ContentAssistContextTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new ContentAssistContextTestLanguageRuntimeModule(), new ContentAssistContextTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/ContentAssistCustomizingTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/ContentAssistCustomizingTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.ContentAssistCustomizingTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.ContentAssistCustomizingTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class ContentAssistCustomizingTestLanguageIdeSetup extends ContentAssistC
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new ContentAssistCustomizingTestLanguageRuntimeModule(), new ContentAssistCustomizingTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new ContentAssistCustomizingTestLanguageRuntimeModule(), new ContentAssistCustomizingTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/CrossReferenceProposalTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/CrossReferenceProposalTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.CrossReferenceProposalTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.CrossReferenceProposalTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class CrossReferenceProposalTestLanguageIdeSetup extends CrossReferencePr
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new CrossReferenceProposalTestLanguageRuntimeModule(), new CrossReferenceProposalTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new CrossReferenceProposalTestLanguageRuntimeModule(), new CrossReferenceProposalTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/DatatypeRuleTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/DatatypeRuleTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.DatatypeRuleTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.DatatypeRuleTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class DatatypeRuleTestLanguageIdeSetup extends DatatypeRuleTestLanguageSt
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new DatatypeRuleTestLanguageRuntimeModule(), new DatatypeRuleTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new DatatypeRuleTestLanguageRuntimeModule(), new DatatypeRuleTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/DomainModelTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/DomainModelTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.DomainModelTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.DomainModelTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class DomainModelTestLanguageIdeSetup extends DomainModelTestLanguageStan
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new DomainModelTestLanguageRuntimeModule(), new DomainModelTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new DomainModelTestLanguageRuntimeModule(), new DomainModelTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/LookAheadContentAssistTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/LookAheadContentAssistTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.LookAheadContentAssistTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.LookAheadContentAssistTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class LookAheadContentAssistTestLanguageIdeSetup extends LookAheadContent
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new LookAheadContentAssistTestLanguageRuntimeModule(), new LookAheadContentAssistTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new LookAheadContentAssistTestLanguageRuntimeModule(), new LookAheadContentAssistTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/ParametersTestLanguageExIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/ParametersTestLanguageExIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.ParametersTestLanguageExRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.ParametersTestLanguageExStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class ParametersTestLanguageExIdeSetup extends ParametersTestLanguageExSt
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new ParametersTestLanguageExRuntimeModule(), new ParametersTestLanguageExIdeModule());
+		return Guice.createInjector(Modules2.mixin(new ParametersTestLanguageExRuntimeModule(), new ParametersTestLanguageExIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/ParametersTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/ParametersTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.ParametersTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.ParametersTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class ParametersTestLanguageIdeSetup extends ParametersTestLanguageStanda
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new ParametersTestLanguageRuntimeModule(), new ParametersTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new ParametersTestLanguageRuntimeModule(), new ParametersTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/TwoContextsTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/TwoContextsTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.TwoContextsTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.TwoContextsTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class TwoContextsTestLanguageIdeSetup extends TwoContextsTestLanguageStan
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new TwoContextsTestLanguageRuntimeModule(), new TwoContextsTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new TwoContextsTestLanguageRuntimeModule(), new TwoContextsTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/TwoParametersTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/TwoParametersTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.TwoParametersTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.TwoParametersTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class TwoParametersTestLanguageIdeSetup extends TwoParametersTestLanguage
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new TwoParametersTestLanguageRuntimeModule(), new TwoParametersTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new TwoParametersTestLanguageRuntimeModule(), new TwoParametersTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/UnorderedGroupsTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ide/UnorderedGroupsTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.contentassist.UnorderedGroupsTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.contentassist.UnorderedGroupsTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class UnorderedGroupsTestLanguageIdeSetup extends UnorderedGroupsTestLang
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new UnorderedGroupsTestLanguageRuntimeModule(), new UnorderedGroupsTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new UnorderedGroupsTestLanguageRuntimeModule(), new UnorderedGroupsTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/encoding/ide/EncodingUiTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/encoding/ide/EncodingUiTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.encoding.EncodingUiTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.encoding.EncodingUiTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class EncodingUiTestLanguageIdeSetup extends EncodingUiTestLanguageStanda
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new EncodingUiTestLanguageRuntimeModule(), new EncodingUiTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new EncodingUiTestLanguageRuntimeModule(), new EncodingUiTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/outline/ide/OutlineTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/outline/ide/OutlineTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.editor.outline.OutlineTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.editor.outline.OutlineTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class OutlineTestLanguageIdeSetup extends OutlineTestLanguageStandaloneSe
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new OutlineTestLanguageRuntimeModule(), new OutlineTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new OutlineTestLanguageRuntimeModule(), new OutlineTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/enumrules/ide/EnumRulesUiTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/enumrules/ide/EnumRulesUiTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.enumrules.EnumRulesUiTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.enumrules.EnumRulesUiTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class EnumRulesUiTestLanguageIdeSetup extends EnumRulesUiTestLanguageStan
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new EnumRulesUiTestLanguageRuntimeModule(), new EnumRulesUiTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new EnumRulesUiTestLanguageRuntimeModule(), new EnumRulesUiTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/ide/FoldingTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/ide/FoldingTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.FoldingTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.FoldingTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class FoldingTestLanguageIdeSetup extends FoldingTestLanguageStandaloneSe
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new FoldingTestLanguageRuntimeModule(), new FoldingTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new FoldingTestLanguageRuntimeModule(), new FoldingTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/ide/TestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/ide/TestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.TestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.TestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class TestLanguageIdeSetup extends TestLanguageStandaloneSetup {
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new TestLanguageRuntimeModule(), new TestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new TestLanguageRuntimeModule(), new TestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/linking/ide/ImportUriUiTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/linking/ide/ImportUriUiTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.linking.ImportUriUiTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.linking.ImportUriUiTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class ImportUriUiTestLanguageIdeSetup extends ImportUriUiTestLanguageStan
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new ImportUriUiTestLanguageRuntimeModule(), new ImportUriUiTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new ImportUriUiTestLanguageRuntimeModule(), new ImportUriUiTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/parser/keywords/ide/KeywordsUiTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/parser/keywords/ide/KeywordsUiTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.parser.keywords.KeywordsUiTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.parser.keywords.KeywordsUiTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class KeywordsUiTestLanguageIdeSetup extends KeywordsUiTestLanguageStanda
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new KeywordsUiTestLanguageRuntimeModule(), new KeywordsUiTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new KeywordsUiTestLanguageRuntimeModule(), new KeywordsUiTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/ide/QuickfixCrossrefTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/ide/QuickfixCrossrefTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.quickfix.QuickfixCrossrefTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.quickfix.QuickfixCrossrefTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class QuickfixCrossrefTestLanguageIdeSetup extends QuickfixCrossrefTestLa
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new QuickfixCrossrefTestLanguageRuntimeModule(), new QuickfixCrossrefTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new QuickfixCrossrefTestLanguageRuntimeModule(), new QuickfixCrossrefTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/refactoring/ide/RefactoringTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/refactoring/ide/RefactoringTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.refactoring.RefactoringTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.refactoring.RefactoringTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class RefactoringTestLanguageIdeSetup extends RefactoringTestLanguageStan
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new RefactoringTestLanguageRuntimeModule(), new RefactoringTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new RefactoringTestLanguageRuntimeModule(), new RefactoringTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/refactoring/ide/ReferringTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/refactoring/ide/ReferringTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.refactoring.ReferringTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.refactoring.ReferringTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class ReferringTestLanguageIdeSetup extends ReferringTestLanguageStandalo
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new ReferringTestLanguageRuntimeModule(), new ReferringTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new ReferringTestLanguageRuntimeModule(), new ReferringTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/testlanguages/ide/ContentAssistTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/testlanguages/ide/ContentAssistTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.testlanguages.ContentAssistTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.testlanguages.ContentAssistTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class ContentAssistTestLanguageIdeSetup extends ContentAssistTestLanguage
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new ContentAssistTestLanguageRuntimeModule(), new ContentAssistTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new ContentAssistTestLanguageRuntimeModule(), new ContentAssistTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/testlanguages/ide/ReferenceGrammarUiTestLanguageIdeSetup.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/testlanguages/ide/ReferenceGrammarUiTestLanguageIdeSetup.java
@@ -7,6 +7,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.eclipse.xtext.ui.tests.testlanguages.ReferenceGrammarUiTestLanguageRuntimeModule;
 import org.eclipse.xtext.ui.tests.testlanguages.ReferenceGrammarUiTestLanguageStandaloneSetup;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -15,6 +16,6 @@ public class ReferenceGrammarUiTestLanguageIdeSetup extends ReferenceGrammarUiTe
 
 	@Override
 	public Injector createInjector() {
-		return Guice.createInjector(new ReferenceGrammarUiTestLanguageRuntimeModule(), new ReferenceGrammarUiTestLanguageIdeModule());
+		return Guice.createInjector(Modules2.mixin(new ReferenceGrammarUiTestLanguageRuntimeModule(), new ReferenceGrammarUiTestLanguageIdeModule()));
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/src/org/eclipse/xtext/example/homeautomation/ide/RuleEngineIdeSetup.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/src/org/eclipse/xtext/example/homeautomation/ide/RuleEngineIdeSetup.xtend
@@ -5,6 +5,7 @@ package org.eclipse.xtext.example.homeautomation.ide
 import com.google.inject.Guice
 import org.eclipse.xtext.example.homeautomation.RuleEngineRuntimeModule
 import org.eclipse.xtext.example.homeautomation.RuleEngineStandaloneSetup
+import org.eclipse.xtext.util.Modules2
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -12,6 +13,6 @@ import org.eclipse.xtext.example.homeautomation.RuleEngineStandaloneSetup
 class RuleEngineIdeSetup extends RuleEngineStandaloneSetup {
 
 	override createInjector() {
-		Guice.createInjector(new RuleEngineRuntimeModule, new RuleEngineIdeModule)
+		Guice.createInjector(Modules2.mixin(new RuleEngineRuntimeModule, new RuleEngineIdeModule))
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/xtend-gen/org/eclipse/xtext/example/homeautomation/ide/RuleEngineIdeSetup.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/xtend-gen/org/eclipse/xtext/example/homeautomation/ide/RuleEngineIdeSetup.java
@@ -8,6 +8,7 @@ import com.google.inject.Injector;
 import org.eclipse.xtext.example.homeautomation.RuleEngineRuntimeModule;
 import org.eclipse.xtext.example.homeautomation.RuleEngineStandaloneSetup;
 import org.eclipse.xtext.example.homeautomation.ide.RuleEngineIdeModule;
+import org.eclipse.xtext.util.Modules2;
 
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
@@ -18,6 +19,6 @@ public class RuleEngineIdeSetup extends RuleEngineStandaloneSetup {
   public Injector createInjector() {
     RuleEngineRuntimeModule _ruleEngineRuntimeModule = new RuleEngineRuntimeModule();
     RuleEngineIdeModule _ruleEngineIdeModule = new RuleEngineIdeModule();
-    return Guice.createInjector(_ruleEngineRuntimeModule, _ruleEngineIdeModule);
+    return Guice.createInjector(Modules2.mixin(_ruleEngineRuntimeModule, _ruleEngineIdeModule));
   }
 }


### PR DESCRIPTION
See eclipse/xtext-core#524