### PR TITLE
[#477] Prevent NPE in XtextProposalProvider for rules without type.

### DIFF
--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/contentassist/XtextProposalProvider.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/contentassist/XtextProposalProvider.java
@@ -9,6 +9,7 @@ import static org.eclipse.xtext.util.Strings.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
@@ -794,14 +795,11 @@ public class XtextProposalProvider extends AbstractXtextProposalProvider {
 		if (eClassifier instanceof EDataType && !((EDataType) eClassifier).isSerializable()) {
 			return false;
 		}
-		Iterable<EClassifier> allRuleNames = Iterables.transform(GrammarUtil.allParserRules(grammar),
-				new Function<ParserRule, EClassifier>() {
-					@Override
-					public EClassifier apply(ParserRule from) {
-						return from.getType().getClassifier();
-					}
-				});
-		return !Iterables.contains(allRuleNames, eClassifier);
+		return GrammarUtil.allParserRules(grammar)
+				.stream()
+				.filter(r -> r.getType() != null)
+				.map(r -> r.getType().getClassifier())
+				.allMatch(c -> !Objects.equals(c, eClassifier));
 	}
 
 	@Override


### PR DESCRIPTION
In `XtextProposalProvider#isProposeParserRule`, an NPE can occur if the grammar contains a rule without type. Since rules without types cannot possibly match the `eClassifier` parameter of the method, they can safely be filtered out.

This solution expects that a grammar may contain a rule with `getType() == null`. If this is the case, it fixes #477. If such a rule is invalid, further investigation is neccesary to find the root cause for that issue.

Signed-off-by: Florian Stolte <fstolte@gmx.de>