### PR TITLE
Null safe read only and modify

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/AbstractDocumentSimulatingTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/AbstractDocumentSimulatingTest.java
@@ -23,6 +23,7 @@ import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.IXtextDocumentContentObserver;
 import org.eclipse.xtext.ui.editor.model.IXtextModelListener;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork.Void;
 
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
@@ -311,12 +312,25 @@ public abstract class AbstractDocumentSimulatingTest extends AbstractXtextTests 
 		return null;
 	}
 	
+	@Deprecated
 	@Override
 	public <T> T readOnly(IUnitOfWork<T, XtextResource> work) {
 		fail("Unexpected call");
 		return null;
 	}
+	
+	@Override
+	public <T> T readOnly(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+		fail("Unexpected call");
+		return null;
+	}
 
+	@Override
+	public boolean readOnly(Void<XtextResource> work) {
+		fail("Unexpected call");
+		return false;
+	}
+	
 	@Override
 	public ITypedRegion[] computePartitioning(String partitioning, int offset, int length,
 			boolean includeZeroLengthPartitions) throws BadLocationException, BadPartitioningException {

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/DirtyStateEditorSupportTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/DirtyStateEditorSupportTest.java
@@ -45,6 +45,7 @@ import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.IXtextModelListener;
 import org.eclipse.xtext.ui.notification.StateChangeEventBroker;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork.Void;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -336,6 +337,7 @@ public class DirtyStateEditorSupportTest extends AbstractDocumentSimulatingTest
 		return "myContents";
 	}
 	
+	@Deprecated
 	@Override
 	public <T> T readOnly(IUnitOfWork<T, XtextResource> work) {
 		try {
@@ -344,12 +346,37 @@ public class DirtyStateEditorSupportTest extends AbstractDocumentSimulatingTest
 			throw new RuntimeException(e);
 		}
 	}
-
+	
+	@Override
+	public boolean readOnly(Void<XtextResource> work) {
+		Object success = readOnly(Boolean.FALSE, work);
+		// Void always returns null
+		return success == null;
+	}
+	
+	@Override
+	public <T> T readOnly(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+		if (resource == null) return defaultValue;
+		
+		return readOnly(defaultValue, work);
+	}
+	
+	@Deprecated
 	@Override
 	public <T> T priorityReadOnly(IUnitOfWork<T, XtextResource> work) {
 		return readOnly(work);
 	}
