### PR TITLE
[#631] Example generators java classes with upper case letter.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/generator/StatemachineGenerator.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/generator/StatemachineGenerator.xtend
@@ -24,7 +24,7 @@ class StatemachineGenerator extends AbstractGenerator {
 	
 	def className(Resource res) {
 		var name = res.URI.lastSegment
-		return name.substring(0, name.indexOf('.'))
+		return name.substring(0, name.indexOf('.')).toFirstUpper
 	}
 	
 	def toJavaCode(Statemachine sm) '''

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/xtend-gen/org/eclipse/xtext/example/fowlerdsl/generator/StatemachineGenerator.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/xtend-gen/org/eclipse/xtext/example/fowlerdsl/generator/StatemachineGenerator.java
@@ -37,7 +37,7 @@ public class StatemachineGenerator extends AbstractGenerator {
   
   public String className(final Resource res) {
     String name = res.getURI().lastSegment();
-    return name.substring(0, name.indexOf("."));
+    return StringExtensions.toFirstUpper(name.substring(0, name.indexOf(".")));
   }
   
   public CharSequence toJavaCode(final Statemachine sm) {

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/jvmmodel/RuleEngineJvmModelInferrer.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/jvmmodel/RuleEngineJvmModelInferrer.xtend
@@ -28,7 +28,7 @@ class RuleEngineJvmModelInferrer extends AbstractModelInferrer {
 	@Inject extension JvmTypesBuilder
 
 	def dispatch void infer(Model element, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
-		val className = element.eResource.URI.trimFileExtension.lastSegment
+		val className = element.eResource.URI.trimFileExtension.lastSegment.toFirstUpper
 		acceptor.accept(element.toClass(className)) [
 			for (device : element.declarations.filter(Rule)) {
 				members += device.toMethod(getRuleMethodName(device), typeRef(void)) [

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/jvmmodel/RuleEngineJvmModelInferrer.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/xtend-gen/org/eclipse/xtext/example/homeautomation/jvmmodel/RuleEngineJvmModelInferrer.java
@@ -29,6 +29,7 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
  * <p>Infers a JVM model from the source model.</p>
@@ -46,7 +47,7 @@ public class RuleEngineJvmModelInferrer extends AbstractModelInferrer {
   private JvmTypesBuilder _jvmTypesBuilder;
   
   protected void _infer(final Model element, final IJvmDeclaredTypeAcceptor acceptor, final boolean isPreIndexingPhase) {
-    final String className = element.eResource().getURI().trimFileExtension().lastSegment();
+    final String className = StringExtensions.toFirstUpper(element.eResource().getURI().trimFileExtension().lastSegment());
     final Procedure1<JvmGenericType> _function = (JvmGenericType it) -> {
       Iterable<Rule> _filter = Iterables.<Rule>filter(element.getDeclarations(), Rule.class);
       for (final Rule device : _filter) {


### PR DESCRIPTION
- Modify the Generators of the Xtext Homeautomation and the Xtext
State-Machine examples to generate java classes with upper case letters.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>