### PR TITLE
[#479] Prevent NPE in XtextProposalProvider if rule has no type.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
@@ -748,6 +748,30 @@ public class XtextContentAssistTest extends AbstractXtextTests implements Resour
 	        		"importURI=");
     }
     
+    @Test public void testCompleteFeatureName_17() throws Exception {
+    	newBuilder()
+	        .appendNl("grammar org.foo.bar")
+	        .appendNl("fragment Foo *:")
+	        .append("name =\"Bar\";")
+	        .assertTextAtCursorPosition("=",
+	        		"=>",
+	        		"->",
+	        		"\"Value\"",
+	        		"Feature",
+	        		"(",
+	        		"{",
+	        		"<", // guarded alternative
+	        		"&",
+	        		"*",
+	        		"+",
+	        		"+=",
+	        		";",
+	        		"=",
+	        		"?",
+	        		"?=",
+	        		"|");
+    }
+    
     @Test public void testAliasCompletion_01() throws Exception {
     	newBuilder()
 	        .appendNl("grammar org.foo.bar with org.eclipse.xtext.common.Terminals")

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/contentassist/XtextProposalProvider.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/contentassist/XtextProposalProvider.java
@@ -384,9 +384,9 @@ public class XtextProposalProvider extends AbstractXtextProposalProvider {
 	public void completeAssignment_Feature(EObject model, Assignment assignment, ContentAssistContext context,
 			ICompletionProposalAcceptor acceptor) {
 		AbstractRule rule = EcoreUtil2.getContainerOfType(model, AbstractRule.class);
-		EClassifier type = rule.getType().getClassifier();
-		if (type instanceof EClass) {
-			Iterable<EStructuralFeature> features = ((EClass) type).getEAllStructuralFeatures();
+		TypeRef typeRef = rule.getType();
+		if (typeRef != null && typeRef.getClassifier() instanceof EClass) {
+			Iterable<EStructuralFeature> features = ((EClass) typeRef.getClassifier()).getEAllStructuralFeatures();
 			Function<IEObjectDescription, ICompletionProposal> factory = getProposalFactory(grammarAccess.getValidIDRule().getName(), context);
 			Iterable<String> processedFeatures = completeStructuralFeatures(context, factory, acceptor, features);
 			if(rule.getType().getMetamodel() instanceof GeneratedMetamodel) {


### PR DESCRIPTION
In XtextProposalProvider#completeAssignment_Feature, an NPE can occur if the grammar contains a rule without type. Since there is a check if the eClassifier of the type is an EClass, is seems reasonable to also add a nullguard for the type to that if-statement.

This solution expects that a grammar may contain a rule with getType() == null. If this is the case, it fixes #479. If such a rule is invalid, however, further investigation is neccesary to find the root cause for that issue.

Signed-off-by: Florian Stolte <fstolte@gmx.de>