### PR TITLE
[#514] Fix tests under windows by handling \r\n as well as \n.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.xtend
@@ -84,7 +84,7 @@ class AnnotatedTextToString {
 			lastOffset = offset
 		}
 		result.append(cnt.substring(lastOffset, cnt.length))
-		val maxLineLenght = result.toString.replace("\t", "    ").split("\n").map[length].max
+		val maxLineLenght = result.toString.replace("\t", "    ").split("\r?\n").map[length].max
 		if (result.substring(result.length - 1, result.length) != "\n") {
 			result.append("\n")
 		}

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.java
@@ -162,7 +162,7 @@ public class AnnotatedTextToString {
     final Function1<String, Integer> _function_3 = (String it) -> {
       return Integer.valueOf(it.length());
     };
-    final Integer maxLineLenght = IterableExtensions.<Integer>max(ListExtensions.<String, Integer>map(((List<String>)Conversions.doWrapArray(result.toString().replace("\t", "    ").split("\n"))), _function_3));
+    final Integer maxLineLenght = IterableExtensions.<Integer>max(ListExtensions.<String, Integer>map(((List<String>)Conversions.doWrapArray(result.toString().replace("\t", "    ").split("\r?\n"))), _function_3));
     int _length = result.length();
     int _minus = (_length - 1);
     String _substring = result.substring(_minus, result.length());

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
@@ -42,6 +42,7 @@ import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.eclipse.xtext.util.StringInputStream;
+import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.Issue;
@@ -153,7 +154,7 @@ public abstract class AbstractQuickfixTest extends AbstractWorkbenchTest {
 	protected void assertContentsAndMarkers(IFile file, IMarker[] markers, CharSequence expectation) {
 		String actual = new AnnotatedTextToString().withFile(file).withMarkers(markers).toString().trim();
 		String exp = expectation.toString().trim();
-		Assert.assertEquals(exp, actual);
+		Assert.assertEquals(Strings.toUnixLineSeparator(exp), Strings.toUnixLineSeparator(actual));
 	}
 
 	protected void applyQuickfixOnMultipleMarkers(IMarker[] markers) {


### PR DESCRIPTION
Change-Id: I3bc38ee1d402026d4f304dca6c618623bf80e5a1
Signed-off-by: Arne Deutsch <arne@idedeluxe.com>