### PR TITLE
[#462] Remove annotations not based on resource markers.

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/handler/ValidateActionHandler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/handler/ValidateActionHandler.java
@@ -50,7 +50,7 @@ public class ValidateActionHandler extends AbstractHandler {
 			IXtextDocument xtextDocument = xtextEditor.getDocument();
 			IResource resource = xtextEditor.getResource();
 			if(resource != null)
-				issueProcessor = new MarkerIssueProcessor(resource, markerCreator, markerTypeProvider);
+				issueProcessor = new MarkerIssueProcessor(resource, xtextEditor.getInternalSourceViewer().getAnnotationModel(), markerCreator, markerTypeProvider);
 			else
 				issueProcessor = new AnnotationIssueProcessor(xtextDocument, xtextEditor.getInternalSourceViewer().getAnnotationModel(), issueResolutionProvider);
 			ValidationJob validationJob = new ValidationJob(resourceValidator, xtextDocument, issueProcessor,

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerIssueProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerIssueProcessor.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.xtext.ui.MarkerTypes;
 import org.eclipse.xtext.ui.validation.MarkerTypeProvider;
 import org.eclipse.xtext.validation.Issue;
@@ -26,24 +27,29 @@ import com.google.common.collect.ImmutableSet;
  */
 public class MarkerIssueProcessor implements IValidationIssueProcessor {
 	private final IResource resource;
-	
+
 	private Logger log = Logger.getLogger(getClass());
 
 	private MarkerCreator markerCreator;
 
 	private MarkerTypeProvider markerTypeProvider;
 
+	private IAnnotationModel annotationModel;
+
 	/**
-	 * @deprecated use {@link MarkerIssueProcessor#MarkerIssueProcessor(IResource, MarkerCreator, MarkerTypeProvider) instead.}
+	 * @deprecated use {@link MarkerIssueProcessor#MarkerIssueProcessor(IResource, IAnnotationModel, MarkerCreator, MarkerTypeProvider)}
+	 *             instead.
 	 */
 	@Deprecated
 	public MarkerIssueProcessor(IResource resource, MarkerCreator markerCreator) {
 		this(resource, markerCreator, new MarkerTypeProvider());
 	}
-	
+
 	/**
-	 * @since 2.3
+	 * @deprecated use {@link MarkerIssueProcessor#MarkerIssueProcessor(IResource, IAnnotationModel, MarkerCreator, MarkerTypeProvider)}
+	 *             instead.
 	 */
+	@Deprecated
 	public MarkerIssueProcessor(IResource resource, MarkerCreator markerCreator, MarkerTypeProvider markerTypeProvider) {
 		super();
 		this.resource = resource;
@@ -51,12 +57,24 @@ public class MarkerIssueProcessor implements IValidationIssueProcessor {
 		this.markerTypeProvider = markerTypeProvider;
 	}
 
+	/**
+	 * @since 2.14
+	 */
+	public MarkerIssueProcessor(IResource resource, IAnnotationModel annotationModel, MarkerCreator markerCreator,
+			MarkerTypeProvider markerTypeProvider) {
+		super();
+		this.resource = resource;
+		this.annotationModel = annotationModel;
+		this.markerCreator = markerCreator;
+		this.markerTypeProvider = markerTypeProvider;
+	}
+
 	@Override
 	public void processIssues(List<Issue> issues, IProgressMonitor monitor) {
 		try {
-			new AddMarkersOperation(resource, issues, ImmutableSet.of(MarkerTypes.FAST_VALIDATION,
-					MarkerTypes.NORMAL_VALIDATION, MarkerTypes.EXPENSIVE_VALIDATION), true, // delete existing markers 
-					markerCreator, markerTypeProvider).run(monitor);
+			new AddMarkersOperation(resource, issues,
+					ImmutableSet.of(MarkerTypes.FAST_VALIDATION, MarkerTypes.NORMAL_VALIDATION, MarkerTypes.EXPENSIVE_VALIDATION), true, // delete existing markers 
+					annotationModel, markerCreator, markerTypeProvider).run(monitor);
 		} catch (InvocationTargetException e) {
 			log.error("Could not create marker.", e);
 		} catch (InterruptedException e) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/ValidatingEditorCallback.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/ValidatingEditorCallback.java
@@ -21,13 +21,13 @@ import com.google.inject.Inject;
  * @author Michael Clay
  */
 public class ValidatingEditorCallback extends IXtextEditorCallback.NullImpl {
-	
+
 	@Inject
 	private IResourceValidator resourceValidator;
-	
-	@Inject 
+
+	@Inject
 	private MarkerCreator markerCreator;
-	
+
 	@Inject
 	private MarkerTypeProvider markerTypeProvider;
 	@Inject
@@ -54,9 +54,11 @@ public class ValidatingEditorCallback extends IXtextEditorCallback.NullImpl {
 	private ValidationJob newValidationJob(XtextEditor editor) {
 		IValidationIssueProcessor issueProcessor;
 		if (editor.getResource() == null) {
-			issueProcessor = new AnnotationIssueProcessor(editor.getDocument(), editor.getInternalSourceViewer().getAnnotationModel(), issueResolutionProvider);
+			issueProcessor = new AnnotationIssueProcessor(editor.getDocument(), editor.getInternalSourceViewer().getAnnotationModel(),
+					issueResolutionProvider);
 		} else {
-			issueProcessor = new MarkerIssueProcessor(editor.getResource(), markerCreator, markerTypeProvider);
+			issueProcessor = new MarkerIssueProcessor(editor.getResource(), editor.getInternalSourceViewer().getAnnotationModel(),
+					markerCreator, markerTypeProvider);
 		}
 		ValidationJob validationJob = new ValidationJob(resourceValidator, editor.getDocument(), issueProcessor, CheckMode.NORMAL_AND_FAST);
 		return validationJob;


### PR DESCRIPTION
Xtext adds annotations when validating from the editor. These
annotations are set in addition to the ones based on resource markers.
If an expensive validation is triggered it is necessary to remove these
annotations as well to ensure that validations that are NOT triggered by
expensive validation are not shown (of course they will be re-added in
case the validation is triggered e.g. by an edit again).

Change-Id: I0b2708e8a24a54e382f8a6a809dc8883b99c8637
Signed-off-by: Arne Deutsch <arne@idedeluxe.com>