### PR TITLE
[Refactoring] Save editors when persisted files are affected

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
@@ -79,8 +79,11 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 	protected def void doConvert(IEmfResourceChange change) {
 		handleReplacements(change)
 		handleUriChange(change)
+		if(affectsPersistedFiles()) {
+			saveEditorsAfterApply()
+		}
 	}
-
+	
 	protected def dispatch void handleReplacements(IEmfResourceChange change) {
 		val outputStream = new ByteArrayOutputStream
 		tryWith(outputStream) [
@@ -165,5 +168,15 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 					.findFirst[ it.editorInput == editorInput ]
 			}
 		}.syncExec()
+	}
+	
+	protected def boolean affectsPersistedFiles() {
+		currentChange.children.exists[!(it instanceof EditorDocumentChange)]
+	}
+
+	protected def void saveEditorsAfterApply() {
+		for (change : currentChange.children.filter(EditorDocumentChange)) {
+			change.doSave = true
+		}
 	}
 }

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
@@ -113,6 +113,10 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
   protected void doConvert(final IEmfResourceChange change) {
     this.handleReplacements(change);
     this.handleUriChange(change);
+    boolean _affectsPersistedFiles = this.affectsPersistedFiles();
+    if (_affectsPersistedFiles) {
+      this.saveEditorsAfterApply();
+    }
   }
   
   protected void _handleReplacements(final IEmfResourceChange change) {
@@ -264,6 +268,20 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
         return IterableExtensions.<ITextEditor>findFirst(Iterables.<ITextEditor>filter(ListExtensions.<IEditorReference, IEditorPart>map(((List<IEditorReference>)Conversions.doWrapArray(ChangeConverter.this.workbench.getActiveWorkbenchWindow().getActivePage().getEditorReferences())), _function), ITextEditor.class), _function_1);
       }
     }.syncExec();
+  }
+  
+  protected boolean affectsPersistedFiles() {
+    final Function1<Change, Boolean> _function = (Change it) -> {
+      return Boolean.valueOf((!(it instanceof EditorDocumentChange)));
+    };
+    return IterableExtensions.<Change>exists(((Iterable<Change>)Conversions.doWrapArray(this.currentChange.getChildren())), _function);
+  }
+  
+  protected void saveEditorsAfterApply() {
+    Iterable<EditorDocumentChange> _filter = Iterables.<EditorDocumentChange>filter(((Iterable<?>)Conversions.doWrapArray(this.currentChange.getChildren())), EditorDocumentChange.class);
+    for (final EditorDocumentChange change : _filter) {
+      change.setDoSave(true);
+    }
   }
   
   protected void handleReplacements(final IEmfResourceChange change) {


### PR DESCRIPTION
Editors should remain unsaved after a refactoring only when no persited
files are affected. Otherwise, the builder will find an inconsistent
state since it can't see the dirty state.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>