### PR TITLE
[releng] Removed project import exclusion for *.idea projects

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -1332,14 +1332,7 @@
         xsi:type="projects:ProjectsImportTask">
       <sourceLocator
           rootFolder="${git.clone.xtext.xtend.location}"
-          locateNestedProjects="true">
-        <predicate
-            xsi:type="predicates:NotPredicate">
-          <operand
-              xsi:type="predicates:NamePredicate"
-              pattern=".*\.idea.*"/>
-        </predicate>
-      </sourceLocator>
+          locateNestedProjects="true"/>
       <description>Maven Dependencies</description>
     </setupTask>
     <setupTask


### PR DESCRIPTION
Projects have been moved to xtext-idea with eclipse/xtext-xtend#311

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>