### PR TITLE
[xtext-eclipse#145] Extend implementations from core.

### DIFF
--- a/org.eclipse.xtext.common.types.shared/src/org/eclipse/xtext/common/types/shared/SharedCommonTypesModule.java
+++ b/org.eclipse.xtext.common.types.shared/src/org/eclipse/xtext/common/types/shared/SharedCommonTypesModule.java
@@ -20,13 +20,14 @@ import org.eclipse.xtext.common.types.ui.refactoring.participant.JvmMemberRename
 import org.eclipse.xtext.common.types.xtext.JvmIdentifiableQualifiedNameProvider;
 import org.eclipse.xtext.common.types.xtext.ui.JdtHoverDocumentationProvider;
 import org.eclipse.xtext.common.types.xtext.ui.JdtHoverProvider;
+import org.eclipse.xtext.naming.DefaultCopyQualifiedNameService;
+import org.eclipse.xtext.naming.ICopyQualifiedNameService;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.resource.impl.LiveShadowedResourceDescriptions;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsProvider;
 import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService;
-import org.eclipse.xtext.ui.editor.copyqualifiedname.DefaultCopyQualifiedNameService;
 import org.eclipse.xtext.ui.editor.hover.IEObjectHoverProvider;
 import org.eclipse.xtext.ui.editor.hover.html.IEObjectHoverDocumentationProvider;
 import org.eclipse.xtext.ui.generator.trace.ITraceForStorageProvider;
@@ -55,7 +56,9 @@ public class SharedCommonTypesModule implements Module {
 		binder.bindConstant().annotatedWith(Names.named(Constants.FILE_EXTENSIONS)).to("java");
 		
 		binder.bind(IQualifiedNameProvider.class).to(JvmIdentifiableQualifiedNameProvider.class);
-		binder.bind(CopyQualifiedNameService.class).to(DefaultCopyQualifiedNameService.class);
+		binder.bind(CopyQualifiedNameService.class)
+				.to(org.eclipse.xtext.ui.editor.copyqualifiedname.DefaultCopyQualifiedNameService.class);
+		binder.bind(ICopyQualifiedNameService.class).to(DefaultCopyQualifiedNameService.class);
 		binder.bind(IJvmTypeProvider.Factory.class).to(JdtTypeProviderFactory.class);
 		binder.bind(IRenameRefactoringProvider.class).to(DefaultRenameRefactoringProvider.class);
 		binder.bind(AbstractRenameProcessor.class).to(JvmMemberRenameProcessor.class);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/DefaultUiModule.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/DefaultUiModule.java
@@ -33,6 +33,8 @@ import org.eclipse.xtext.formatting.IWhitespaceInformationProvider;
 import org.eclipse.xtext.generator.IShouldGenerate;
 import org.eclipse.xtext.ide.editor.bracketmatching.DefaultBracePairProvider;
 import org.eclipse.xtext.ide.editor.bracketmatching.IBracePairProvider;
+import org.eclipse.xtext.naming.DefaultCopyQualifiedNameService;
+import org.eclipse.xtext.naming.ICopyQualifiedNameService;
 import org.eclipse.xtext.parser.IEncodingProvider;
 import org.eclipse.xtext.preferences.IPreferenceValuesProvider;
 import org.eclipse.xtext.resource.IExternalContentSupport;
@@ -63,8 +65,6 @@ import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalPostProcesso
 import org.eclipse.xtext.ui.editor.contentassist.IContentAssistantFactory;
 import org.eclipse.xtext.ui.editor.contentassist.ITemplateProposalProvider;
 import org.eclipse.xtext.ui.editor.contentassist.XtextContentAssistProcessor;
-import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService;
-import org.eclipse.xtext.ui.editor.copyqualifiedname.DefaultCopyQualifiedNameService;
 import org.eclipse.xtext.ui.editor.formatting.ContentFormatterFactory;
 import org.eclipse.xtext.ui.editor.formatting.IContentFormatterFactory;
 import org.eclipse.xtext.ui.editor.formatting.PreferenceStoreIndentationInformation;
@@ -396,7 +396,14 @@ public class DefaultUiModule extends AbstractGenericModule {
 	/**
 	 * @since 2.4
 	 */
-	public Class<? extends CopyQualifiedNameService> bindCopyQualifiedNameService() {
+	public Class<? extends org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService> bindCopyQualifiedNameService() {
+		return org.eclipse.xtext.ui.editor.copyqualifiedname.DefaultCopyQualifiedNameService.class;
+	}
+
+	/**
+	 * @since 2.14
+	 */
+	public Class<? extends ICopyQualifiedNameService> bindICopyQualifiedNameService() {
 		return DefaultCopyQualifiedNameService.class;
 	}
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/AbstractCopyQualifiedNameHandler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/AbstractCopyQualifiedNameHandler.java
@@ -11,6 +11,7 @@ import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.naming.ICopyQualifiedNameService;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.ui.util.ClipboardUtil;
 
@@ -34,7 +35,7 @@ public abstract class AbstractCopyQualifiedNameHandler extends AbstractHandler {
 	protected abstract String getQualifiedName(ExecutionEvent event);
 
 	protected String getQualifiedName(EObject selectedElement) {
-		CopyQualifiedNameService copyQualifiedNameService = getCopyQualifiedNameService(selectedElement);
+		ICopyQualifiedNameService copyQualifiedNameService = getCopyQualifiedNameService(selectedElement);
 		if (copyQualifiedNameService == null) {
 			return null;
 		}
@@ -42,14 +43,14 @@ public abstract class AbstractCopyQualifiedNameHandler extends AbstractHandler {
 	}
 
 	protected String getQualifiedName(EObject selectedElement, EObject context) {
-		CopyQualifiedNameService copyQualifiedNameService = getCopyQualifiedNameService(selectedElement);
+		ICopyQualifiedNameService copyQualifiedNameService = getCopyQualifiedNameService(selectedElement);
 		if (copyQualifiedNameService == null) {
 			return null;
 		}
 		return copyQualifiedNameService.getQualifiedName(selectedElement, context);
 	}
 
-	protected CopyQualifiedNameService getCopyQualifiedNameService(EObject selectedElement) {
+	protected ICopyQualifiedNameService getCopyQualifiedNameService(EObject selectedElement) {
 		if (selectedElement == null) {
 			return null;
 		}
@@ -57,7 +58,7 @@ public abstract class AbstractCopyQualifiedNameHandler extends AbstractHandler {
 		if (resourceServiceProvider == null) {
 			return null;
 		}
-		return resourceServiceProvider.get(CopyQualifiedNameService.class);
+		return resourceServiceProvider.get(ICopyQualifiedNameService.class);
 	}
 
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/CopyQualifiedNameService.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/CopyQualifiedNameService.xtend
@@ -7,14 +7,14 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.editor.copyqualifiedname
 
-import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.naming.ICopyQualifiedNameService
 
 /**
  * @author Anton Kosyakov - Initial contribution and API
  * @since 2.4
+ * @deprecated Use org.eclipse.xtext.naming.ICopyQualifiedNameService instead
  */
-interface CopyQualifiedNameService {
-
-	def abstract String getQualifiedName(EObject selectedElement, EObject context)
+@Deprecated
+interface CopyQualifiedNameService extends ICopyQualifiedNameService {
 
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.xtend
@@ -7,67 +7,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.editor.copyqualifiedname
 
-import com.google.inject.Inject
-import java.util.List
-import org.eclipse.emf.ecore.EObject
-import org.eclipse.xtext.naming.IQualifiedNameConverter
-import org.eclipse.xtext.naming.IQualifiedNameProvider
-import org.eclipse.xtext.naming.QualifiedName
-
 /**
  * @author Anton Kosyakov - Initial contribution and API
+ * @author Arne Deutsch - Deprecated class by moving base class to core
  * @since 2.4
+ * @deprecated Use org.eclipse.xtext.naming.DefaultCopyQualifiedNameService instead
  */
-class DefaultCopyQualifiedNameService implements CopyQualifiedNameService {
-
-	@Inject
-	IQualifiedNameProvider qualifiedNameProvider
-
-	@Inject
-	IQualifiedNameConverter qualifiedNameConverter
-
-	def dispatch getQualifiedName(EObject it, EObject context) {
-		toFullyQualifiedName
-	}
-
-	def dispatch getQualifiedName(EObject it, Void context) {
-		toFullyQualifiedName
-	}
-
-	def protected dispatch getQualifiedName(Void it, EObject context) {
-		null
-	}
-
-	def protected dispatch getQualifiedName(Void it, Void context) {
-		null
-	}
-
-	def protected <T> toQualifiedNames(List<T> it, (T)=>String toQualifiedNameFunction) {
-		if (it === null || size == 0) {
-			return ""
-		}
-		'''«FOR element : it SEPARATOR ', '»«toQualifiedNameFunction.apply(element)»«ENDFOR»'''
-	}
-
-	def protected toFullyQualifiedName(EObject it) {
-		if (eIsProxy) {
-			return null
-		}
-		toString(fullyQualifiedName)
-	}
-
-	def protected getFullyQualifiedName(EObject it) {
-		if (it === null) {
-			return null
-		}
-		qualifiedNameProvider.getFullyQualifiedName(it)
-	}
-
-	def protected toString(EObject it, QualifiedName fullyQualifiedName) {
-		if (fullyQualifiedName === null) {
-			return null
-		}
-		qualifiedNameConverter.toString(fullyQualifiedName)
-	}
-
+@Deprecated
+class DefaultCopyQualifiedNameService extends org.eclipse.xtext.naming.DefaultCopyQualifiedNameService implements CopyQualifiedNameService {
 }

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/CopyQualifiedNameService.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/CopyQualifiedNameService.java
@@ -7,13 +7,14 @@
  */
 package org.eclipse.xtext.ui.editor.copyqualifiedname;
 
-import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.naming.ICopyQualifiedNameService;
 
 /**
  * @author Anton Kosyakov - Initial contribution and API
  * @since 2.4
+ * @deprecated Use org.eclipse.xtext.naming.ICopyQualifiedNameService instead
  */
+@Deprecated
 @SuppressWarnings("all")
-public interface CopyQualifiedNameService {
-  public abstract String getQualifiedName(final EObject selectedElement, final EObject context);
+public interface CopyQualifiedNameService extends ICopyQualifiedNameService {
 }

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.java
@@ -7,119 +7,15 @@
  */
 package org.eclipse.xtext.ui.editor.copyqualifiedname;
 
-import com.google.inject.Inject;
-import java.util.Arrays;
-import java.util.List;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.naming.IQualifiedNameConverter;
-import org.eclipse.xtext.naming.IQualifiedNameProvider;
-import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService;
-import org.eclipse.xtext.xbase.lib.Functions.Function1;
 
 /**
  * @author Anton Kosyakov - Initial contribution and API
+ * @author Arne Deutsch - Deprecated class by moving base class to core
  * @since 2.4
+ * @deprecated Use org.eclipse.xtext.naming.DefaultCopyQualifiedNameService instead
  */
+@Deprecated
 @SuppressWarnings("all")
-public class DefaultCopyQualifiedNameService implements CopyQualifiedNameService {
-  @Inject
-  private IQualifiedNameProvider qualifiedNameProvider;
-  
-  @Inject
-  private IQualifiedNameConverter qualifiedNameConverter;
-  
-  protected String _getQualifiedName(final EObject it, final EObject context) {
-    return this.toFullyQualifiedName(it);
-  }
-  
-  protected String _getQualifiedName(final EObject it, final Void context) {
-    return this.toFullyQualifiedName(it);
-  }
-  
-  protected String _getQualifiedName(final Void it, final EObject context) {
-    return null;
-  }
-  
-  protected String _getQualifiedName(final Void it, final Void context) {
-    return null;
-  }
-  
-  protected <T extends Object> CharSequence toQualifiedNames(final List<T> it, final Function1<? super T, ? extends String> toQualifiedNameFunction) {
-    CharSequence _xblockexpression = null;
-    {
-      if (((it == null) || (it.size() == 0))) {
-        return "";
-      }
-      StringConcatenation _builder = new StringConcatenation();
-      {
-        boolean _hasElements = false;
-        for(final T element : it) {
-          if (!_hasElements) {
-            _hasElements = true;
-          } else {
-            _builder.appendImmediate(", ", "");
-          }
-          String _apply = toQualifiedNameFunction.apply(element);
-          _builder.append(_apply);
-        }
-      }
-      _xblockexpression = _builder;
-    }
-    return _xblockexpression;
-  }
-  
-  protected String toFullyQualifiedName(final EObject it) {
-    String _xblockexpression = null;
-    {
-      boolean _eIsProxy = it.eIsProxy();
-      if (_eIsProxy) {
-        return null;
-      }
-      _xblockexpression = this.toString(it, this.getFullyQualifiedName(it));
-    }
-    return _xblockexpression;
-  }
-  
-  protected QualifiedName getFullyQualifiedName(final EObject it) {
-    QualifiedName _xblockexpression = null;
-    {
-      if ((it == null)) {
-        return null;
-      }
-      _xblockexpression = this.qualifiedNameProvider.getFullyQualifiedName(it);
-    }
-    return _xblockexpression;
-  }
-  
-  protected String toString(final EObject it, final QualifiedName fullyQualifiedName) {
-    String _xblockexpression = null;
-    {
-      if ((fullyQualifiedName == null)) {
-        return null;
-      }
-      _xblockexpression = this.qualifiedNameConverter.toString(fullyQualifiedName);
-    }
-    return _xblockexpression;
-  }
-  
-  public String getQualifiedName(final EObject it, final EObject context) {
-    if (it != null
-         && context != null) {
-      return _getQualifiedName(it, context);
-    } else if (it != null
-         && context == null) {
-      return _getQualifiedName(it, (Void)null);
-    } else if (it == null
-         && context != null) {
-      return _getQualifiedName((Void)null, context);
-    } else if (it == null
-         && context == null) {
-      return _getQualifiedName((Void)null, (Void)null);
-    } else {
-      throw new IllegalArgumentException("Unhandled parameter types: " +
-        Arrays.<Object>asList(it, context).toString());
-    }
-  }
+public class DefaultCopyQualifiedNameService extends org.eclipse.xtext.naming.DefaultCopyQualifiedNameService implements CopyQualifiedNameService {
 }

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/XbaseUiModule.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/XbaseUiModule.xtend
@@ -3,27 +3,27 @@
  */
 package org.eclipse.xtext.xbase.ui
 
+import com.google.inject.Binder
 import org.eclipse.jface.viewers.ILabelProvider
 import org.eclipse.ui.plugin.AbstractUIPlugin
-import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService
+import org.eclipse.xtext.naming.ICopyQualifiedNameService
 import org.eclipse.xtext.ui.editor.hover.html.IEObjectHoverDocumentationProvider
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration
 import org.eclipse.xtext.ui.resource.ResourceServiceDescriptionLabelProvider
 import org.eclipse.xtext.validation.IssueSeveritiesProvider
-import org.eclipse.xtext.xbase.typesystem.internal.OptimizingFeatureScopeTrackerProvider
 import org.eclipse.xtext.xbase.typesystem.internal.IFeatureScopeTracker
+import org.eclipse.xtext.xbase.typesystem.internal.OptimizingFeatureScopeTrackerProvider
 import org.eclipse.xtext.xbase.ui.editor.copyqualifiedname.XbaseCopyQualifiedNameService
 import org.eclipse.xtext.xbase.ui.highlighting.XbaseHighlightingConfiguration
 import org.eclipse.xtext.xbase.ui.hover.XbaseHoverDocumentationProvider
 import org.eclipse.xtext.xbase.ui.labeling.XbaseDescriptionLabelProvider
 import org.eclipse.xtext.xbase.ui.labeling.XbaseLabelProvider
 import org.eclipse.xtext.xbase.ui.validation.XbaseIssueSeveritiesProvider
-import com.google.inject.Binder
 
 /** 
  * Use this class to register components to be used within the IDE.
  */
-@SuppressWarnings("restriction") class XbaseUiModule extends org.eclipse.xtext.xbase.ui.AbstractXbaseUiModule {
+@SuppressWarnings("restriction") class XbaseUiModule extends AbstractXbaseUiModule {
 
 	new(AbstractUIPlugin plugin) {
 		super(plugin)
@@ -49,7 +49,7 @@ import com.google.inject.Binder
 		binder.bind(ILabelProvider).annotatedWith(ResourceServiceDescriptionLabelProvider).to(XbaseDescriptionLabelProvider)
 	}
 
-	override Class<? extends CopyQualifiedNameService> bindCopyQualifiedNameService() {
+	override Class<? extends ICopyQualifiedNameService> bindICopyQualifiedNameService() {
 		return XbaseCopyQualifiedNameService
 	}
 

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.xtend
@@ -13,7 +13,7 @@ import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.common.types.JvmConstructor
 import org.eclipse.xtext.common.types.JvmExecutable
 import org.eclipse.xtext.common.types.JvmOperation
-import org.eclipse.xtext.ui.editor.copyqualifiedname.DefaultCopyQualifiedNameService
+import org.eclipse.xtext.naming.DefaultCopyQualifiedNameService
 import org.eclipse.xtext.xbase.XAbstractFeatureCall
 import org.eclipse.xtext.xbase.XConstructorCall
 import org.eclipse.xtext.xbase.XExpression

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/XbaseUiModule.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/XbaseUiModule.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.xbase.ui;
 import com.google.inject.Binder;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService;
+import org.eclipse.xtext.naming.ICopyQualifiedNameService;
 import org.eclipse.xtext.ui.editor.hover.html.IEObjectHoverDocumentationProvider;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
 import org.eclipse.xtext.ui.resource.ResourceServiceDescriptionLabelProvider;
@@ -55,7 +55,7 @@ public class XbaseUiModule extends AbstractXbaseUiModule {
   }
   
   @Override
-  public Class<? extends CopyQualifiedNameService> bindCopyQualifiedNameService() {
+  public Class<? extends ICopyQualifiedNameService> bindICopyQualifiedNameService() {
     return XbaseCopyQualifiedNameService.class;
   }
   

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.java
@@ -16,7 +16,7 @@ import org.eclipse.xtext.common.types.JvmConstructor;
 import org.eclipse.xtext.common.types.JvmExecutable;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmOperation;
-import org.eclipse.xtext.ui.editor.copyqualifiedname.DefaultCopyQualifiedNameService;
+import org.eclipse.xtext.naming.DefaultCopyQualifiedNameService;
 import org.eclipse.xtext.xbase.XAbstractFeatureCall;
 import org.eclipse.xtext.xbase.XConstructorCall;
 import org.eclipse.xtext.xbase.XExpression;


### PR DESCRIPTION
Change implementation to use new classesfrom xtext core plugin and
deprecate the UI classes.

Change-Id: I0d3faf0b96e967bf95c549c9e82749e95c24c1c1
Signed-off-by: Arne Deutsch <arne@idedeluxe.com>