### PR TITLE
[eclipse/xtext#1152] Java 9 - Added Automatic-Module-Name header

### DIFF
--- a/org.eclipse.xtext.activities/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.activities/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.xtext.activities.Activator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0"
 Export-Package: org.eclipse.xtext.activities;x-internal:=true
+Automatic-Module-Name: org.eclipse.xtext.activities

--- a/org.eclipse.xtext.builder.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.builder.tests/META-INF/MANIFEST.MF
@@ -57,4 +57,5 @@ Export-Package: org.eclipse.xtext.builder.tests,
  org.eclipse.xtext.builder.tests.ui.quickfix,
  org.eclipse.xtext.builder.tests.ide.contentassist.antlr.internal,
  org.eclipse.xtext.builder.tests.internal
+Automatic-Module-Name: org.eclipse.xtext.builder.tests
 

--- a/org.eclipse.xtext.builder/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.builder/META-INF/MANIFEST.MF
@@ -49,3 +49,4 @@ Require-Bundle: org.eclipse.xtext,
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.log4j;version="1.2.15"
 Bundle-Activator: org.eclipse.xtext.builder.internal.Activator
+Automatic-Module-Name: org.eclipse.xtext.builder

--- a/org.eclipse.xtext.common.types.eclipse.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types.eclipse.tests/META-INF/MANIFEST.MF
@@ -62,3 +62,4 @@ Import-Package: org.apache.log4j,
  org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0",
  org.junit.runners;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtext.common.types.eclipse.tests

--- a/org.eclipse.xtext.common.types.edit/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types.edit/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Bundle-Activator: org.eclipse.xtext.common.types.provider.TypesEditPlugin$Implem
 Require-Bundle: org.eclipse.xtext.common.types,
  org.eclipse.emf.edit;bundle-version="2.10.1",
  org.eclipse.core.runtime;bundle-version="3.6.0"
+Automatic-Module-Name: org.eclipse.xtext.common.types.edit

--- a/org.eclipse.xtext.common.types.shared.jdt38/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types.shared.jdt38/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Bundle-Vendor: %providerName
 Import-Package: org.apache.log4j;version="1.2.15",
  org.eclipse.ui.ide
 Export-Package: org.eclipse.xtext.common.types.shared.jdt38;x-internal:=true
+Automatic-Module-Name: org.eclipse.xtext.common.types.shared.jdt38

--- a/org.eclipse.xtext.common.types.shared/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types.shared/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.xtext.common.types.shared;x-internal:=true
+Automatic-Module-Name: org.eclipse.xtext.common.types.shared

--- a/org.eclipse.xtext.common.types.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.common.types.ui/META-INF/MANIFEST.MF
@@ -37,3 +37,4 @@ Export-Package: org.eclipse.xtext.common.types.access.jdt,
  org.eclipse.xtext.common.types.util.jdt,
  org.eclipse.xtext.common.types.xtext.ui
 Bundle-Localization: plugin
+Automatic-Module-Name: org.eclipse.xtext.common.types.ui

--- a/org.eclipse.xtext.eclipse.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.eclipse.tests/META-INF/MANIFEST.MF
@@ -36,3 +36,4 @@ Import-Package: com.ibm.icu.text;version="4.0.0",
  org.junit.runner.notification;version="4.5.0",
  org.junit.runners.model;version="4.5.0",
  org.hamcrest.core
+Automatic-Module-Name: org.eclipse.xtext.eclipse.tests

--- a/org.eclipse.xtext.idea.generator/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.idea.generator/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.xtext.generator
 Export-Package: org.eclipse.xtext.idea.generator,
  org.eclipse.xtext.idea.generator.parser.antlr
+Automatic-Module-Name: org.eclipse.xtext.idea.generator

--- a/org.eclipse.xtext.junit4.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.junit4.tests/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.junit,
  com.google.inject;bundle-version="3.0.0",
  org.eclipse.xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.xtext.junit4.tests

--- a/org.eclipse.xtext.junit4/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.junit4/META-INF/MANIFEST.MF
@@ -41,3 +41,4 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.builder.standalone,
  org.eclipse.emf.codegen.ecore;bundle-version="2.10.2";resolution:=optional,
  org.eclipse.pde.core;resolution:=optional
+Automatic-Module-Name: org.eclipse.xtext.junit4

--- a/org.eclipse.xtext.logging/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.logging/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.osgi.framework;version="1.5.0"
 Export-Package: org.eclipse.xtext.logging;x-internal:=true
+Automatic-Module-Name: org.eclipse.xtext.logging

--- a/org.eclipse.xtext.m2e/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.m2e/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.m2e;x-internal:=true
 Import-Package: org.apache.maven.plugin;provider=m2e;resolution:=optional,
  org.apache.maven.project;provider=m2e;resolution:=optional
+Automatic-Module-Name: org.eclipse.xtext.m2e

--- a/org.eclipse.xtext.purexbase.eclipse.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.purexbase.eclipse.tests/META-INF/MANIFEST.MF
@@ -30,3 +30,4 @@ Import-Package: org.apache.commons.logging,
  org.junit.runners.model;version="4.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.purexbase.ui.tests;x-internal=true
+Automatic-Module-Name: org.eclipse.xtext.purexbase.eclipse.tests

--- a/org.eclipse.xtext.purexbase.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.purexbase.ui/META-INF/MANIFEST.MF
@@ -35,3 +35,4 @@ Export-Package: org.eclipse.xtext.purexbase.ui,
  org.eclipse.xtext.purexbase.ui.quickfix,
  org.eclipse.xtext.purexbase.ui.editor
 Bundle-Activator: org.eclipse.xtext.purexbase.ui.internal.PurexbaseActivator
+Automatic-Module-Name: org.eclipse.xtext.purexbase.ui

--- a/org.eclipse.xtext.testlanguages.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.testlanguages.ui/META-INF/MANIFEST.MF
@@ -50,3 +50,4 @@ Export-Package: org.eclipse.xtext.testlanguages.backtracking.ui,
  org.eclipse.xtext.testlanguages.fileAware.ui.contentassist,
  org.eclipse.xtext.testlanguages.fileAware.ui.tests;x-internal=true
 Bundle-Activator: org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator
+Automatic-Module-Name: org.eclipse.xtext.testlanguages.ui

--- a/org.eclipse.xtext.ui.codetemplates.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.codetemplates.ide/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Export-Package: org.eclipse.xtext.ui.codetemplates.ide,
  org.eclipse.xtext.ui.codetemplates.ide.contentassist.antlr.lexer,
  org.eclipse.xtext.ui.codetemplates.ui.contentassist,
  org.eclipse.xtext.ui.codetemplates.ui.highlighting
+Automatic-Module-Name: org.eclipse.xtext.ui.codetemplates.ide
 

--- a/org.eclipse.xtext.ui.codetemplates.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.codetemplates.tests/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.ui.codetemplates.tests;x-internal=true,
  org.eclipse.xtext.ui.codetemplates.ui.tests;x-internal=true
 Bundle-Vendor: %providerName
+Automatic-Module-Name: org.eclipse.xtext.ui.codetemplates.tests

--- a/org.eclipse.xtext.ui.codetemplates.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.codetemplates.ui/META-INF/MANIFEST.MF
@@ -40,3 +40,4 @@ Export-Package: org.eclipse.xtext.ui.codetemplates.ui;x-friends:="org.eclipse.xt
  org.eclipse.xtext.ui.codetemplates.ui.scoping;x-friends:="org.eclipse.xtext.xtext.ui.tests",
  org.eclipse.xtext.ui.codetemplates.ui.validation;x-friends:="org.eclipse.xtext.xtext.ui.tests"
 Bundle-Activator: org.eclipse.xtext.ui.codetemplates.ui.AccessibleCodetemplatesActivator
+Automatic-Module-Name: org.eclipse.xtext.ui.codetemplates.ui

--- a/org.eclipse.xtext.ui.codetemplates/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.codetemplates/META-INF/MANIFEST.MF
@@ -39,4 +39,5 @@ Export-Package: org.eclipse.xtext.ui.codetemplates;x-friends:="org.eclipse.xtext
  org.eclipse.xtext.ui.codetemplates.templates.util;x-internal:=true,
  org.eclipse.xtext.ui.codetemplates.validation;x-friends:="org.eclipse.xtext.ui.codetemplates.ui",
  org.eclipse.xtext.ui.codetemplates.serializer
+Automatic-Module-Name: org.eclipse.xtext.ui.codetemplates
 

--- a/org.eclipse.xtext.ui.ecore/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.ecore/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.log4j;version="1.2.15"
 Export-Package: org.eclipse.xtext.ui.ecore
+Automatic-Module-Name: org.eclipse.xtext.ui.ecore

--- a/org.eclipse.xtext.ui.shared/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.shared/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.xtext.ui.shared,
  org.eclipse.xtext.ui.shared.internal;x-internal:=true
 Import-Package: org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.ui.shared

--- a/org.eclipse.xtext.ui.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.testing/META-INF/MANIFEST.MF
@@ -30,3 +30,4 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.emf.codegen.ecore;bundle-version="2.10.2";resolution:=optional,
  org.eclipse.pde.core;resolution:=optional,
  org.eclipse.xtext.common.types.ui;resolution:=optional
+Automatic-Module-Name: org.eclipse.xtext.ui.testing

--- a/org.eclipse.xtext.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.tests/META-INF/MANIFEST.MF
@@ -231,4 +231,5 @@ Export-Package: org.eclipse.xtext.ui.tests,
  org.eclipse.xtext.ui.tests.testlanguages.ui.contentassist,
  org.eclipse.xtext.ui.tests.ui.contentassist,
  org.eclipse.xtext.ui.tests.validation
+Automatic-Module-Name: org.eclipse.xtext.ui.tests
 

--- a/org.eclipse.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui/META-INF/MANIFEST.MF
@@ -116,3 +116,4 @@ Bundle-Vendor: %providerName
 Import-Package: com.ibm.icu.text;version="4.0.0",
  org.apache.commons.lang,
  org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.ui

--- a/org.eclipse.xtext.xbase.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.junit/META-INF/MANIFEST.MF
@@ -32,3 +32,4 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Import-Package: org.apache.log4j;version="1.2.15",
  org.junit;version="[4.0.0,5.0.0)"
+Automatic-Module-Name: org.eclipse.xtext.xbase.junit

--- a/org.eclipse.xtext.xbase.testlanguages.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.testlanguages.ui/META-INF/MANIFEST.MF
@@ -38,3 +38,4 @@ Export-Package: org.eclipse.xtext.xbase.testlanguages.ui,
  org.eclipse.xtext.xbase.testlanguages.ui.quickfix,
  org.eclipse.xtext.xbase.testlanguages.bug462047.ui.contentassist
 Bundle-Activator: org.eclipse.xtext.xbase.testlanguages.ui.internal.TestlanguagesActivator
+Automatic-Module-Name: org.eclipse.xtext.xbase.testlanguages.ui

--- a/org.eclipse.xtext.xbase.ui.testing/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.ui.testing/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Import-Package: org.apache.log4j;version="1.2.15",
  org.junit;version="[4.0.0,5.0.0)"
+Automatic-Module-Name: org.eclipse.xtext.xbase.ui.testing

--- a/org.eclipse.xtext.xbase.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.ui.tests/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Import-Package: org.apache.log4j;version="1.2.15",
  org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0",
  org.junit.runners;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtext.xbase.ui.tests

--- a/org.eclipse.xtext.xbase.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.ui/META-INF/MANIFEST.MF
@@ -70,3 +70,4 @@ Export-Package: org.eclipse.xtext.xbase.annotations.ui;x-internal:=true,
  org.eclipse.xtext.xbase.ui.validation;x-friends:="org.eclipse.xtend.ide",
  org.eclipse.xtext.xbase.annotations.ui.editor
 Bundle-Localization: plugin
+Automatic-Module-Name: org.eclipse.xtext.xbase.ui

--- a/org.eclipse.xtext.xtext.ui.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.xtext.xtext.ui.examples;x-internal:=true
+Automatic-Module-Name: org.eclipse.xtext.xtext.ui.examples

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ide/META-INF/MANIFEST.MF
@@ -12,4 +12,5 @@ Require-Bundle: org.eclipse.xtext.example.arithmetics,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.arithmetics.ide.contentassist.antlr,
  org.eclipse.xtext.example.arithmetics.ide.contentassist.antlr.internal
+Automatic-Module-Name: org.eclipse.xtext.example.arithmetics.ide
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.tests/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package: org.hamcrest.core,
  org.junit.runners;version="4.5.0",
  org.junit.runner.manipulation;version="4.5.0",
  org.junit.runner.notification;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtext.example.arithmetics.tests

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Import-Package: org.hamcrest.core,
  org.junit.runners;version="4.5.0",
  org.junit.runner.manipulation;version="4.5.0",
  org.junit.runner.notification;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtext.example.arithmetics.ui.tests

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics.ui/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Export-Package: org.eclipse.xtext.example.arithmetics.ui.internal,
  org.eclipse.xtext.example.arithmetics.ui.quickfix,
  org.eclipse.xtext.example.arithmetics.ui.contentassist
 Bundle-Activator: org.eclipse.xtext.example.arithmetics.ui.internal.ArithmeticsActivator
+Automatic-Module-Name: org.eclipse.xtext.example.arithmetics.ui

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.arithmetics/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Export-Package: org.eclipse.xtext.example.arithmetics,
  org.eclipse.xtext.example.arithmetics.services,
  org.eclipse.xtext.example.arithmetics.validation
 Import-Package: org.apache.log4j
+Automatic-Module-Name: org.eclipse.xtext.example.arithmetics

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ide/META-INF/MANIFEST.MF
@@ -12,4 +12,5 @@ Require-Bundle: org.eclipse.xtext.example.domainmodel,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.domainmodel.ide.contentassist.antlr.internal,
  org.eclipse.xtext.example.domainmodel.ide.contentassist.antlr
+Automatic-Module-Name: org.eclipse.xtext.example.domainmodel.ide
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.tests/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package: org.hamcrest.core,
  org.junit.runners;version="4.5.0",
  org.junit.runner.manipulation;version="4.5.0",
  org.junit.runner.notification;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtext.example.domainmodel.tests

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Import-Package: org.hamcrest.core,
  org.junit.runners;version="4.5.0",
  org.junit.runner.manipulation;version="4.5.0",
  org.junit.runner.notification;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtext.example.domainmodel.ui.tests

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel.ui/META-INF/MANIFEST.MF
@@ -34,3 +34,4 @@ Export-Package: org.eclipse.xtext.example.domainmodel.ui.contentassist,
  org.eclipse.xtext.example.domainmodel.ui.search,
  org.eclipse.xtext.example.domainmodel.ui.editor
 Bundle-Activator: org.eclipse.xtext.example.domainmodel.ui.internal.DomainmodelActivator
+Automatic-Module-Name: org.eclipse.xtext.example.domainmodel.ui

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.domainmodel/META-INF/MANIFEST.MF
@@ -30,3 +30,4 @@ Export-Package: org.eclipse.xtext.example.domainmodel.serializer,
  org.eclipse.xtext.example.domainmodel.jvmmodel,
  org.eclipse.xtext.example.domainmodel.formatting2
 Import-Package: org.apache.log4j
+Automatic-Module-Name: org.eclipse.xtext.example.domainmodel

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.fowlerdsl.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.fowlerdsl.ide/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.fowlerdsl.ide.contentassist.antlr.internal,
  org.eclipse.xtext.example.fowlerdsl.ide.contentassist.antlr
+Automatic-Module-Name: org.eclipse.xtext.example.fowlerdsl.ide

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.fowlerdsl.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.fowlerdsl.ui/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Export-Package: org.eclipse.xtext.example.fowlerdsl.ui.quickfix,
  org.eclipse.xtext.example.fowlerdsl.ui.contentassist,
  org.eclipse.xtext.example.fowlerdsl.ui.internal
 Bundle-Activator: org.eclipse.xtext.example.fowlerdsl.ui.internal.FowlerdslActivator
+Automatic-Module-Name: org.eclipse.xtext.example.fowlerdsl.ui

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.fowlerdsl/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.fowlerdsl/META-INF/MANIFEST.MF
@@ -28,4 +28,5 @@ Export-Package: org.eclipse.xtext.example.fowlerdsl,
  org.eclipse.xtext.example.fowlerdsl.scoping,
  org.eclipse.xtext.example.fowlerdsl.generator,
  org.eclipse.xtext.example.fowlerdsl.formatting
+Automatic-Module-Name: org.eclipse.xtext.example.fowlerdsl
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ide/META-INF/MANIFEST.MF
@@ -13,4 +13,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.ide.contentassist.antlr,
  org.eclipse.xtext.example.homeautomation.ide.contentassist.antlr.internal,
  org.eclipse.xtext.example.homeautomation.ide.contentassist.antlr.lexer
+Automatic-Module-Name: org.eclipse.xtext.example.homeautomation.ide
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.tests/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package: org.junit.runners;version="4.5.0",
  org.junit.runner.notification;version="4.5.0",
  org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtext.example.homeautomation.tests

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation.ui/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Export-Package: org.eclipse.xtext.example.homeautomation.ui.contentassist,
  org.eclipse.xtext.example.homeautomation.ui.internal,
  org.eclipse.xtext.example.homeautomation.ui.editor
 Bundle-Activator: org.eclipse.xtext.example.homeautomation.ui.internal.HomeautomationActivator
+Automatic-Module-Name: org.eclipse.xtext.example.homeautomation.ui

--- a/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/org.eclipse.xtext.example.homeautomation/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Export-Package: org.eclipse.xtext.example.homeautomation.ruleEngine.util,
  org.eclipse.xtext.example.homeautomation.services,
  org.eclipse.xtext.example.homeautomation.formatting2
 Import-Package: org.apache.log4j
+Automatic-Module-Name: org.eclipse.xtext.example.homeautomation

--- a/org.eclipse.xtext.xtext.ui.examples/projects/xbase.tutorial/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/xbase.tutorial/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 2.14.0.qualifier
 Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtext.xbase.lib
+Automatic-Module-Name: xbase.tutorial

--- a/org.eclipse.xtext.xtext.ui.graph.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.graph.tests/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Require-Bundle: org.eclipse.xtext.xtext.ui.graph,
  org.eclipse.xtext.xtext.ui
 Import-Package: org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtext.xtext.ui.graph.tests

--- a/org.eclipse.xtext.xtext.ui.graph/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.graph/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.draw2d;bundle-version="3.5.2"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.xtext.xtext.ui.graph.bundle.Activator
+Automatic-Module-Name: org.eclipse.xtext.xtext.ui.graph

--- a/org.eclipse.xtext.xtext.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.tests/META-INF/MANIFEST.MF
@@ -43,3 +43,4 @@ Export-Package: org.eclipse.xtext.xtext.ui.ecore2xtext,
  org.eclipse.xtext.xtext.ui.ecore2xtext.ui.contentassist,
  org.eclipse.xtext.xtext.ui.ecore2xtext.serializer
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.xtext.xtext.ui.tests

--- a/org.eclipse.xtext.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui/META-INF/MANIFEST.MF
@@ -51,3 +51,4 @@ Export-Package: org.eclipse.xtext.ui.editor.hierarchy;x-friends:="org.eclipse.xt
  org.eclipse.xtext.xtext.ui.wizard.ecore2xtext;x-friends:="org.eclipse.xtext.xtext.ui.tests",
  org.eclipse.xtext.xtext.ui.wizard.project;x-friends:="org.eclipse.xtext.xtext.ui.tests"
 Import-Package: org.apache.log4j;version="1.2.15"
+Automatic-Module-Name: org.eclipse.xtext.xtext.ui


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>