### PR TITLE
Saving a resource with auto build disabled keeps the dirty state available until next build. Issue#1151.

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/DirtyStateAwareResourceDescriptions.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/DirtyStateAwareResourceDescriptions.java
@@ -18,6 +18,7 @@ import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.IResourceDescription.Delta;
+import org.eclipse.xtext.resource.IResourceDescription.Event;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.ISelectable;
 import org.eclipse.xtext.resource.IShadowedResourceDescriptions;
@@ -26,6 +27,7 @@ import org.eclipse.xtext.resource.impl.ChangedResourceDescriptionDelta;
 import org.eclipse.xtext.resource.impl.CoarseGrainedChangeEvent;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionChangeEvent;
 import org.eclipse.xtext.ui.editor.IDirtyStateManager;
+import org.eclipse.xtext.ui.editor.IDirtyStateManagerExtension;
 import org.eclipse.xtext.ui.notification.IStateChangeEventBroker;
 
 import com.google.common.base.Function;
@@ -112,8 +114,14 @@ public class DirtyStateAwareResourceDescriptions extends AbstractResourceDescrip
 		@Override
 		public void descriptionsChanged(IResourceDescription.Event event) {
 			globalDescriptionsChanged(event);
+			notifyDirtyStateManager(event);
 		}
-		
+
+		private void notifyDirtyStateManager(Event event) {
+			if (dirtyStateManager instanceof IDirtyStateManagerExtension) {
+				((IDirtyStateManagerExtension) dirtyStateManager).indexUpdated(event.getDeltas());
+			}
+		}
 	}
 
 	@Override

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/ContentAssistProcessorTestBuilder.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/ContentAssistProcessorTestBuilder.java
@@ -487,7 +487,7 @@ public class ContentAssistProcessorTestBuilder implements Cloneable {
 			return computeCompletionProposals(xtextDocument, cursorPosition);
 		} finally {
 			if (announceDirtyState) {
-				dirtyStateManager.discardDirtyState(dirtyResource);
+				dirtyStateManager.unmanageDirtyState(dirtyResource);
 			}
 		}
 	}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/resource/AbstractScopeResourceDescriptionsTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/resource/AbstractScopeResourceDescriptionsTest.java
@@ -102,7 +102,7 @@ public abstract class AbstractScopeResourceDescriptionsTest {
 			if (!(Throwables.getRootCause(t) instanceof org.eclipse.core.internal.resources.ResourceException))
 				Throwables.propagate(t);
 		} finally {
-			dirtyStateManager.discardDirtyState(mockDirtyResource);
+			dirtyStateManager.unmanageDirtyState(mockDirtyResource);
 		}
 	}
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/DirtyStateEditorSupport.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/DirtyStateEditorSupport.java
@@ -418,7 +418,7 @@ public class DirtyStateEditorSupport implements IResourceDescription.Event.Liste
 				}
 			}
 			if (!isConcurrentEditingIgnored()) {
-				dirtyStateManager.discardDirtyState(delegatingClientAwareResource);
+				dirtyStateManager.unmanageDirtyState(delegatingClientAwareResource);
 				return false;
 			}
 		}
@@ -455,7 +455,7 @@ public class DirtyStateEditorSupport implements IResourceDescription.Event.Liste
 		stateChangeEventBroker.removeListener(this);
 		synchronized (dirtyStateManager) {
 			if (dirtyResource.isInitialized()) 
-				dirtyStateManager.discardDirtyState(delegatingClientAwareResource);
+				dirtyStateManager.unmanageDirtyState(delegatingClientAwareResource);
 			IXtextDocument document = client.getDocument();
 			if (document == null)
 				document = dirtyResource.getUnderlyingDocument();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/IDirtyStateManager.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/IDirtyStateManager.java
@@ -52,6 +52,12 @@ public interface IDirtyStateManager extends ISelectable, IExternalContentSupport
 	 * same {@link URI} will not become unmanaged. A call to this method will raise an event.
 	 * @see #announceDirtyStateChanged(IDirtyResource)
 	 */
+	void unmanageDirtyState(IDirtyResource dirtyResource);
+	
+	/**
+	 * Mark the given dirty resource as to be discarded. The dirty resource will be kept until
+	 * the index for it gets updated so that the new state is available even when auto build is off.
+	 */
 	void discardDirtyState(IDirtyResource dirtyResource);
 	
 	/**
@@ -68,5 +74,4 @@ public interface IDirtyStateManager extends ISelectable, IExternalContentSupport
 	void announceDirtyStateChanged(IDirtyResource dirtyResource);
 	
 	IResourceDescription getDirtyResourceDescription(URI uri);
-	
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/IDirtyStateManagerExtension.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/IDirtyStateManagerExtension.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.ui.editor;
 import java.util.List;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.resource.IResourceDescription.Delta;
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
@@ -20,4 +21,6 @@ import org.eclipse.emf.common.util.URI;
 public interface IDirtyStateManagerExtension {
 
 	List<URI> getDirtyResourceURIs();
+	
+	void indexUpdated(List<Delta> indexChanges);
 }


### PR DESCRIPTION
Saving a dirty resource won't discard the dirty state information until
a build event is received for the affected resource. This allows to keep
the index up to date regardless of the auto build state.