### PR TITLE
Fixed NPE in SyncUtil

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/SyncUtil.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/SyncUtil.java
@@ -134,7 +134,9 @@ public class SyncUtil {
 			});
 			// reconciling schedules both, validation and dirty state
 			Job validationJob = ((XtextDocument)editor.getDocument()).getValidationJob();
-			validationJob.join();
+			if (validationJob != null) {
+				validationJob.join();
+			}
 			editor.getDirtyStateEditorSupport().waitForUpdateEditorJob();
 		} catch (OperationCanceledException e) {
 		} catch (OperationCanceledError e) {


### PR DESCRIPTION
I Have no way of reproducing this but there are plenty of nullchecks on ValidationJob in other places.

Signed-off-by: Titouan Vervack <titouan.vervack@sigasi.com>