### PR TITLE
[xtexteditor] support save() and rewrite() on non-display-thread

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -105,6 +105,7 @@ import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingHelper;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.TextAttributeProvider;
 import org.eclipse.xtext.ui.editor.toggleComments.ToggleSLCommentAction;
 import org.eclipse.xtext.ui.internal.Activator;
+import org.eclipse.xtext.ui.util.DisplayRunnable;
 
 import com.google.common.collect.ObjectArrays;
 import com.google.inject.Inject;
@@ -316,6 +317,26 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 	public void doSave(IProgressMonitor progressMonitor) {
 		super.doSave(progressMonitor);
 		callback.afterSave(this);
+	}
+	
+	@Override
+	protected void updateState(final IEditorInput input) {
+		new DisplayRunnable() {
+			@Override
+			protected void run() throws Exception {
+				XtextEditor.super.updateState(input);
+			}
+		}.syncExec();
+	}
+	
+	@Override
+	protected void validateState(IEditorInput input) {
+		new DisplayRunnable() {
+			@Override
+			protected void run() throws Exception {
+				XtextEditor.super.validateState(input);
+			}
+		}.syncExec();
 	}
 
 	@Override

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/EditorDocumentChange.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/EditorDocumentChange.java
@@ -18,7 +18,6 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.TextChange;
 import org.eclipse.text.edits.UndoEdit;
 import org.eclipse.ui.texteditor.ITextEditor;
-import org.eclipse.xtext.ui.util.DisplayRunnableWithResult;
 
 /**
  * Copied and adapted {@link DocumentChange}.
@@ -93,16 +92,6 @@ public class EditorDocumentChange extends TextChange {
 
 	@Override
 	protected void releaseDocument(IDocument document, IProgressMonitor pm) throws CoreException {
-	}
-
-	@Override
-	public Change perform(final IProgressMonitor pm) throws CoreException {
-		return new DisplayRunnableWithResult<Change>() {
-			@Override
-			protected Change run() throws Exception {
-				return EditorDocumentChange.super.perform(pm);
-			}
-		}.syncExec();
 	}
 		
 	@Override


### PR DESCRIPTION
use case: persisted files should be in a consistent state after
refactoring and quickfix-operations. Thus, if some of those files are
opened in an editor, we currently modify the editor's contents and save
if afterwards (see https://github.com/eclipse/xtext-eclipse/pull/593 )

However, running editor.save() in Display.syncExec() seems to make the
file changes escape the workspace modification operations. Consequently,
the builder running after the operations doens't see all changes.

This change attempts to make editor.save() and TextEdit.apply() runnable
in non-display-thread, so that refactoring and quickfix operations can
safely be executed in non-display-threads and don't escape
workspace-operations.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>