-
+	
+	@Override
+	public <T> T priorityReadOnly(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+		return readOnly(defaultValue, work);
+	}
+	
+	@Override
+	public boolean priorityReadOnly(Void<XtextResource> work) {
+		return readOnly(work);
+	}
+	
 	@Override
 	public Shell getShell() {
 		fail("Unexpected call");

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/DocumentBasedDirtyResourceTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/DocumentBasedDirtyResourceTest.java
@@ -31,6 +31,7 @@ import org.eclipse.xtext.ui.editor.DocumentBasedDirtyResource;
 import org.eclipse.xtext.ui.editor.model.ILexerTokenRegion;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork.Void;
 import org.junit.Test;
 
 /**
@@ -189,6 +190,7 @@ public class DocumentBasedDirtyResourceTest extends AbstractDocumentSimulatingTe
 		return documentContent;
 	}
 
+	@Deprecated
 	@Override
 	public <T> T readOnly(IUnitOfWork<T, XtextResource> work) {
 		try {
@@ -199,7 +201,32 @@ public class DocumentBasedDirtyResourceTest extends AbstractDocumentSimulatingTe
 	}
 	
 	@Override
+	public boolean readOnly(Void<XtextResource> work) {
+		Object success = readOnly(Boolean.FALSE, work);
+		// Void always returns null
+		return success == null;
+	}
+	
+	@Override
+	public <T> T readOnly(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+		if (resource == null) return defaultValue;
+		
+		return readOnly(defaultValue, work);
+	}
+	
+	@Deprecated
+	@Override
 	public <T> T priorityReadOnly(IUnitOfWork<T, XtextResource> work) {
+		return readOnly(work);
+	}
+	
+	@Override
+	public <T> T priorityReadOnly(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+		return readOnly(defaultValue, work);
+	}
+	
+	@Override
+	public boolean priorityReadOnly(Void<XtextResource> work) {
 		return readOnly(work);
 	}
 

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.xtend
@@ -39,18 +39,18 @@ class DocumentLockerTest extends AbstractXtextDocumentTest {
 			new XtextResourceSet().resources += it
 		]
 		assertEquals(0, s.size)
-		document.readOnly [
+		val size1 = document.readOnly [
 			assertEquals(1, s.size)
-			document.readOnly [
+			val size2 = document.readOnly [
 				assertEquals(1, s.size)
-				document.readOnly [
+				val size3 = document.readOnly [
 					assertEquals(1, s.size)
-					return null
 				]
-				return null
+				assertTrue("Assert was not executed due to null resource in readOnly", size3)
 			]
-			return null
+			assertTrue("Assert was not executed due to null resource in readOnly", size2)
 		]
+		assertTrue("Assert was not executed due to null resource in readOnly", size1)
 		assertEquals(1, s.size)
 	}
 
@@ -60,18 +60,20 @@ class DocumentLockerTest extends AbstractXtextDocumentTest {
 			new XtextResourceSet().resources += it
 		]
 		document.input = resource
-		document.internalModify [
+		val modify1 = document.internalModify(Boolean.FALSE) [
 			assertFalse(document.cancelIndicator.isCanceled())
 			null
 		]
+		assertNull("Failed to modify resource due to null resource in readOnly", modify1)
 		val indicator = document.cancelIndicator
 		assertFalse(indicator.isCanceled())
 		document.set("fupp");
 		assertTrue(indicator.isCanceled())
-		document.internalModify [
+		val modify2 = document.internalModify(Boolean.FALSE) [
 			assertFalse(document.cancelIndicator.isCanceled())
 			null
 		]
+		assertNull("Failed to modify resource due to null resource in readOnly", modify2)
 	}
 	
 	@Test def void testPriorityReadOnlyCancelsReaders() {
@@ -81,7 +83,7 @@ class DocumentLockerTest extends AbstractXtextDocumentTest {
 		]
 		val boolean[] check = newBooleanArrayOfSize(1) 
 		val thread = new Thread([
-			document.readOnly(new CancelableUnitOfWork<Object, XtextResource>() {
+			val success = document.readOnly(Boolean.FALSE, new CancelableUnitOfWork<Object, XtextResource>() {
 				override Object exec(XtextResource state, CancelIndicator cancelIndicator) throws Exception {
 					check.set(0,true)
 					val wait = 4000;
@@ -94,16 +96,17 @@ class DocumentLockerTest extends AbstractXtextDocumentTest {
 					}
 					return null;
 				}
-				
 			})
+			assertNull("Failed to read resource due to null resource in readOnly", success)
 		])
 		thread.start
 		while (!check.get(0)) {
 			Thread.sleep(1)
 		}
-		document.priorityReadOnly[
+		val success = document.priorityReadOnly(Boolean.FALSE)[
 			null
 		]
+		assertNull("Failed to read resource due to null resource in priorityReadOnly", success)
 		assertFalse(thread.interrupted)
 	}
 	
@@ -115,9 +118,11 @@ class DocumentLockerTest extends AbstractXtextDocumentTest {
 		val cancelIndicators = newArrayList
 		document.addReaderCancelationListener(cancelIndicators)
 		assertTrue(cancelIndicators.empty)
-		document.readOnly[]
+		val success1 = document.readOnly(Boolean.FALSE)[null]
+		assertNull("Failed to read resource due to null resource in readOnly", success1)
 		assertTrue(cancelIndicators.empty)
-		document.readOnly[]
+		val success2 = document.readOnly(Boolean.FALSE)[null]
+		assertNull("Failed to read resource due to null resource in readOnly", success2)
 		assertTrue(cancelIndicators.empty)
 	}
 	
@@ -153,7 +158,8 @@ class DocumentLockerTest extends AbstractXtextDocumentTest {
 				assertFalse(cancelIndicator.isCanceled)
 				cancelIndicators += cancelIndicator
 			]
-			document.readOnly(work)
+			val workResult = document.readOnly(null, work)
+			assertNotNull("Failed to read resource due to null resource in readOnly", workResult)
 		]
 	} 
 }

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/edit/XtextDocumentModifyTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/edit/XtextDocumentModifyTest.java
@@ -149,6 +149,15 @@ public class XtextDocumentModifyTest extends AbstractXtextTests {
 			}});
 		
 		final XtextDocument document = new XtextDocument(tokenSource, get(ITextEditComposer.class), new OutdatedStateManager(), new OperationCanceledManager()) {
+			
+			@Override
+			public <T> T internalModify(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+				if (resource == null) return defaultValue;
+				
+				return internalModify(work);
+			}
+			
+			@Deprecated
 			@Override
 			public <T> T internalModify(IUnitOfWork<T, XtextResource> work) {
 				try {

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.java
@@ -58,21 +58,30 @@ public class DocumentLockerTest extends AbstractXtextDocumentTest {
     XtextResource _doubleArrow = ObjectExtensions.<XtextResource>operator_doubleArrow(_xtextResource, _function);
     document.setInput(_doubleArrow);
     Assert.assertEquals(0, s.size());
-    final IUnitOfWork<Object, XtextResource> _function_1 = (XtextResource it) -> {
-      Assert.assertEquals(1, s.size());
-      final IUnitOfWork<Object, XtextResource> _function_2 = (XtextResource it_1) -> {
+    final IUnitOfWork.Void<XtextResource> _function_1 = new IUnitOfWork.Void<XtextResource>() {
+      @Override
+      public void process(final XtextResource it) throws Exception {
         Assert.assertEquals(1, s.size());
-        final IUnitOfWork<Object, XtextResource> _function_3 = (XtextResource it_2) -> {
-          Assert.assertEquals(1, s.size());
-          return null;
+        final IUnitOfWork.Void<XtextResource> _function = new IUnitOfWork.Void<XtextResource>() {
+          @Override
+          public void process(final XtextResource it) throws Exception {
+            Assert.assertEquals(1, s.size());
+            final IUnitOfWork.Void<XtextResource> _function = new IUnitOfWork.Void<XtextResource>() {
+              @Override
+              public void process(final XtextResource it) throws Exception {
+                Assert.assertEquals(1, s.size());
+              }
+            };
+            final boolean size3 = document.readOnly(_function);
+            Assert.assertTrue("Assert was not executed due to null resource in readOnly", size3);
+          }
         };
-        document.<Object>readOnly(_function_3);
-        return null;
-      };
-      document.<Object>readOnly(_function_2);
-      return null;
+        final boolean size2 = document.readOnly(_function);
+        Assert.assertTrue("Assert was not executed due to null resource in readOnly", size2);
+      }
     };
-    document.<Object>readOnly(_function_1);
+    final boolean size1 = document.readOnly(_function_1);
+    Assert.assertTrue("Assert was not executed due to null resource in readOnly", size1);
     Assert.assertEquals(1, s.size());
   }
   
@@ -88,28 +97,30 @@ public class DocumentLockerTest extends AbstractXtextDocumentTest {
     };
     final XtextResource resource = ObjectExtensions.<XtextResource>operator_doubleArrow(_xtextResource, _function);
     document.setInput(resource);
-    final IUnitOfWork<Object, XtextResource> _function_1 = (XtextResource it) -> {
+    final IUnitOfWork<Boolean, XtextResource> _function_1 = (XtextResource it) -> {
       Object _xblockexpression = null;
       {
         Assert.assertFalse(document.getCancelIndicator().isCanceled());
         _xblockexpression = null;
       }
-      return _xblockexpression;
+      return ((Boolean)_xblockexpression);
     };
-    document.<Object>internalModify(_function_1);
+    final Boolean modify1 = document.<Boolean>internalModify(Boolean.FALSE, _function_1);
+    Assert.assertNull("Failed to modify resource due to null resource in readOnly", modify1);
     final CancelIndicator indicator = document.getCancelIndicator();
     Assert.assertFalse(indicator.isCanceled());
     document.set("fupp");
     Assert.assertTrue(indicator.isCanceled());
-    final IUnitOfWork<Object, XtextResource> _function_2 = (XtextResource it) -> {
+    final IUnitOfWork<Boolean, XtextResource> _function_2 = (XtextResource it) -> {
       Object _xblockexpression = null;
       {
         Assert.assertFalse(document.getCancelIndicator().isCanceled());
         _xblockexpression = null;
       }
-      return _xblockexpression;
+      return ((Boolean)_xblockexpression);
     };
-    document.<Object>internalModify(_function_2);
+    final Boolean modify2 = document.<Boolean>internalModify(Boolean.FALSE, _function_2);
+    Assert.assertNull("Failed to modify resource due to null resource in readOnly", modify2);
   }
   
   @Test
@@ -126,7 +137,7 @@ public class DocumentLockerTest extends AbstractXtextDocumentTest {
       document.setInput(_doubleArrow);
       final boolean[] check = new boolean[1];
       final Runnable _function_1 = () -> {
-        document.<Object>readOnly(new CancelableUnitOfWork<Object, XtextResource>() {
+        final Object success = document.<Object>readOnly(Boolean.FALSE, new CancelableUnitOfWork<Object, XtextResource>() {
           @Override
           public Object exec(final XtextResource state, final CancelIndicator cancelIndicator) throws Exception {
             check[0] = true;
@@ -144,16 +155,18 @@ public class DocumentLockerTest extends AbstractXtextDocumentTest {
             return null;
           }
         });
+        Assert.assertNull("Failed to read resource due to null resource in readOnly", success);
       };
       final Thread thread = new Thread(_function_1);
       thread.start();
       while ((!check[0])) {
         Thread.sleep(1);
       }
-      final IUnitOfWork<Object, XtextResource> _function_2 = (XtextResource it) -> {
+      final IUnitOfWork<Boolean, XtextResource> _function_2 = (XtextResource it) -> {
         return null;
       };
-      document.<Object>priorityReadOnly(_function_2);
+      final Boolean success = document.<Boolean>priorityReadOnly(Boolean.FALSE, _function_2);
+      Assert.assertNull("Failed to read resource due to null resource in priorityReadOnly", success);
       Assert.assertFalse(thread.isInterrupted());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -174,15 +187,17 @@ public class DocumentLockerTest extends AbstractXtextDocumentTest {
     final ArrayList<CancelIndicator> cancelIndicators = CollectionLiterals.<CancelIndicator>newArrayList();
     this.addReaderCancelationListener(document, cancelIndicators);
     Assert.assertTrue(cancelIndicators.isEmpty());
-    final IUnitOfWork<Object, XtextResource> _function_1 = (XtextResource it) -> {
+    final IUnitOfWork<Boolean, XtextResource> _function_1 = (XtextResource it) -> {
       return null;
     };
-    document.<Object>readOnly(_function_1);
+    final Boolean success1 = document.<Boolean>readOnly(Boolean.FALSE, _function_1);
+    Assert.assertNull("Failed to read resource due to null resource in readOnly", success1);
     Assert.assertTrue(cancelIndicators.isEmpty());
-    final IUnitOfWork<Object, XtextResource> _function_2 = (XtextResource it) -> {
+    final IUnitOfWork<Boolean, XtextResource> _function_2 = (XtextResource it) -> {
       return null;
     };
-    document.<Object>readOnly(_function_2);
+    final Boolean success2 = document.<Boolean>readOnly(Boolean.FALSE, _function_2);
+    Assert.assertNull("Failed to read resource due to null resource in readOnly", success2);
     Assert.assertTrue(cancelIndicators.isEmpty());
   }
   
@@ -233,7 +248,8 @@ public class DocumentLockerTest extends AbstractXtextDocumentTest {
         }
       };
       final CancelableUnitOfWork<Boolean, XtextResource> work = _function_1;
-      document.<Boolean>readOnly(work);
+      final Boolean workResult = document.<Boolean>readOnly(null, work);
+      Assert.assertNotNull("Failed to read resource due to null resource in readOnly", workResult);
     };
     document.addModelListener(_function);
   }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/IXtextDocumentContentObserver.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/IXtextDocumentContentObserver.java
@@ -27,7 +27,7 @@ public interface IXtextDocumentContentObserver extends IDocumentListener {
 
 	/**
 	 * Called by the document before any client requests access to an IXtextDocument's state via
-	 * {@link IXtextDocument#readOnly(IUnitOfWork)} or {@link IXtextDocument#modify(IUnitOfWork)}
+	 * {@link IXtextDocument#readOnly(Object, IUnitOfWork)} or {@link IXtextDocument#modify(Object, IUnitOfWork)}
 	 * 
 	 * Implementers get the chance to do any work using the passed {@link Processor}
 	 * 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocument.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocument.java
@@ -201,7 +201,14 @@ public class XtextDocument extends Document implements IXtextDocument {
 		IUnitOfWork<T, XtextResource> reconcilingUnitOfWork = reconcilingUnitOfWorkProvider.<T>get(work, this, composer);
 		return internalModify(defaultValue, reconcilingUnitOfWork);
 	}
-
+	
+	@Override
+	public boolean modify(Void<XtextResource> work) {
+		Object success = modify(Boolean.FALSE, work);
+		// Void.exec() always returns null
+		return success == null;
+	}
+	
 	/**
 	 * @deprecated use {@link #modify(Object, IUnitOfWork)} instead
 	 */
@@ -486,6 +493,13 @@ public class XtextDocument extends Document implements IXtextDocument {
 			if (state == null) return defaultValue;
 
 			return internalGetReadOnlyLockAndModify(work, state);
+		}
+		
+		@Override
+		public boolean modify(IUnitOfWork.Void<XtextResource> work) {
+			Object success = modify(Boolean.FALSE, work);
+			// Void.exec() always returns null
+			return success == null;
 		}
 		
 		/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocument.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocument.java
@@ -51,7 +51,10 @@ import org.eclipse.xtext.ui.editor.model.edit.ReconcilingUnitOfWork.ReconcilingU
 import org.eclipse.xtext.ui.util.DisplayRunnable;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.concurrent.CancelableUnitOfWork;
+import org.eclipse.xtext.util.concurrent.IReadAccess;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork.Void;
+import org.eclipse.xtext.util.concurrent.IWriteAccess;
 
 import com.google.inject.Inject;
 
@@ -107,7 +110,7 @@ public class XtextDocument extends Document implements IXtextDocument {
 		if (validationJob != null) {
 			validationJob.cancel();
 		}
-		internalModify(new IUnitOfWork.Void<XtextResource>() {
+		internalModify(null, new IUnitOfWork.Void<XtextResource>() {
 			@Override
 			public void process(XtextResource state) throws Exception {
 				// the resource may already be null if the document was opened for a bogus
@@ -130,17 +133,59 @@ public class XtextDocument extends Document implements IXtextDocument {
 		return new XtextDocumentLocker();
 	}
 
+	/**
+	 * Warning: The XtextResource passed to {@code work} is nullable!
+	 * 
+	 * @deprecated use {@link #readOnly(Object, IUnitOfWork) instead}
+	 */
+	@Deprecated
 	@Override
 	public <T> T readOnly(IUnitOfWork<T, XtextResource> work) {
 		T readOnly = stateAccess.readOnly(work);
 		return readOnly;
 	}
-	
+
 	/**
-	 * @since 2.7
+	 * @since 2.14
 	 */
 	@Override
+	public <T> T readOnly(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+		return stateAccess.readOnly(defaultValue, work);
+	}
+	
+	/**
+	 * @since 2.14
+	 */
+	@Override
+	public boolean readOnly(Void<XtextResource> work) {
+		return stateAccess.readOnly(work);
+	}
+	
+	/**
+	 * Warning: The XtextResource passed to {@code work} is nullable!
+	 * 
+	 * @deprecated use {@link #priorityReadOnly(Object, IUnitOfWork) instead}
+	 * @since 2.7
+	 */
+	@Deprecated
+	@Override
 	public <T> T priorityReadOnly(IUnitOfWork<T, XtextResource> work) {
+		return stateAccess.priorityReadOnly(work);
+	}
+
+	/**
+	 * @since 2.14
+	 */
+	@Override
+	public <T> T priorityReadOnly(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+		return stateAccess.priorityReadOnly(defaultValue, work);
+	}
+
+	/**
+	 * @since 2.14
+	 */
+	@Override
+	public boolean priorityReadOnly(Void<XtextResource> work) {
 		return stateAccess.priorityReadOnly(work);
 	}
 	
@@ -149,6 +194,18 @@ public class XtextDocument extends Document implements IXtextDocument {
 		public void process(XtextResource state) throws Exception {}
 	};
 
+	@Override
+	public <T> T modify(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+		// do a dummy read only, to make sure any scheduled changes get applied.
+		readOnly(noWork);
+		IUnitOfWork<T, XtextResource> reconcilingUnitOfWork = reconcilingUnitOfWorkProvider.<T>get(work, this, composer);
+		return internalModify(defaultValue, reconcilingUnitOfWork);
+	}
+
+	/**
+	 * @deprecated use {@link #modify(Object, IUnitOfWork)} instead
+	 */
+	@Deprecated
 	@Override
 	public <T> T modify(IUnitOfWork<T, XtextResource> work) {
 		// do a dummy read only, to make sure any scheduled changes get applied.
@@ -159,9 +216,18 @@ public class XtextDocument extends Document implements IXtextDocument {
 
 	/**
 	 * Modifies the document's semantic model without reconciling the text nor the node model. For internal use only.
+	 * @deprecated use {@link #internalModify(Object, IUnitOfWork)} instead
 	 */
+	@Deprecated
 	public <T> T internalModify(IUnitOfWork<T, XtextResource> work) {
 		return stateAccess.modify(work);
+	}
+	
+	/**
+	 * Modifies the document's semantic model without reconciling the text nor the node model. For internal use only.
+	 */
+	public <T> T internalModify(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+		return stateAccess.modify(defaultValue, work);
 	}
 
 	protected void ensureThatStateIsNotReturned(Object exec, IUnitOfWork<?, XtextResource> uow) {
@@ -295,7 +361,7 @@ public class XtextDocument extends Document implements IXtextDocument {
 	 * @author Sven Efftinge - Initial contribution and API
 	 * 
 	 */
-	protected class XtextDocumentLocker implements Processor {
+	protected class XtextDocumentLocker implements Processor, IReadAccess<XtextResource>, IWriteAccess<XtextResource>, Priority<XtextResource> {
 		
 		private AtomicInteger potentialUpdaterCount = new AtomicInteger(0);
 		
@@ -336,7 +402,7 @@ public class XtextDocument extends Document implements IXtextDocument {
 			try {
 				if (log.isTraceEnabled())
 					log.trace("process - " + Thread.currentThread().getName());
-				return this.modify(transaction);
+				return this.modify(null, transaction);
 			} finally {
 				if (log.isTraceEnabled())
 					log.trace("Downgrading from write lock to read lock...");
@@ -414,10 +480,28 @@ public class XtextDocument extends Document implements IXtextDocument {
 			return resource;
 		}
 
+		@Override
+		public <T> T modify(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+			XtextResource state = getState();
+			if (state == null) return defaultValue;
+
+			return internalGetReadOnlyLockAndModify(work, state);
+		}
+		
+		/**
+		 * Warning: The XtextResource passed to {@code work} is nullable!
+		 * 
+		 * @deprecated use {@link #modify(Object, IUnitOfWork)} instead
+		 */
+		@Deprecated
+		@Override
 		public <T> T modify(IUnitOfWork<T, XtextResource> work) {
+			return internalGetReadOnlyLockAndModify(work, getState());
+		}
+
+		protected <T> T internalGetReadOnlyLockAndModify(IUnitOfWork<T, XtextResource> work, XtextResource state) {
 			boolean isCancelable = work instanceof CancelableUnitOfWork;
 			try {
-				XtextResource state = getState();
 				try {
 					synchronized (getResourceLock()) {
 						acquireWriteLock();
@@ -480,25 +564,66 @@ public class XtextDocument extends Document implements IXtextDocument {
 		}
 		
 		/**
+		 * Warning: The XtextResource passed to {@code work} is nullable!
 		 * 
+		 * @deprecated use {@link #priorityReadOnly(Object, IUnitOfWork) instead}
 		 * @since 2.7
 		 */
+		@Deprecated
+		@Override
 		public <T> T priorityReadOnly(IUnitOfWork<T, XtextResource> work) {
 			return internalReadOnly(work, true);
 		}
 		
+		@Override
+		public boolean priorityReadOnly(Void<XtextResource> work) {
+			Object success = priorityReadOnly(Boolean.FALSE, work);
+			// Void.exec() always returns null
+			return success == null;
+		}
+		
 		/**
+		 * @since 2.14
+		 */
+		@Override
+		public <T> T priorityReadOnly(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+			return internalReadOnly(work, true, defaultValue);
+		}
+		
+		/**
+		 * Warning: The XtextResource passed to {@code work} is nullable!
+		 * 
+		 * @deprecated use {@link #readOnly(Object, IUnitOfWork) instead}
 		 * @since 2.4
 		 */
+		@Deprecated
+		@Override
 		public <T> T readOnly(IUnitOfWork<T, XtextResource> work) {
 			return internalReadOnly(work, false);
 		}
 
 		/**
-		 * @since 2.7
+		 * @since 2.14
 		 */
-		protected <T> T internalReadOnly(IUnitOfWork<T, XtextResource> work, boolean isCancelReaders) {
-			boolean isCancelable = work instanceof CancelableUnitOfWork;
+		@Override
+		public boolean readOnly(Void<XtextResource> work) {
+			Object success = readOnly(Boolean.FALSE, work);
+			// Void.exec() always returns null
+			return success == null;
+		}
+		
+		/**
+		 * @since 2.14
+		 */
+		@Override
+		public <T> T readOnly(T defaultValue, IUnitOfWork<T, XtextResource> work) {
+			return internalReadOnly(work, false, defaultValue);
+		}
+
+		/**
+		 * @since 2.14
+		 */
+		protected <T> T internalReadOnly(IUnitOfWork<T, XtextResource> work, boolean isCancelReaders, T defaultValue) {
 			if(isCancelReaders) {
 				if (Display.getCurrent() == null) {
 					log.error("Priority read only called from non UI-thread.", new IllegalStateException());
@@ -506,6 +631,22 @@ public class XtextDocument extends Document implements IXtextDocument {
 				cancelReaders(resource);
 			}
 			XtextResource state = getState();
+			if (state == null) return defaultValue;
+
+			return internalGetReadOnlyLockAndExecute(work, isCancelReaders, state);
+		}
+		
+		/**
+		 * @deprecated use {@link #internalReadOnly(IUnitOfWork, boolean, Object)} instead
+		 * @since 2.7
+		 */
+		@Deprecated
+		protected <T> T internalReadOnly(IUnitOfWork<T, XtextResource> work, boolean isCancelReaders) {
+			return internalGetReadOnlyLockAndExecute(work, isCancelReaders, getState());
+		}
+		
+		protected <T> T internalGetReadOnlyLockAndExecute(IUnitOfWork<T, XtextResource> work, boolean isCancelReaders, XtextResource state) {
+			boolean isCancelable = work instanceof CancelableUnitOfWork;
 			synchronized (getResourceLock()) {
 				acquireReadLock();
 				if(isCancelReaders) 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/DocumentRootNode.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/DocumentRootNode.java
@@ -55,15 +55,25 @@ public class DocumentRootNode extends AbstractOutlineNode {
 	}
 
 	@Override
+	public <T> T readOnly(T defaultValue, IUnitOfWork<T, EObject> work) {
+		return document.readOnly(defaultValue, getSafeUnitOfWork(work));
+	}
+	
+	@Deprecated
+	@Override
 	public <T> T readOnly(final IUnitOfWork<T, EObject> work) {
-		return document.readOnly(new IUnitOfWork<T, XtextResource>() {
+		return readOnly(null, work);
+	}
+	
+	protected <T> IUnitOfWork<T, XtextResource> getSafeUnitOfWork(final IUnitOfWork<T, EObject> work) {
+		return new IUnitOfWork<T, XtextResource>() {
 			@Override
 			public T exec(XtextResource resource) throws Exception {
-				if(resource != null && !resource.getContents().isEmpty()) {
+				if(!resource.getContents().isEmpty()) {
 					return work.exec(resource.getContents().get(0));
 				}
 				return null;
 			}
-		});
+		};
 	}
 }


### PR DESCRIPTION
Solution to eclipse/xtext-eclipse#587
In combination with https://github.com/eclipse/xtext-core/pull/677