### PR TITLE
[528817] Fixed PatternSyntaxException below StringMatcher.getPattern

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/StringMatcherTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/StringMatcherTest.java
@@ -80,4 +80,9 @@ public class StringMatcherTest extends Assert {
 		assertTrue(matcher.match("block([{some more text}])"));
 	}
 	
+	@Test public void testBug528817() {
+		StringMatcher matcher = createStringMatcher("keyw\\");
+		assertFalse(matcher.match("egal"));
+	}
+
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/StringMatcher.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/StringMatcher.java
@@ -8,6 +8,7 @@
 package org.eclipse.xtext.ui.editor.outline.quickoutline;
 
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Matches a given {@link String} against a prefix pattern. The matching algorithm
@@ -60,7 +61,11 @@ public class StringMatcher {
 	}
 	
 	public boolean match(String text) {
-		return getPattern().matcher(text).find();
+		try {
+			return getPattern().matcher(text).find();
+		} catch (PatternSyntaxException e) {
+			return false;
+		}
 	}
 
 }


### PR DESCRIPTION
[528817] Fixed PatternSyntaxException below StringMatcher.getPattern
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>