### PR TITLE
[NONE] Fix broken link in StatemachineFormatter of the fowlerdsl example

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/formatting/StatemachineFormatter.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/formatting/StatemachineFormatter.xtend
@@ -14,7 +14,7 @@ import org.eclipse.xtext.formatting.impl.FormattingConfig
  * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#formatting
  * on how and when to use it.
  * 
- * Also see {@link org.eclipse.xtext.xtext.XtextFormattingTokenSerializer} as an example
+ * Also see {@link org.eclipse.xtext.xtext.XtextFormatter} as an example
  */
 class StatemachineFormatter extends AbstractDeclarativeFormatter {
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/xtend-gen/org/eclipse/xtext/example/fowlerdsl/formatting/StatemachineFormatter.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/xtend-gen/org/eclipse/xtext/example/fowlerdsl/formatting/StatemachineFormatter.java
@@ -12,7 +12,7 @@ import org.eclipse.xtext.formatting.impl.FormattingConfig;
  * See https://www.eclipse.org/Xtext/documentation/303_runtime_concepts.html#formatting
  * on how and when to use it.
  * 
- * Also see {@link org.eclipse.xtext.xtext.XtextFormattingTokenSerializer} as an example
+ * Also see {@link org.eclipse.xtext.xtext.XtextFormatter} as an example
  */
 @SuppressWarnings("all")
 public class StatemachineFormatter extends AbstractDeclarativeFormatter {


### PR DESCRIPTION
See also https://github.com/eclipse/xtext-extras/issues/70

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>