### PR TITLE
That the tests are flaky is not reproducible locally. Anyway there are

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/xtend-gen/org/eclipse/xtext/example/arithmetics/ide/.gitignore
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/xtend-gen/org/eclipse/xtext/example/arithmetics/ide/.gitignore
@@ -1,0 +1,2 @@
+/ArithmeticsIdeModule.java
+/ArithmeticsIdeSetup.java

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProviderTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProviderTest.java
@@ -19,8 +19,11 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.ui.IMarkerResolution;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
@@ -37,9 +40,11 @@ import org.eclipse.xtext.ui.MarkerTypes;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocument;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolution;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionProvider;
 import org.eclipse.xtext.ui.editor.quickfix.MarkerResolutionGenerator;
+import org.eclipse.xtext.ui.editor.validation.ValidationJob;
 import org.eclipse.xtext.ui.shared.SharedStateModule;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
@@ -219,8 +224,8 @@ public class XtextGrammarQuickfixProviderTest extends AbstractXtextTests {
 			xtextEditor.doSave(new NullProgressMonitor());
 		}
 		InternalBuilderTest.fullBuild();
-
 		IXtextDocument document = xtextEditor.getDocument();
+		validateInEditor(document);
 		List<Issue> issues = getIssues(document);
 		assertFalse("Document has no issues, but should.", issues.isEmpty());
 
@@ -232,18 +237,36 @@ public class XtextGrammarQuickfixProviderTest extends AbstractXtextTests {
 		IResource resource = xtextEditor.getResource();
 		IMarker[] problems = resource.findMarkers(MarkerTypes.FAST_VALIDATION, true, IResource.DEPTH_INFINITE);
 		assertEquals("Resource should have " + issueCount + " error marker.", issueCount, problems.length);
-
+		validateInEditor(document);
 		MarkerResolutionGenerator instance = injector.getInstance(MarkerResolutionGenerator.class);
 		List<IMarkerResolution> resolutions = Lists.newArrayList(instance.getResolutions(problems[0]));
 		assertEquals(1, resolutions.size());
 		IMarkerResolution resolution = resolutions.iterator().next();
 		assertTrue(resolution instanceof WorkbenchMarkerResolution);
 		WorkbenchMarkerResolution workbenchResolution = (WorkbenchMarkerResolution) resolution;
-		workbenchResolution.run(workbenchResolution.findOtherMarkers(problems), new NullProgressMonitor());
+		IMarker primaryMarker = problems[0];
+		List<IMarker> others = Lists.newArrayList(workbenchResolution.findOtherMarkers(problems));
+		assertFalse(others.contains(primaryMarker));
+		assertEquals(problems.length - 1, others.size());
+		others.add(primaryMarker);
+		workbenchResolution.run(others.toArray(new IMarker[others.size()]), new NullProgressMonitor());
+		if (xtextEditor.isDirty()) {
+			xtextEditor.doSave(null);
+		}
 		InternalBuilderTest.cleanBuild();
 		problems = resource.findMarkers(MarkerTypes.FAST_VALIDATION, true, IResource.DEPTH_INFINITE);
 		assertEquals("Resource should have no error marker.", 0, problems.length);
 
+	}
+
+	private void validateInEditor(IXtextDocument document) {
+		try {
+			Job validationJob = ((XtextDocument)document).getValidationJob();
+			validationJob.schedule();
+			Job.getJobManager().join(ValidationJob.XTEXT_VALIDATION_FAMILY, new NullProgressMonitor());
+		} catch (OperationCanceledException | InterruptedException e) {
+			e.printStackTrace();
+		}
 	}
 
 	private XtextEditor editorForGrammar(String... bodyContent) throws PartInitException, CoreException {


### PR DESCRIPTION
two issues fixed in the test. The IResourceChangeListener were not
removed, hence are executed way to often even after creating test case
has been finished. The listeners are now removed after test case has
been finished. Second the IProject was each time the same instance,
leading the == test inside the resource change listener to result in
true even for projects from different test case. To decouple test cases
a new project name is invented for each test case.

Change-Id: Ibbd2abdabd86146329d5f4c95add0595ed61bd35
Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>