### PR TITLE
[eclipse/xtext-eclipse#626] fixed java project factory referencedProjects bug

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JavaProjectFactory.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JavaProjectFactory.java
@@ -52,7 +52,7 @@ public class JavaProjectFactory extends ProjectFactory {
 				subMonitor.subTask(Messages.JavaProjectFactory_ConfigureJavaProject + projectName);
 				IJavaProject javaProject = JavaCore.create(project);
 				List<IClasspathEntry> classpathEntries = new ArrayList<IClasspathEntry>();
-				for (final IProject referencedProject : project.getReferencingProjects()) {
+				for (final IProject referencedProject : project.getReferencedProjects()) {
 					final IClasspathEntry referencedProjectClasspathEntry = JavaCore.newProjectEntry(referencedProject
 							.getFullPath());
 					classpathEntries.add(referencedProjectClasspathEntry);


### PR DESCRIPTION
[eclipse/xtext-eclipse#626] fixed java project factory referencedProjects bug

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>