### PR TITLE
[eclipse/xtext#1160] Update copyright date range

### DIFF
--- a/org.eclipse.xtext.activities/plugin.properties
+++ b/org.eclipse.xtext.activities/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+# Copyright (c) 2008, 2016 itemis AG (http://www.itemis.eu) and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/Bug386476Test.java
+++ b/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/Bug386476Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/BuildCancellationTest.java
+++ b/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/BuildCancellationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/BuilderParticipantTest.java
+++ b/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/BuilderParticipantTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/BuilderPerformanceTest.java
+++ b/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/BuilderPerformanceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/IntegrationTest.java
+++ b/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/IntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/ResourceDescriptionUpdaterTest.java
+++ b/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/ResourceDescriptionUpdaterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/SimpleProjectsIntegrationTest.java
+++ b/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/SimpleProjectsIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/XtextBuilderParticipantTest.java
+++ b/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/XtextBuilderParticipantTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-no-jdt/org/eclipse/xtext/builder/noJdt/AbstractBuilderTest.java
+++ b/org.eclipse.xtext.builder.tests/src-no-jdt/org/eclipse/xtext/builder/noJdt/AbstractBuilderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-no-jdt/org/eclipse/xtext/builder/noJdt/SingleProjectTest.java
+++ b/org.eclipse.xtext.builder.tests/src-no-jdt/org/eclipse/xtext/builder/noJdt/SingleProjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-no-jdt/org/eclipse/xtext/builder/noJdt/TwoProjectsTest.java
+++ b/org.eclipse.xtext.builder.tests/src-no-jdt/org/eclipse/xtext/builder/noJdt/TwoProjectsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-standalone/org/eclipse/xtext/builder/standalone/StandaloneBuilderInjectorProvider.java
+++ b/org.eclipse.xtext.builder.tests/src-standalone/org/eclipse/xtext/builder/standalone/StandaloneBuilderInjectorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src-standalone/org/eclipse/xtext/builder/standalone/StandaloneBuilderTest.java
+++ b/org.eclipse.xtext.builder.tests/src-standalone/org/eclipse/xtext/builder/standalone/StandaloneBuilderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/builderState/EObjectDescriptionImplTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/builderState/EObjectDescriptionImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/builderState/EclipseResourceFileSystemAccess2Test.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/builderState/EclipseResourceFileSystemAccess2Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/builderState/EclipseResourceFileSystemAccessTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/builderState/EclipseResourceFileSystemAccessTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractBuilderParticipantTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractBuilderParticipantTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractBuilderTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractBuilderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractFSSynchronizationTest.xtend
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractFSSynchronizationTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractParticipatingBuilderTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractParticipatingBuilderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug334456Test.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug334456Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug355821Test.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug355821Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug486584Test.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug486584Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/BuilderUtil.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/BuilderUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/ProfilerAbstractBuilderTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/ProfilerAbstractBuilderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/GenerateBuilderTestLanguages.mwe2
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/GenerateBuilderTestLanguages.mwe2
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder.tests/xtend-gen/org/eclipse/xtext/builder/impl/AbstractFSSynchronizationTest.java
+++ b/org.eclipse.xtext.builder.tests/xtend-gen/org/eclipse/xtext/builder/impl/AbstractFSSynchronizationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/BuilderParticipant.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/BuilderParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/EclipseResourceFileSystemAccess2.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/EclipseResourceFileSystemAccess2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/JDTAwareEclipseResourceFileSystemAccess2.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/JDTAwareEclipseResourceFileSystemAccess2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/debug/XtextBuildConsole.xtend
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/debug/XtextBuildConsole.xtend
@@ -1,5 +1,5 @@
 /** 
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/javasupport/JdtQueuedBuildData.xtend
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/javasupport/JdtQueuedBuildData.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/nature/NatureAddingEditorCallback.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/nature/NatureAddingEditorCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/nature/ToggleXtextNatureAction.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/nature/ToggleXtextNatureAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/preferences/BuilderConfigurationBlock.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/preferences/BuilderConfigurationBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/resourceloader/ParallelResourceLoader.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/resourceloader/ParallelResourceLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Sigasi NV (http://www.sigasi.com) and others.
+ * Copyright (c) 2011, 2017 Sigasi NV (http://www.sigasi.com) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/resourceloader/ResourceLoaderProviders.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/resourceloader/ResourceLoaderProviders.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 Sigasi NV (http://www.sigasi.com) and others.
+ * Copyright (c) 2011, 2017 Sigasi NV (http://www.sigasi.com) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/DebugSourceInstallingCompilationParticipant.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/DebugSourceInstallingCompilationParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/StratumBreakpointAdapterFactory.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/StratumBreakpointAdapterFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/XbaseBreakpointUtil.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/XbaseBreakpointUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/debug/XtextBuildConsole.java
+++ b/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/debug/XtextBuildConsole.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/impl/javasupport/JdtQueuedBuildData.java
+++ b/org.eclipse.xtext.builder/xtend-gen/org/eclipse/xtext/builder/impl/javasupport/JdtQueuedBuildData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/util/CopyJavaToText.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/util/CopyJavaToText.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/util/CopyTestData.mwe2
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/util/CopyTestData.mwe2
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/util/CreateJar.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/util/CreateJar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/ContentAssistTestLanguage.xtext
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/ContentAssistTestLanguage.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2010 itemis AG and others.
+* Copyright (c) 2010, 2017 itemis AG and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/GenerateTypesTestLanguages.mwe2
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/GenerateTypesTestLanguages.mwe2
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/RefactoringTestLanguage.xtext
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/RefactoringTestLanguage.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2010 itemis AG and others.
+* Copyright (c) 2010, 2017 itemis AG and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/RefactoringTestLanguage1.xtext
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/RefactoringTestLanguage1.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2010 itemis AG and others.
+* Copyright (c) 2010, 2017 itemis AG and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/RefactoringTestLanguage2.xtext
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src/org/eclipse/xtext/common/types/xtext/ui/RefactoringTestLanguage2.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2010 itemis AG and others.
+* Copyright (c) 2010, 2017 itemis AG and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/testdata/org/eclipse/xtext/common/types/testSetups/TestAnnotation.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/testdata/org/eclipse/xtext/common/types/testSetups/TestAnnotation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/testdata/org/eclipse/xtext/common/types/testSetups/TestAnnotation.java.txt
+++ b/org.eclipse.xtext.common.types.eclipse.tests/testdata/org/eclipse/xtext/common/types/testSetups/TestAnnotation.java.txt
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/access/impl/AbstractTypeProviderTest.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/access/impl/AbstractTypeProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/access/jdt/MockJavaProjectProvider.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/access/jdt/MockJavaProjectProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/ui/notification/RebuildDependentResourcesTest.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/ui/notification/RebuildDependentResourcesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/ui/refactoring/participant/TextChangeCombinerTest.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/ui/refactoring/participant/TextChangeCombinerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/xtext/ui/ContentAssistTest.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/xtext/ui/ContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/xtext/ui/RefactoringTest.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/xtext/ui/RefactoringTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.shared/src/org/eclipse/xtext/common/types/shared/SharedCommonTypesModule.java
+++ b/org.eclipse.xtext.common.types.shared/src/org/eclipse/xtext/common/types/shared/SharedCommonTypesModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtBasedTypeFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtTypeProvider.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/access/jdt/JdtTypeProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009-2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.xtend
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/refactoring/JdtRenameRefactoringProcessorFactory.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/refactoring/JdtRenameRefactoringProcessorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/trace/ClassFileBasedOpenerContributor.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/trace/ClassFileBasedOpenerContributor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/trace/TraceForTypeRootProvider.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/trace/TraceForTypeRootProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.common.types.ui/xtend-gen/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.java
+++ b/org.eclipse.xtext.common.types.ui/xtend-gen/org/eclipse/xtext/common/types/ui/notification/JavaBuilderState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/IdeaPluginGenerator.xtend
+++ b/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/IdeaPluginGenerator.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/AntlrGrammarGenerator.xtend
+++ b/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/AntlrGrammarGenerator.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.xtend
+++ b/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/XtextIDEAGeneratorExtensions.xtend
+++ b/org.eclipse.xtext.idea.generator/src/org/eclipse/xtext/idea/generator/parser/antlr/XtextIDEAGeneratorExtensions.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/IdeaPluginGenerator.java
+++ b/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/IdeaPluginGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/AntlrGrammarGenerator.java
+++ b/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/AntlrGrammarGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.java
+++ b/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/GrammarAccessExtensions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/XtextIDEAGeneratorExtensions.java
+++ b/org.eclipse.xtext.idea.generator/xtend-gen/org/eclipse/xtext/idea/generator/parser/antlr/XtextIDEAGeneratorExtensions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/Flaky.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/Flaky.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.xtend
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/logging/LoggingTester.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/smoketest/internal/AbstractScenarioRunner.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/smoketest/internal/AbstractScenarioRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractAutoEditTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractAutoEditTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractCStyleLanguageAutoEditTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractCStyleLanguageAutoEditTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractContentAssistProcessorTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractContentAssistProcessorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractCursorHandlingTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractCursorHandlingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractDamagerRepairerTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractDamagerRepairerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractEditorTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractLinkedEditingIntegrationTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractLinkedEditingIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractOutlineTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractOutlineTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractWorkbenchTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractWorkbenchTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/ContentAssistProcessorTestBuilder.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/ContentAssistProcessorTestBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/MockableSelectionProvider.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/MockableSelectionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/MockableTextViewer.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/MockableTextViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/IResourcesSetupUtil.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/IResourcesSetupUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/JavaProjectSetupUtil.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/JavaProjectSetupUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/TargetPlatformUtil.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/TargetPlatformUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/util/InMemoryURIHandler.xtend
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/util/InMemoryURIHandler.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/logging/LoggingTester.java
+++ b/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/logging/LoggingTester.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/util/InMemoryURIHandler.java
+++ b/org.eclipse.xtext.junit4/xtend-gen/org/eclipse/xtext/junit4/util/InMemoryURIHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.codetemplates.tests/src/org/eclipse/xtext/ui/codetemplates/tests/HighlightingTest.java
+++ b/org.eclipse.xtext.ui.codetemplates.tests/src/org/eclipse/xtext/ui/codetemplates/tests/HighlightingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/preferences/AdvancedTemplatesPreferencePage.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/preferences/AdvancedTemplatesPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/preferences/TemplatesLanguageConfiguration.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/preferences/TemplatesLanguageConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/validation/TemplateValidator.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/validation/TemplateValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/Access.java
+++ b/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/Access.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/Activator.java
+++ b/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/ExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/ExecutableExtensionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractAutoEditTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractAutoEditTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractCStyleLanguageAutoEditTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractCStyleLanguageAutoEditTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractContentAssistTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractContentAssistTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractCursorHandlingTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractCursorHandlingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractDamagerRepairerTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractDamagerRepairerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractEditorTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractLinkedEditingIntegrationTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractLinkedEditingIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractOutlineTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractOutlineTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractWorkbenchTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractWorkbenchTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/ContentAssistProcessorTestBuilder.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/ContentAssistProcessorTestBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/MockableSelectionProvider.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/MockableSelectionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/MockableTextViewer.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/MockableTextViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.xtend
@@ -1,5 +1,5 @@
 /** 
- * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2017, 2018 TypeFox GmbH (http://www.typefox.io) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/LineDelimiters.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/LineDelimiters.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/ResourceLoadHelper.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/ResourceLoadHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/TargetPlatformUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/TargetPlatformUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractContentAssistTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractContentAssistTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2017, 2018 TypeFox GmbH (http://www.typefox.io) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/DirtyStateEditorSupportIntegrationTest.xtend
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/DirtyStateEditorSupportIntegrationTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/autoedit/AutoEditTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/autoedit/AutoEditTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/autoedit/Bug330096Test.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/autoedit/Bug330096Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/RefactoringDocumentProviderTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/RefactoringDocumentProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/RenameRefactoringIntegrationTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/RenameRefactoringIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/ToSaveOrNotToSaveTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/ToSaveOrNotToSaveTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/scoping/namespaces/JavaProjectsStateTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/scoping/namespaces/JavaProjectsStateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/GenerateTestLanguages.mwe2
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/GenerateTestLanguages.mwe2
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/TestLanguagesFragments.mwe2
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/TestLanguagesFragments.mwe2
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/TestLanguagesFragmentsWithConversionTimeout.mwe2
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/TestLanguagesFragmentsWithConversionTimeout.mwe2
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/Bug348199TestLanguage.xtext
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/Bug348199TestLanguage.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ParametersTestLanguage.xtext
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ParametersTestLanguage.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ParametersTestLanguageEx.xtext
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/ParametersTestLanguageEx.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/TwoParametersTestLanguage.xtext
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/contentassist/TwoParametersTestLanguage.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/mpe/MultiPageEditor.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/editor/mpe/MultiPageEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/refactoring/ReferringTestLanguage.xtext
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/refactoring/ReferringTestLanguage.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/refactoring/ui/ReferringXmiExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/refactoring/ui/ReferringXmiExecutableExtensionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/testlanguages/ContentAssistTestLanguage.xtext
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/testlanguages/ContentAssistTestLanguage.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2008 itemis AG and others.
+* Copyright (c) 2008, 2017 itemis AG and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/builder/impl/PackageFragmentRootWalkerTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/builder/impl/PackageFragmentRootWalkerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJdtImplTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJdtImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/util/ValidURITest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/util/ValidURITest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/ImportURINavigationTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/ImportURINavigationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/PresentationDamagerTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/PresentationDamagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/SimpleEditorTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/SimpleEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/AbstractBug326948Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/AbstractBug326948Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/AbstractBug348427Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/AbstractBug348427Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/AbstractParametersContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/AbstractParametersContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/BacktrackingContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/BacktrackingContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug281198Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug281198Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug282031Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug282031Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug286935Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug286935Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug287941Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug287941Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug288734Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug288734Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug288760Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug288760Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug289187Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug289187Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug291022Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug291022Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug297909Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug297909Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug303200ContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug303200ContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug304681Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug304681Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug307519Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug307519Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug309949Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug309949Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug332217Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug332217Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug347012Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug347012Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug348199Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug348199Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug360834Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug360834Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug377311Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug377311Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug381381Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/Bug381381Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ContentAssistContextTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ContentAssistContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ContentAssistCustomizingTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ContentAssistCustomizingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ContentAssistGrammarContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ContentAssistGrammarContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/CrossReferenceProposalTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/CrossReferenceProposalTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/CurrentModelBugTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/CurrentModelBugTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/EnumsContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/EnumsContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/KeywordContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/KeywordContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ParametersContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ParametersContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ParametersContentAssistTestEx.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ParametersContentAssistTestEx.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ReferenceGrammarUiContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/ReferenceGrammarUiContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/TwoContextsContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/TwoContextsContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/TwoParametersContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/TwoParametersContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/UnorderedGroupsContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/UnorderedGroupsContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/XtextGrammarUiContentAssistTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/XtextGrammarUiContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/antlr/Bug281198ParserTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/antlr/Bug281198ParserTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/antlr/Bug282031ParserTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/antlr/Bug282031ParserTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/antlr/Bug303200Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/contentassist/antlr/Bug303200Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/cursorHandling/CursorHandlingTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/cursorHandling/CursorHandlingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/encoding/EncodingTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/encoding/EncodingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/folding/DefaultFoldingRegionProviderTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/folding/DefaultFoldingRegionProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/handler/ValidateActionHandlerTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/handler/ValidateActionHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Michael Clay and others.
+ * Copyright (c) 2010, 2017 Michael Clay and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractCompositeHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractCompositeHoverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Christoph Kulla
+ * Copyright (c) 2010, 2017 Christoph Kulla
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractProblemHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractProblemHoverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Christoph Kulla
+ * Copyright (c) 2010, 2017 Christoph Kulla
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AnnotationWithQuickFixesHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AnnotationWithQuickFixesHoverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Christoph Kulla
+ * Copyright (c) 2010, 2017 Christoph Kulla
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/DispatchingEObjectTextHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/DispatchingEObjectTextHoverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Christoph Kulla
+ * Copyright (c) 2010, 2017 Christoph Kulla
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/ProblemHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/ProblemHoverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Christoph Kulla
+ * Copyright (c) 2010, 2017 Christoph Kulla
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/html/DefaultEObjectHoverProviderTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/html/DefaultEObjectHoverProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Christoph Kulla
+ * Copyright (c) 2010, 2017 Christoph Kulla
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/html/XtextElementLinksTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/html/XtextElementLinksTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Christoph Kulla
+ * Copyright (c) 2010, 2017 Christoph Kulla
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/Bug369087Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/Bug369087Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/JavaClassPathResourceForIEditorInputFactoryTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/JavaClassPathResourceForIEditorInputFactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/edit/AbstractTextEditComposerTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/edit/AbstractTextEditComposerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/edit/DefaultTextEditComposerTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/edit/DefaultTextEditComposerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/edit/RealXtextDocumentModifyTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/edit/RealXtextDocumentModifyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/mpe/MultipageEditorTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/mpe/MultipageEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/occurrences/MarkOccurrencesTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/occurrences/MarkOccurrencesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/AbstractOutlineWorkbenchTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/AbstractOutlineWorkbenchTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/Bug326812Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/Bug326812Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/Bug379500Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/Bug379500Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/DisplaySafeSyncer.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/DisplaySafeSyncer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/OutlineFilterAndSorterTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/OutlineFilterAndSorterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/OutlineNodeComparerTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/OutlineNodeComparerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/OutlineNodeTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/OutlineNodeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/OutlineTreeProviderTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/OutlineTreeProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/StringMatcherTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/StringMatcherTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/DeclarativeQuickfixProviderTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/DeclarativeQuickfixProviderTest.xtend
@@ -1,5 +1,5 @@
 /** 
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MockMarker.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MockMarker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/selection/AstSelectionProviderTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/selection/AstSelectionProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/syntaxcoloring/DeprecatedTaskHighlightingTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/syntaxcoloring/DeprecatedTaskHighlightingTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/findrefs/EditorResourceAccessTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/findrefs/EditorResourceAccessTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/findrefs/OpenDocumentTrackerTests.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/findrefs/OpenDocumentTrackerTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/preferences/PreferenceStoreAccessTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/preferences/PreferenceStoreAccessTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/DefaultRenameElementStrategyTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/DefaultRenameElementStrategyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/DisplayChangeWrapperTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/DisplayChangeWrapperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/LinkedEditingRefactoringIntegrationTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/LinkedEditingRefactoringIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/LinkedModelCalculatorIntegrationTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/LinkedModelCalculatorIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/RefactoringCrossReferenceSerializerTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/RefactoringCrossReferenceSerializerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/RenamedElementTrackerTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/refactoring/RenamedElementTrackerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/resource/AbstractScopeResourceDescriptionsTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/resource/AbstractScopeResourceDescriptionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/resource/containers/LiveShadowedAllContainerStateTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/resource/containers/LiveShadowedAllContainerStateTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/AbstractContainerRelatedTests.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/AbstractContainerRelatedTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/AbstractJavaProjectsStateTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/AbstractJavaProjectsStateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/StateBasedContainerManagerTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/StateBasedContainerManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/StrictJavaProjectsStateTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/StrictJavaProjectsStateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/WorkspaceProjectsStateTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/scoping/namespaces/WorkspaceProjectsStateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/tasks/TaskMarkerContributorTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/tasks/TaskMarkerContributorTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/trace/DefaultUITraceURIConverterTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/trace/DefaultUITraceURIConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/workspace/EclipseWorkspaceConfigurationTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/workspace/EclipseWorkspaceConfigurationTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/DirtyStateEditorSupportIntegrationTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/DirtyStateEditorSupportIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/DeclarativeQuickfixProviderTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/DeclarativeQuickfixProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/syntaxcoloring/DeprecatedTaskHighlightingTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/syntaxcoloring/DeprecatedTaskHighlightingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/resource/containers/LiveShadowedAllContainerStateTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/resource/containers/LiveShadowedAllContainerStateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/tasks/TaskMarkerContributorTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/tasks/TaskMarkerContributorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/workspace/EclipseWorkspaceConfigurationTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/workspace/EclipseWorkspaceConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/AbstractContentAssistParser.java
+++ b/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/AbstractContentAssistParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/FollowElement.java
+++ b/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/FollowElement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/LookAheadTerminal.java
+++ b/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/LookAheadTerminal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/ObservableXtextTokenStream.java
+++ b/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/ObservableXtextTokenStream.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/ParserBasedContentAssistContextFactory.java
+++ b/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/ParserBasedContentAssistContextFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/internal/AbstractInternalContentAssistParser.java
+++ b/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/internal/AbstractInternalContentAssistParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/internal/DFA.java
+++ b/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/internal/DFA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/internal/InfiniteRecursion.java
+++ b/org.eclipse.xtext.ui/deprecated/org/eclipse/xtext/ui/editor/contentassist/antlr/internal/InfiniteRecursion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/DefaultUiModule.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/DefaultUiModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultViewerCreator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultViewerCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/GlobalURIEditorOpener.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/GlobalURIEditorOpener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/WorkspaceEncodingProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/WorkspaceEncodingProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditorErrorTickUpdater.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditorErrorTickUpdater.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Michael Clay and others.
+ * Copyright (c) 2010, 2017 Michael Clay and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/autoedit/MultiLineTerminalsEditStrategy.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/autoedit/MultiLineTerminalsEditStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/bracketmatching/GoToMatchingBracketAction.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/bracketmatching/GoToMatchingBracketAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/AbstractContentProposalProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/AbstractContentProposalProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/ProposalConflictHelper.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/ProposalConflictHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/AbstractCopyQualifiedNameHandler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/AbstractCopyQualifiedNameHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/CopyQualifiedNameService.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/CopyQualifiedNameService.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorActions.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorActions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorFactory.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/FindReferencesHandler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/FindReferencesHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceQuery.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/folding/DefaultFoldingStructureProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/folding/DefaultFoldingStructureProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Michael Clay and others.
+ * Copyright (c) 2010, 2017 Michael Clay and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting/PreferenceStoreWhitespaceInformationProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting/PreferenceStoreWhitespaceInformationProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting2/ContentFormatter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting2/ContentFormatter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/handler/ValidateActionHandler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/handler/ValidateActionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AnnotationWithQuickFixesHover.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AnnotationWithQuickFixesHover.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Christoph Kulla
+ * Copyright (c) 2010, 2017 Christoph Kulla
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/html/DefaultEObjectHoverProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/html/DefaultEObjectHoverProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Christoph Kulla
+ * Copyright (c) 2010, 2017 Christoph Kulla
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hyperlinking/HyperlinkHelper.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hyperlinking/HyperlinkHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/occurrences/MarkOccurrenceActionContributor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/occurrences/MarkOccurrenceActionContributor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/occurrences/OccurrenceMarker.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/occurrences/OccurrenceMarker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/actions/OutlineWithEditorLinker.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/actions/OutlineWithEditorLinker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/actions/SortOutlineContribution.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/actions/SortOutlineContribution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/AbstractOutlineNode.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/AbstractOutlineNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/DefaultOutlineTreeProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/DefaultOutlineTreeProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/QuickOutlinePopup.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/QuickOutlinePopup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/ShowQuickOutlineActionHandler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/ShowQuickOutlineActionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/StringMatcher.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/quickoutline/StringMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/AbstractPreferencePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/AbstractPreferencePage.java
@@ -1,7 +1,7 @@
 package org.eclipse.xtext.ui.editor.preferences;
 
 /*******************************************************************************
- * Copyright (c) 2008, 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/LanguageRootPreferencePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/LanguageRootPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/AbstractDeclarativeQuickfixProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/AbstractDeclarativeQuickfixProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/AbstractIssueResolutionProviderAdapter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/AbstractIssueResolutionProviderAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/DefaultQuickfixProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/DefaultQuickfixProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/Fix.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/Fix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/IssueResolutionAcceptor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/IssueResolutionAcceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/QuickAssistCompletionProposal.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/QuickAssistCompletionProposal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/QuickAssistInvocationContext.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/QuickAssistInvocationContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/XtextQuickAssistProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/XtextQuickAssistProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextReconciler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextReconciler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/selection/AstSelectionProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/selection/AstSelectionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/templates/XtextTemplateContextTypeRegistry.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/templates/XtextTemplateContextTypeRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/AddMarkersOperation.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/AddMarkersOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/AnnotationIssueProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/AnnotationIssueProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 Michael Clay and others.
+ * Copyright (c) 2009, 2017 Michael Clay and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerIssueProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/MarkerIssueProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 Michael Clay and others.
+ * Copyright (c) 2009, 2017 Michael Clay and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/ValidatingEditorCallback.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/ValidatingEditorCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/XtextAnnotation.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/validation/XtextAnnotation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/ITraceForStorageProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/ITraceForStorageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/TraceForStorageProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/TraceForStorageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/WrappedCoreException.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/WrappedCoreException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/guice/AbstractGuiceAwareExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/guice/AbstractGuiceAwareExecutableExtensionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/internal/XtextPluginImages.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/internal/XtextPluginImages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/label/DefaultDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/label/DefaultDescriptionLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/preferences/OptionsConfigurationBlock.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/preferences/OptionsConfigurationBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/preferences/ResetPromptDialogSettingsField.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/preferences/ResetPromptDialogSettingsField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DefaultRefactoringDocumentProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DefaultRefactoringDocumentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DefaultReferenceUpdater.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DefaultReferenceUpdater.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DisplayChangeWrapper.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DisplayChangeWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/RefactoringCrossReferenceSerializer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/RefactoringCrossReferenceSerializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/ReferenceUpdaterDispatcher.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/ReferenceUpdaterDispatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/DefaultLinkedPositionGroupCalculator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/DefaultLinkedPositionGroupCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/DefaultRenameElementHandler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/DefaultRenameElementHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameElementWizard.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameElementWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameRefactoringController.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameRefactoringController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameRefactoringExecuter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameRefactoringExecuter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameRefactoringPopup.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameRefactoringPopup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/SyncUtil.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/SyncUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagConfigurationBlock.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagConfigurationBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagPreferencePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/tasks/preferences/TaskTagPreferencePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainDialogs.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainDialogs.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JavaProjectClasspathChangeAnalyzer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JavaProjectClasspathChangeAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/validation/MarkerEraser.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/validation/MarkerEraser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/CopyQualifiedNameService.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/CopyQualifiedNameService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/copyqualifiedname/DefaultCopyQualifiedNameService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/CompilationTestHelper.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/CompilationTestHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.xtend
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/JavaVersionModule.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/JavaVersionModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/OnTheFlyJavaCompiler.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/OnTheFlyJavaCompiler.java
@@ -1,7 +1,7 @@
 package org.eclipse.xtext.xbase.compiler;
 
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/RegisteringFileSystemAccess.xtend
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/RegisteringFileSystemAccess.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/SingletonGeneratorConfigModule.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/SingletonGeneratorConfigModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/SynchronizedXtextResourceSetProvider.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/SynchronizedXtextResourceSetProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/evaluation/AbstractXbaseEvaluationTest.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/evaluation/AbstractXbaseEvaluationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/NoJRESmokeTester.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/NoJRESmokeTester.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/Oven.xtend
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/Oven.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/PublicTypesForTesting.xtend
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/PublicTypesForTesting.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/TypeSystemSmokeTester.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/typesystem/TypeSystemSmokeTester.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/ui/AbstractContentAssistTest.xtend
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/ui/AbstractContentAssistTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/ui/AbstractXbaseContentAssistInBlockTest.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/ui/AbstractXbaseContentAssistInBlockTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/ui/AbstractXbaseContentAssistTest.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/ui/AbstractXbaseContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/ui/FindReferencesTestUtil.java
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/junit/ui/FindReferencesTestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/testdata/testdata/ClassWithVarArgs.java
+++ b/org.eclipse.xtext.xbase.junit/testdata/testdata/ClassWithVarArgs.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/testdata/testdata/ClosureClient.java
+++ b/org.eclipse.xtext.xbase.junit/testdata/testdata/ClosureClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/testdata/testdata/ClosureClient2.java
+++ b/org.eclipse.xtext.xbase.junit/testdata/testdata/ClosureClient2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/testdata/testdata/GenericType2.java
+++ b/org.eclipse.xtext.xbase.junit/testdata/testdata/GenericType2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/JavaSource.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/JavaSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/RegisteringFileSystemAccess.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/RegisteringFileSystemAccess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/Oven.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/Oven.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/PublicReentrantTypeResolver.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/PublicReentrantTypeResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/PublicResolvedTypes.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/PublicResolvedTypes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/PublicStackedResolvedTypes.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/typesystem/PublicStackedResolvedTypes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/ui/AbstractContentAssistTest.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/junit/ui/AbstractContentAssistTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/AbstractXbaseContentAssistInBlockTest.java
+++ b/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/AbstractXbaseContentAssistInBlockTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/AbstractXbaseContentAssistTest.java
+++ b/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/AbstractXbaseContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/FindReferencesTestUtil.java
+++ b/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/FindReferencesTestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src-longrunning/org/eclipse/xtext/xbase/ui/tests/editor/ContentAssistInBlockTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/src-longrunning/org/eclipse/xtext/xbase/ui/tests/editor/ContentAssistInBlockTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/AbstractXbaseTestCase.java
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/AbstractXbaseTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/AbstractXbaseUITestCase.java
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/AbstractXbaseUITestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/XbaseInjectorProviderWithScopeTracking.java
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/XbaseInjectorProviderWithScopeTracking.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/contentassist/Bug471434Test.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/contentassist/Bug471434Test.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/editor/AbstractXbaseContentAssistBugTest.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/editor/AbstractXbaseContentAssistBugTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/editor/Bug379238Test.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/editor/Bug379238Test.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/editor/ContentAssistTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/editor/ContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/hyperlinking/AbstractHyperlinkingTest.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/hyperlinking/AbstractHyperlinkingTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/navigation/FindReferencesTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/navigation/FindReferencesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/contentassist/Bug471434Test.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/contentassist/Bug471434Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/editor/AbstractXbaseContentAssistBugTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/editor/AbstractXbaseContentAssistBugTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/editor/Bug379238Test.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/editor/Bug379238Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/editor/TestingXbaseHoverProvider.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/editor/TestingXbaseHoverProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/hyperlinking/AbstractHyperlinkingTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/hyperlinking/AbstractHyperlinkingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/DefaultXbaseUiModule.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/DefaultXbaseUiModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/builder/XbaseBuilderPreferenceAccess.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/builder/XbaseBuilderPreferenceAccess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/contentassist/ImportingTypesProposalProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/contentassist/ImportingTypesProposalProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/debug/JavaBreakPointProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/debug/JavaBreakPointProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/debug/XbaseBreakpointPropertyTester.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/debug/XbaseBreakpointPropertyTester.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/actions/ImportsAwareClipboardAction.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/actions/ImportsAwareClipboardAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/highlighting/XbaseHighlightingConfiguration.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/highlighting/XbaseHighlightingConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/JvmAnnotationReferencePrinter.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/JvmAnnotationReferencePrinter.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseDispatchingEObjectTextHover.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseDispatchingEObjectTextHover.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverDocumentationProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverDocumentationProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseHoverProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseInformationControl.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseInformationControl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/imports/OrganizeImportsHandler.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/imports/OrganizeImportsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegate.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateAdapterFactory.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateAdapterFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/quickfix/CreateJavaTypeQuickfixes.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/quickfix/CreateJavaTypeQuickfixes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/quickfix/JavaTypeQuickfixes.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/quickfix/JavaTypeQuickfixes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/refactoring/XbaseReferenceUpdater.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/refactoring/XbaseReferenceUpdater.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/templates/XbaseTemplateContext.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/templates/XbaseTemplateContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/util/InsertionOffsets.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/util/InsertionOffsets.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/validation/Messages.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/validation/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/validation/ProjectAwareUniqueClassNameValidator.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/validation/ProjectAwareUniqueClassNameValidator.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/validation/XbaseValidationConfigurationBlock.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/validation/XbaseValidationConfigurationBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/copyqualifiedname/XbaseCopyQualifiedNameService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/hover/JvmAnnotationReferencePrinter.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/hover/JvmAnnotationReferencePrinter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/util/InsertionOffsets.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/util/InsertionOffsets.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/validation/ProjectAwareUniqueClassNameValidator.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/validation/ProjectAwareUniqueClassNameValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/src/org/eclipse/xtext/example/arithmetics/ide/ArithmeticsIdeModule.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/src/org/eclipse/xtext/example/arithmetics/ide/ArithmeticsIdeModule.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/src/org/eclipse/xtext/example/arithmetics/ide/ArithmeticsIdeSetup.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/src/org/eclipse/xtext/example/arithmetics/ide/ArithmeticsIdeSetup.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/xtend-gen/org/eclipse/xtext/example/arithmetics/ide/ArithmeticsIdeModule.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/xtend-gen/org/eclipse/xtext/example/arithmetics/ide/ArithmeticsIdeModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/xtend-gen/org/eclipse/xtext/example/arithmetics/ide/ArithmeticsIdeSetup.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/xtend-gen/org/eclipse/xtext/example/arithmetics/ide/ArithmeticsIdeSetup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/src/org/eclipse/xtext/example/arithmetics/tests/ArithmeticsParsingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/src/org/eclipse/xtext/example/arithmetics/tests/ArithmeticsParsingTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/src/org/eclipse/xtext/example/arithmetics/tests/interpreter/CalculatorTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/src/org/eclipse/xtext/example/arithmetics/tests/interpreter/CalculatorTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/tests/ArithmeticsParsingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/tests/ArithmeticsParsingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/tests/interpreter/CalculatorTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/tests/interpreter/CalculatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/autoedit/AutoEditTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/autoedit/AutoEditTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/autoedit/AutoEditTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/autoedit/AutoEditTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/ArithmeticsUiModule.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/ArithmeticsUiModule.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/AutoEditStrategy.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/AutoEditStrategy.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/contentassist/ArithmeticsProposalProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/contentassist/ArithmeticsProposalProvider.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsDescriptionLabelProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsDescriptionLabelProvider.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsLabelProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsLabelProvider.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/outline/ArithmeticsOutlineTreeProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/outline/ArithmeticsOutlineTreeProvider.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/quickfix/ArithmeticsQuickfixProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/quickfix/ArithmeticsQuickfixProvider.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/ArithmeticsUiModule.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/ArithmeticsUiModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/autoedit/AutoEditStrategy.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/autoedit/AutoEditStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/contentassist/ArithmeticsProposalProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/contentassist/ArithmeticsProposalProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsDescriptionLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsLabelProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/outline/ArithmeticsOutlineTreeProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/outline/ArithmeticsOutlineTreeProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/quickfix/ArithmeticsQuickfixProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/quickfix/ArithmeticsQuickfixProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/Arithmetics.xtext
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/Arithmetics.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/ArithmeticsRuntimeModule.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/ArithmeticsRuntimeModule.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/ArithmeticsStandaloneSetup.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/ArithmeticsStandaloneSetup.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/GenerateArithmetics.mwe2
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/GenerateArithmetics.mwe2
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/generator/ArithmeticsGenerator.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/generator/ArithmeticsGenerator.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/interpreter/Calculator.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/interpreter/Calculator.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/scoping/ArithmeticsScopeProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/scoping/ArithmeticsScopeProvider.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/validation/ArithmeticsValidator.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/validation/ArithmeticsValidator.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/ArithmeticsRuntimeModule.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/ArithmeticsRuntimeModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/ArithmeticsStandaloneSetup.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/ArithmeticsStandaloneSetup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/generator/ArithmeticsGenerator.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/generator/ArithmeticsGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/interpreter/Calculator.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/interpreter/Calculator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/scoping/ArithmeticsScopeProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/scoping/ArithmeticsScopeProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/validation/ArithmeticsValidator.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/xtend-gen/org/eclipse/xtext/example/arithmetics/validation/ArithmeticsValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/autoedit/FantasticEditStrategyProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/autoedit/FantasticEditStrategyProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyBuilder.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyBuilder.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyNodeLocationProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyNodeLocationProvider.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyViewPart.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyViewPart.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/OpenAssociationHierarchyHandler.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/OpenAssociationHierarchyHandler.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/linking/DomainmodelLinkingDiagnosticMessageProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/linking/DomainmodelLinkingDiagnosticMessageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/navigation/DomainmodelHyperlinkHelper.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/navigation/DomainmodelHyperlinkHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/outline/FilterOperationsContribution.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/outline/FilterOperationsContribution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyBuilder.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyNodeLocationProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyNodeLocationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyViewPart.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/AssociationHierarchyViewPart.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/OpenAssociationHierarchyHandler.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/editor/hierarchy/OpenAssociationHierarchyHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2016, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/Domainmodel.xtext
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/Domainmodel.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/DomainmodelRuntimeModule.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/DomainmodelRuntimeModule.xtend
@@ -1,5 +1,5 @@
 /** 
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/GenerateDomainmodel.mwe2
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/GenerateDomainmodel.mwe2
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/validation/IssueCodes.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/validation/IssueCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/DomainmodelRuntimeModule.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/DomainmodelRuntimeModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/formatting2/DomainmodelFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/RuleEngine.xtext
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/RuleEngine.xtext
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.graph/src/org/eclipse/xtext/xtext/ui/graph/actions/ExportToFileAction.java
+++ b/org.eclipse.xtext.xtext.ui.graph/src/org/eclipse/xtext/xtext/ui/graph/actions/ExportToFileAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu)
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu)
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.graph/src/org/eclipse/xtext/xtext/ui/graph/figures/layouts/RailroadConnectionRouter.java
+++ b/org.eclipse.xtext.xtext.ui.graph/src/org/eclipse/xtext/xtext/ui/graph/figures/layouts/RailroadConnectionRouter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu)
+ * Copyright (c) 2010, 2016 itemis AG (http://www.itemis.eu)
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/editor/autoedit/XtextAutoEditStrategyTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/editor/autoedit/XtextAutoEditStrategyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/refactoring/XtextGrammarRefactoringIntegrationTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/refactoring/XtextGrammarRefactoringIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/GrammarLinkingInWorkspaceTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/GrammarLinkingInWorkspaceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/hierarchy/XtextCallHierarchyBuilderTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/hierarchy/XtextCallHierarchyBuilderTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2016, 2017 TypeFox GmbH (http://www.typefox.io) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProviderTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Michael Clay and others.
+ * Copyright (c) 2010, 2018 Michael Clay and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/hierarchy/XtextCallHierarchyBuilderTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/hierarchy/XtextCallHierarchyBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2016, 2017 TypeFox GmbH (http://www.typefox.io) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/plugin.properties
+++ b/org.eclipse.xtext.xtext.ui/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2008-2012 itemis AG (http://www.itemis.eu) and others.
+# Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/launcher/WorkflowLaunchUtils.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/launcher/WorkflowLaunchUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProvider.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Michael Clay and others.
+ * Copyright (c) 2010, 2018 Michael Clay and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/Messages.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/XtextValidatorConfigurationBlock.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/XtextValidatorConfigurationBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/internal/XtextUIModuleInternal.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/internal/XtextUIModuleInternal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/NewXtextProjectWizard.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/NewXtextProjectWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 Dakshinamurthy Karra, itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2017 Dakshinamurthy Karra, itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/WizardNewXtextProjectCreationPage.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/WizardNewXtextProjectCreationPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 Dakshinamurthy Karra, itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2016 Dakshinamurthy Karra, itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/messages.properties
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+# Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
+++ b/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Additional cleanup for some files:
- remove empty line at end of file
- move package statement below copyright header

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>