### PR TITLE
[eclipse/xtext-core#517] Moved Class File Constant Calculation to JavaVersion Enum

### DIFF
--- a/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.xtend
+++ b/org.eclipse.xtext.xbase.junit/src/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.xtend
@@ -18,7 +18,6 @@ import org.eclipse.jdt.core.compiler.CategorizedProblem
 import org.eclipse.jdt.internal.compiler.Compiler
 import org.eclipse.jdt.internal.compiler.DefaultErrorHandlingPolicies
 import org.eclipse.jdt.internal.compiler.batch.CompilationUnit
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment
@@ -29,7 +28,6 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.Data
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.eclipse.xtext.util.JavaVersion
-import org.eclipse.xtext.xbase.compiler.InMemoryJavaCompiler.Result
 
 /**
  * 
@@ -147,13 +145,7 @@ class InMemoryJavaCompiler {
 	}
 	
 	private def long toClassFmt(JavaVersion version) {
-		switch(version) {
-			case JAVA5: return ClassFileConstants.JDK1_5
-			case JAVA6: return ClassFileConstants.JDK1_6
-			case JAVA7: return ClassFileConstants.JDK1_7
-			case JAVA8: return ((ClassFileConstants.MAJOR_VERSION_1_7 + 1) << 16) + ClassFileConstants.MINOR_VERSION_0 // ClassFileConstants.JDK1_8
-			case JAVA9: return ((ClassFileConstants.MAJOR_VERSION_1_7 + 2) << 16) + ClassFileConstants.MINOR_VERSION_0 // ClassFileConstants.JDK1_9
-		}
+		version.toJdtClassFileConstant
 	}
 	
 	/**

--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
@@ -24,7 +24,6 @@ import org.eclipse.jdt.internal.compiler.DefaultErrorHandlingPolicies;
 import org.eclipse.jdt.internal.compiler.ICompilerRequestor;
 import org.eclipse.jdt.internal.compiler.IErrorHandlingPolicy;
 import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
@@ -234,23 +233,7 @@ public class InMemoryJavaCompiler {
   }
   
   private long toClassFmt(final JavaVersion version) {
-    if (version != null) {
-      switch (version) {
-        case JAVA5:
-          return ClassFileConstants.JDK1_5;
-        case JAVA6:
-          return ClassFileConstants.JDK1_6;
-        case JAVA7:
-          return ClassFileConstants.JDK1_7;
-        case JAVA8:
-          return (((ClassFileConstants.MAJOR_VERSION_1_7 + 1) << 16) + ClassFileConstants.MINOR_VERSION_0);
-        case JAVA9:
-          return (((ClassFileConstants.MAJOR_VERSION_1_7 + 2) << 16) + ClassFileConstants.MINOR_VERSION_0);
-        default:
-          break;
-      }
-    }
-    return 0;
+    return version.toJdtClassFileConstant();
   }
   
   /**

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/JavaVersionExtendedTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/JavaVersionExtendedTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.xbase.ui.tests;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.xtext.util.JavaVersion;
+import org.junit.Test;
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ */
+public class JavaVersionExtendedTest {
+
+	@Test
+	public void testToJdtClassFileConstant() {
+		assertEquals(ClassFileConstants.JDK1_5, JavaVersion.JAVA5.toJdtClassFileConstant());
+		assertEquals(ClassFileConstants.JDK1_6, JavaVersion.JAVA6.toJdtClassFileConstant());
+		assertEquals(ClassFileConstants.JDK1_7, JavaVersion.JAVA7.toJdtClassFileConstant());
+		try {
+			long value = ClassFileConstants.class.getField("JDK1_8").getLong(null);
+			assertEquals(value, JavaVersion.JAVA8.toJdtClassFileConstant());
+		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException | SecurityException e) {
+			// ok
+		}
+		try {
+			long value = ClassFileConstants.class.getField("JDK9").getLong(null);
+			assertEquals(value, JavaVersion.JAVA9.toJdtClassFileConstant());
+		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException | SecurityException e) {
+			// ok
+		}
+	}
+
+}


### PR DESCRIPTION
[eclipse/xtext#2578] Moved Class File Constant Calculation to JavaVersion Enum

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>