### PR TITLE
[NONE] Fix indentation in the formatter of the homeautomation example.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.xtend
@@ -19,7 +19,7 @@ import static org.eclipse.xtext.xbase.XbasePackage.Literals.*
 
 class RuleEngineFormatter extends XbaseFormatter {
 	
-		def dispatch void format(Model model, extension IFormattableDocument document) {
+	def dispatch void format(Model model, extension IFormattableDocument document) {
 		model.prepend[setNewLines(0, 0, 1); noSpace]
 		for (Declaration declaration : model.getDeclarations()) {
 			declaration.format.append[setNewLines(1, 1, 2)]


### PR DESCRIPTION
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>