### PR TITLE
Generalized DontAskAgain

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainDialogs.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainDialogs.java
@@ -13,7 +13,7 @@ import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.swt.widgets.Shell;
 
 /**
- * A utility class to ask a user questions, trough a dialog, and remember his decision.<br>
+ * A utility class to ask a user questions, through a dialog, and remember his decision.<br>
  * The settings are stored in {@link IDialogSettings} of your language UIPlugin.
  * 
  * @author Dennis Huebner - Initial contribution and API

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainDialogs.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainDialogs.java
@@ -12,16 +12,14 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.swt.widgets.Shell;
 
-import com.google.inject.Inject;
-
 /**
- * A utility class to ask a user questions and remember his decision.<br>
+ * A utility class to ask a user questions, trough a dialog, and remember his decision.<br>
  * The settings are stored in {@link IDialogSettings} of your language UIPlugin.
  * 
  * @author Dennis Huebner - Initial contribution and API
  * @since 2.8
  */
-public class DontAskAgainDialogs {
+public class DontAskAgainDialogs extends DontAskAgainPreferences {
 	/**
 	 * A section id that holds the "don't ask me again" dialog settings.
 	 * <p>
@@ -35,27 +33,11 @@ public class DontAskAgainDialogs {
 	 */
 	public static final String DONT_ASK_AGAIN_DIALOG_PREFIX = "dont_ask_again_dialog";
 
-	private @Inject IDialogSettings dialogSettings;
-
-	/**
-	 * Returns the stored user answer to the question identified with the passed key.
-	 * 
-	 * @param key
-	 *            unique identifier . Represents the key to use when storing or reading the setting.
-	 * 
-	 * @return User decision for the corresponding question. Value is one of type <code>String</code> and is one of
-	 *         {@link org.eclipse.jface.dialogs.MessageDialogWithToggle#ALWAYS},
-	 *         {@link org.eclipse.jface.dialogs.MessageDialogWithToggle#NEVER} or (default)
-	 *         {@link org.eclipse.jface.dialogs.MessageDialogWithToggle#PROMPT}. Never <code>null</code>
-	 */
-	public String getUserDecision(String key) {
-		String userDecision = getDontAskAgainDialogSettings().get(key);
-		if (userDecision == null) {
-			userDecision = MessageDialogWithToggle.PROMPT;
-		}
-		return userDecision;
+	@Override
+	protected String getPrefix() {
+		return DONT_ASK_AGAIN_DIALOG_PREFIX;
 	}
-
+	
 	/**
 	 * Opens a {@link MessageDialogWithToggle} and stores the answer, if user activated the corresponding checkbox.
 	 *
@@ -78,31 +60,11 @@ public class DontAskAgainDialogs {
 		int userAnswer = dialogWithToggle.getReturnCode();
 		if (rememberDecision) {
 			if (userAnswer == IDialogConstants.NO_ID) {
-				storeUserDecision(storeKey, MessageDialogWithToggle.NEVER);
+				neverAskAgain(storeKey);
 			} else if (userAnswer == IDialogConstants.YES_ID) {
 				storeUserDecision(storeKey, MessageDialogWithToggle.ALWAYS);
 			}
 		}
 		return userAnswer;
-	}
-
-	/**
-	 * Rewrites the {@link #DONT_ASK_AGAIN_DIALOG_PREFIX} section in {@link IDialogSettings} for the current language.<br>
-	 * All the user decisions will be reset.
-	 */
-	public void forgetAllUserDecisions() {
-		dialogSettings.addNewSection(DONT_ASK_AGAIN_DIALOG_PREFIX);
-	}
-
-	private IDialogSettings getDontAskAgainDialogSettings() {
-		IDialogSettings section = dialogSettings.getSection(DONT_ASK_AGAIN_DIALOG_PREFIX);
-		if (section == null) {
-			return dialogSettings.addNewSection(DONT_ASK_AGAIN_DIALOG_PREFIX);
-		}
-		return section;
-	}
-
-	private void storeUserDecision(String key, String value) {
-		getDontAskAgainDialogSettings().put(key, value);
 	}
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainPreferences.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainPreferences.java
@@ -47,7 +47,6 @@ public class DontAskAgainPreferences {
 	 * Returns whether the "Don't Ask Again" question should be asked again.
 	 *
 	 * @return Whether to show the question again or not
-	 * @since 2.14
 	 */
 	public boolean shouldAskAgain(String key) {
 		return getUserDecision(key) != MessageDialogWithToggle.NEVER;
@@ -57,7 +56,6 @@ public class DontAskAgainPreferences {
 	 * Saves the user's preference to never ask a certain question again.
 	 *
 	 * @param key The unique identifier of the question never to ask again.
-	 * @since 2.14
 	 */
 	protected void neverAskAgain(String key) {
 		storeUserDecision(key, MessageDialogWithToggle.NEVER);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainPreferences.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainPreferences.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ui.util;
+
+import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.jface.dialogs.MessageDialogWithToggle;
+
+import com.google.inject.Inject;
+
+/**
+ * A utility class to remember a user's decision concerning "Don't ask again" preferences.<br>
+ * The settings are stored in {@link IDialogSettings} of your language UIPlugin.
+ *
+ * @author Titouan Vervack - Initial contribution and API
+ * @since 2.14
+ */
+public class DontAskAgainPreferences {
+	/**
+	 * A section id that holds the "don't ask me again" settings.
+	 * <p>
+	 * Value is of type <code>String</code> and is one of
+	 * {@link org.eclipse.jface.dialogs.MessageDialogWithToggle#ALWAYS},
+	 * {@link org.eclipse.jface.dialogs.MessageDialogWithToggle#NEVER} or (default)
+	 * {@link org.eclipse.jface.dialogs.MessageDialogWithToggle#PROMPT}.
+	 * </p>
+	 *
+	 * @since 2.14
+	 */
+	public static final String DONT_ASK_AGAIN_PREFERENCE_PREFIX = "dont_ask_again_preference";
+
+	private @Inject IDialogSettings dialogSettings;
+
+	/**
+	 * Returns the prefix of this specific preference.
+	 * This allows for granular removal of "Don't Ask Again" settings.
+	 */
+	protected String getPrefix() {
+		return DONT_ASK_AGAIN_PREFERENCE_PREFIX;
+	}
+
+	/**
+	 * Returns whether the "Don't Ask Again" question should be asked again.
+	 *
+	 * @return Whether to show the question again or not
+	 * @since 2.14
+	 */
+	public boolean shouldAskAgain(String key) {
+		return getUserDecision(key) != MessageDialogWithToggle.NEVER;
+	}
+
+	/**
+	 * Saves the user's preference to never ask a certain question again.
+	 *
+	 * @param key The unique identifier of the question never to ask again.
+	 * @since 2.14
+	 */
+	protected void neverAskAgain(String key) {
+		storeUserDecision(key, MessageDialogWithToggle.NEVER);
+	}
+
+	/**
+	 * Returns the stored user answer to the question identified with the passed key.
+	 *
+	 * @param key
+	 *            unique identifier . Represents the key to use when storing or reading the setting.
+	 *
+	 * @return User decision for the corresponding question. Value is one of type <code>String</code> and is one of
+	 *         {@link org.eclipse.jface.dialogs.MessageDialogWithToggle#ALWAYS},
+	 *         {@link org.eclipse.jface.dialogs.MessageDialogWithToggle#NEVER} or (default)
+	 *         {@link org.eclipse.jface.dialogs.MessageDialogWithToggle#PROMPT}. Never <code>null</code>
+	 */
+	public String getUserDecision(String key) {
+		String userDecision = getDontAskAgainDialogSettings().get(key);
+		if (userDecision == null) {
+			userDecision = MessageDialogWithToggle.PROMPT;
+		}
+		return userDecision;
+	}
+
+	/**
+	 * Rewrites the {@link #getPrefix()} section in {@link IDialogSettings} for the current language.<br>
+	 * All the user decisions will be reset.
+	 */
+	public void forgetAllUserDecisions() {
+		dialogSettings.addNewSection(getPrefix());
+	}
+
+	protected IDialogSettings getDontAskAgainDialogSettings() {
+		IDialogSettings section = dialogSettings.getSection(getPrefix());
+		if (section == null) {
+			return dialogSettings.addNewSection(getPrefix());
+		}
+		return section;
+	}
+
+	protected void storeUserDecision(String key, String value) {
+		getDontAskAgainDialogSettings().put(key, value);
+	}
+}


### PR DESCRIPTION
DontAskAgainDialogs allowed you to manage "Do not ask again" settings, but it always did this via a dialog. There are other ways to show this option to the user, thus I made the class more generic.

This also allows for more granular resets of such settings. Before, when you reset the DontAskAgain setting, all of them got reset. Now you can create two classes (e.g. XtendDontAskAgainPreferences and JavaDontAskAgainPrefences.) that both extend DontAskAgainPreferences. These would have two different prefixes, which allows for their settings to be cleared separately for each of them.

Signed-off-by: Titouan <titouan.vervack@sigasi.com>