### PR TITLE
[#347] Avoid double semantic highlighting by removing bad call.

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
@@ -20,8 +20,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.quickassist.IQuickAssistProcessor;
 import org.eclipse.jface.text.quickassist.QuickAssistAssistant;
-import org.eclipse.jface.text.reconciler.IReconciler;
-import org.eclipse.jface.text.reconciler.IReconcilingStrategyExtension;
 import org.eclipse.jface.text.source.TextInvocationContext;
 import org.eclipse.ui.IMarkerResolution;
 import org.eclipse.ui.IMarkerResolutionGenerator2;
@@ -35,7 +33,6 @@ import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.quickfix.MarkerResolutionGenerator;
 import org.eclipse.xtext.ui.editor.quickfix.WorkbenchMarkerResolutionAdapter;
-import org.eclipse.xtext.ui.editor.reconciler.XtextReconciler;
 import org.eclipse.xtext.ui.testing.AbstractWorkbenchTest;
 import org.eclipse.xtext.ui.testing.util.AnnotatedTextToString;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
@@ -112,10 +109,8 @@ public abstract class AbstractQuickfixTest extends AbstractWorkbenchTest {
 	}
 	
 	protected ICompletionProposal[] computeQuickAssistProposals(XtextEditor editor, int offset) {
+		IResourcesSetupUtil.waitForBuild();
 		XtextSourceViewer sourceViewer = (XtextSourceViewer) editor.getInternalSourceViewer();
-		XtextReconciler reconciler = (XtextReconciler) sourceViewer.getAdapter(IReconciler.class);
-		IReconcilingStrategyExtension reconcilingStrategyExtension = (IReconcilingStrategyExtension) reconciler.getReconcilingStrategy("");
-		reconcilingStrategyExtension.initialReconcile();
 		QuickAssistAssistant quickAssistAssistant = (QuickAssistAssistant) sourceViewer.getQuickAssistAssistant();
 		IQuickAssistProcessor quickAssistProcessor = quickAssistAssistant.getQuickAssistProcessor();
 		ICompletionProposal[] quickAssistProposals = quickAssistProcessor

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -515,7 +515,6 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 		installSelectionChangedListener();
 		initializeDirtyStateSupport();
 		callback.afterCreatePartControl(this);
-		forceReconcile();
 	}
 
 	protected ProjectionSupport installProjectionSupport(ProjectionViewer projectionViewer) {


### PR DESCRIPTION
Experimented with highlighting while open/close outline view, setting
breakpoints etc. Can not find any side effect when removing the
"forceReconcile()" call. I guess the original bug 454227 was fixed by
the other changes inside
https://github.com/eclipse/xtext-eclipse/commit/d4fe755d6dd211ce0ca0d498d3f9e5913d4659e6
and the added "forceReconcile()" was a mistake. After removing the call
no duplicate highlighting happens any more. This should improve
performance for large files or files with expensive semantic
highlighting quite a lot.

Change-Id: I3a543dfa1f0e7b1e690bf40fbf1db766c73217b5
Signed-off-by: Arne Deutsch <arne@idedeluxe.com>