### PR TITLE
[#560] Restore old Delegate on TearDown so that other tests are not affected

### DIFF
--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractBuilderParticipantTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractBuilderParticipantTest.java
@@ -40,6 +40,8 @@ import com.google.inject.Injector;
  */
 public abstract class AbstractBuilderParticipantTest extends AbstractBuilderTest {
 	
+	private IXtextBuilderParticipant oldDelegate;
+
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
@@ -48,6 +50,7 @@ public abstract class AbstractBuilderParticipantTest extends AbstractBuilderTest
 		participant = injector.getInstance(BuilderParticipant.class);
 		preferenceStoreAccess = injector.getInstance(IPreferenceStoreAccess.class);
 		DelegatingBuilderParticipant delegatingParticipant = (DelegatingBuilderParticipant) instance;
+		oldDelegate = delegatingParticipant.getDelegate();
 		delegatingParticipant.setDelegate(participant);
 	}
 
@@ -62,6 +65,9 @@ public abstract class AbstractBuilderParticipantTest extends AbstractBuilderTest
 
 	@Override
 	public void tearDown() throws Exception {
+		IXtextBuilderParticipant instance = getInjector().getInstance(IXtextBuilderParticipant.class);
+		DelegatingBuilderParticipant delegatingParticipant = (DelegatingBuilderParticipant) instance;
+		delegatingParticipant.setDelegate(oldDelegate);
 		super.tearDown();
 		participant = null;
 	}


### PR DESCRIPTION
[#560] Restore old Delegate on TearDown so that other tests are not affected

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>