### PR TITLE
[refactoring] don't run build in UI thread

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameRefactoringExecuter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/RenameRefactoringExecuter.java
@@ -116,9 +116,7 @@ public class RenameRefactoringExecuter {
 			manager.endRule(rule);
 			refactoring.setValidationContext(null);
 		}
-		syncUtil.yieldToQueuedDisplayJobs(new NullProgressMonitor());
-		syncUtil.reconcileAllEditors(workbench, false, new NullProgressMonitor());
-		syncUtil.waitForBuild(new NullProgressMonitor());
+		Display.getDefault().asyncExec(() -> syncUtil.reconcileAllEditors(workbench, false, new NullProgressMonitor()));
 	}
 
 	private void showFatalErrorMessage(Shell parent, String message) {


### PR DESCRIPTION
Because this freezes the UI.

Also, don't call yieldToQueuedDisplayJobs() because we're inside a
Workspace Operation and this causes the Resource Change Events to be
handled prematurely and thus to *not* trigger a build.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>