### PR TITLE
[eclipse/xtext-core#664] Fixed Content Assist Tests regarding new grammar annotations

### DIFF
--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/contentassist/XtextContentAssistTest.java
@@ -202,7 +202,7 @@ public class XtextContentAssistTest extends AbstractXtextTests implements Resour
     @Test public void testCompleteAfterGrammarName_02() throws Exception {
     	newBuilder()
         .append("grammar org.foo.bar ")
-        .assertText("with", "Name", "enum", "terminal", "fragment", "hidden", "generate", "import", "@", "@Override");
+        .assertText("with", "Name", "enum", "terminal", "fragment", "hidden", "generate", "import", "@", "@Override", "@Deprecated", "@Exported", "@Final");
     }
     
     @Test public void testCompleteAfterGenerateName_01() throws Exception {


### PR DESCRIPTION
[eclipse/xtext-core#664] Fixed Content Assist Tests regarding new grammar annotations

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>