### PR TITLE
[eclipse/xtext-core#686] Update new project wizard.

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/PluginProjectFactory.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/PluginProjectFactory.java
@@ -48,7 +48,7 @@ public class PluginProjectFactory extends JavaProjectFactory {
 		this.getRequiredBundles().addAll(requiredBundles);
 		return this;
 	}
-	
+
 	/**
 	 * @since 2.14
 	 */
@@ -62,7 +62,7 @@ public class PluginProjectFactory extends JavaProjectFactory {
 		this.getExportedPackages().addAll(exportedPackages);
 		return this;
 	}
-	
+
 	/**
 	 * @since 2.14
 	 */
@@ -76,7 +76,7 @@ public class PluginProjectFactory extends JavaProjectFactory {
 		this.getImportedPackages().addAll(importedPackages);
 		return this;
 	}
-	
+
 	/**
 	 * @since 2.14
 	 */
@@ -130,6 +130,7 @@ public class PluginProjectFactory extends JavaProjectFactory {
 
 	protected void createManifest(IProject project, IProgressMonitor progressMonitor) throws CoreException {
 		final StringBuilder content = new StringBuilder("Manifest-Version: 1.0\n");
+		content.append("Automatic-Module-Name: " + projectName + "\n");
 		content.append("Bundle-ManifestVersion: 2\n");
 		content.append("Bundle-Name: " + projectName + "\n");
 		content.append("Bundle-Vendor: My Company\n");
@@ -171,7 +172,7 @@ public class PluginProjectFactory extends JavaProjectFactory {
 	 * 
 	 * @see JREContainerProvider#getDefaultBREE()
 	 * @param breeToUse
-	 *            - BREE to use (e.g. JavaSE-1.6)
+	 *                      - BREE to use (e.g. JavaSE-1.6)
 	 * @since 2.7
 	 */
 	public void setBreeToUse(String breeToUse) {
@@ -248,7 +249,7 @@ public class PluginProjectFactory extends JavaProjectFactory {
 		this.getDevelopmentTimeBundles().addAll(devTimeBundles);
 		return this;
 	}
-	
+
 	/**
 	 * @since 2.14
 	 */

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
@@ -34,7 +34,6 @@ class AdvancedNewProjectPage extends WizardPage {
 	Button createUiProject
 	Button createSDKProject
 	Button createP2Project
-	Button createIdeaProject
 	Button createWebProject
 	Button createIdeProject
 	Button createTestProject
@@ -71,10 +70,6 @@ class AdvancedNewProjectPage extends WizardPage {
 					createP2Project = CheckBox [
 						text = AdvancedNewProjectPage_projEclipseP2
 					]
-				]
-				createIdeaProject = CheckBox [
-					text = AdvancedNewProjectPage_projIdea
-					enabled = true
 				]
 				createWebProject = CheckBox [
 					text = AdvancedNewProjectPage_projWeb
@@ -124,7 +119,7 @@ class AdvancedNewProjectPage extends WizardPage {
 				validate(e)
 			}
 		}
-		val uiButtons = #[createUiProject,createIdeaProject,createWebProject]
+		val uiButtons = #[createUiProject,createWebProject]
 		val selectionControlUi = new SelectionAdapter() {
 			override widgetSelected(SelectionEvent e) {
 				if ((e.source as Button).selection) {
@@ -196,7 +191,6 @@ class AdvancedNewProjectPage extends WizardPage {
 		sourceLayout.addSelectionListener(selectionControl)
 		createTestProject.addSelectionListener(selectionControl)
 		createUiProject.addSelectionListener(selectionControlUi)
-		createIdeaProject.addSelectionListener(selectionControlUi)
 		createWebProject.addSelectionListener(selectionControlUi)
 		createIdeProject.addSelectionListener(selectionControl)
 		createSDKProject.addSelectionListener(selectionControl)
@@ -214,7 +208,7 @@ class AdvancedNewProjectPage extends WizardPage {
 	}
 
 	def checkWidgets(SelectionEvent e) {
-		val uiButtons = #[createUiProject,createIdeaProject,createWebProject]
+		val uiButtons = #[createUiProject,createWebProject]
 		
 		if (preferredBuildSystem.isSelected(BuildSystem.MAVEN) && !isBundleResolved("org.eclipse.m2e.maven.runtime")) {
 			reportIssue(WARNING, AdvancedNewProjectPage_noM2e)
@@ -225,14 +219,6 @@ class AdvancedNewProjectPage extends WizardPage {
 		if (preferredBuildSystem.isSelected(BuildSystem.GRADLE) && createUiProject.selection) {
 			reportIssue(WARNING,
 				AdvancedNewProjectPage_eclipseAndGradleWarn)
-		}
-		if (preferredBuildSystem.isSelected(BuildSystem.MAVEN) && createIdeaProject.selection) {
-			reportIssue(WARNING,
-				AdvancedNewProjectPage_ideaAndMavenWarn)
-		}
-		if (preferredBuildSystem.isSelected(BuildSystem.NONE) && createIdeaProject.selection) {
-			reportIssue(INFORMATION,
-				AdvancedNewProjectPage_ideaReqGradleInfo)
 		}
 		if (createUiProject.selection && createP2Project.selection && !createSDKProject.selection) {
 			addIssue(INFORMATION,
@@ -376,7 +362,6 @@ class AdvancedNewProjectPage extends WizardPage {
 		createUiProject.selection = true
 		createIdeProject.selection = true
 		createTestProject.selection = true
-		createIdeaProject.selection = false
 		createWebProject.selection = false
 		createSDKProject.selection = false
 		createP2Project.selection = false
@@ -395,10 +380,6 @@ class AdvancedNewProjectPage extends WizardPage {
 
 	def boolean isCreateIdeProject() {
 		createIdeProject.selection
-	}
-
-	def boolean isCreateIntellijProject() {
-		createIdeaProject.selection
 	}
 
 	def boolean isCreateWebProject() {

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/Messages.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/Messages.java
@@ -14,6 +14,7 @@ public class Messages extends NLS {
 	public static String WizardNewXtextProjectCreationPage_eeInfo_0;
 	public static String WizardNewXtextProjectCreationPage_eeInfo_1;
 	public static String WizardNewXtextProjectCreationPage_ErrorMessageExtensions;
+	public static String WizardNewXtextProjectCreationPage_MessageAtLeastJava8;
 	public static String WizardNewXtextProjectCreationPage_ErrorMessageLanguageName;
 	public static String WizardNewXtextProjectCreationPage_ErrorMessageLanguageNameWithoutPackage;
 	public static String WizardNewXtextProjectCreationPage_ErrorMessageProjectName;
@@ -25,8 +26,6 @@ public class Messages extends NLS {
 	public static String AdvancedNewProjectPage_Description;
 	public static String AdvancedNewProjectPage_LabelFacets;
 	public static String AdvancedNewProjectPage_eclipseAndGradleWarn;
-	public static String AdvancedNewProjectPage_ideaAndMavenWarn;
-	public static String AdvancedNewProjectPage_ideaReqGradleInfo;
 	
 	public static String AdvancedNewProjectPage_noBuildship;
 	public static String AdvancedNewProjectPage_noM2e;
@@ -38,7 +37,6 @@ public class Messages extends NLS {
 	public static String AdvancedNewProjectPage_projIde_description;
 	public static String AdvancedNewProjectPage_languageServer;
 	public static String AdvancedNewProjectPage_languageServer_description;
-	public static String AdvancedNewProjectPage_projIdea;
 	public static String AdvancedNewProjectPage_projWeb;
 	public static String AdvancedNewProjectPage_srcLayout;
 	public static String AdvancedNewProjectPage_p2AndSdkInfo;

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/NewXtextProjectWizard.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/NewXtextProjectWizard.java
@@ -93,7 +93,6 @@ public class NewXtextProjectWizard extends XtextNewProjectWizard {
 			projectInfo.setProjectLayout(ProjectLayout.HIERARCHICAL);
 		}
 		projectInfo.getIdeProject().setEnabled(advancedPage.isCreateIdeProject());
-		projectInfo.getIntellijProject().setEnabled(advancedPage.isCreateIntellijProject());
 		projectInfo.getWebProject().setEnabled(advancedPage.isCreateWebProject());
 		projectInfo.getSdkProject().setEnabled(advancedPage.isCreateSdkProject());
 		projectInfo.getP2Project().setEnabled(advancedPage.isCreateP2Project());

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/WizardNewXtextProjectCreationPage.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/WizardNewXtextProjectCreationPage.java
@@ -63,11 +63,11 @@ public class WizardNewXtextProjectCreationPage extends WizardNewProjectCreationP
 	 * Constructs a new WizardNewXtextProjectCreationPage.
 	 * 
 	 * @param pageName
-	 *            the name of the page
+	 *                      the name of the page
 	 * 
 	 * @param selection
-	 *            The current selection. If the current selection includes workingsets the workingsets field is initialized with the
-	 *            selection.
+	 *                      The current selection. If the current selection includes workingsets the workingsets field is initialized with
+	 *                      the selection.
 	 */
 	public WizardNewXtextProjectCreationPage(String pageName, IStructuredSelection selection) {
 		super(pageName);
@@ -137,7 +137,7 @@ public class WizardNewXtextProjectCreationPage extends WizardNewProjectCreationP
 	}
 
 	protected void fillBreeCombo(Combo comboToFill) {
-		Set<String> brees = Sets.newHashSet(JREContainerProvider.getDefaultBREE());
+		Set<String> brees = Sets.newHashSet();
 		Set<String> availableBrees = Sets.newHashSet();
 		for (IExecutionEnvironment ee : JavaRuntime.getExecutionEnvironmentsManager().getExecutionEnvironments()) {
 			availableBrees.add(ee.getId());
@@ -154,8 +154,13 @@ public class WizardNewXtextProjectCreationPage extends WizardNewProjectCreationP
 		String selectionMemento = comboToFill.getText();
 		comboToFill.setItems(array);
 		int index = comboToFill.indexOf(selectionMemento);
+		String defaultBree = JREContainerProvider.getDefaultBREE();
 		if (index < 0) {
-			comboToFill.select(comboToFill.indexOf(JREContainerProvider.getDefaultBREE()));
+			if (brees.contains(defaultBree)) {
+				comboToFill.select(comboToFill.indexOf(defaultBree));
+			} else {
+				comboToFill.select(array.length - 1);
+			}
 		}
 		comboToFill.select(index);
 	}
@@ -171,7 +176,7 @@ public class WizardNewXtextProjectCreationPage extends WizardNewProjectCreationP
 	 * Sets the defaults for the languageName and extensions.
 	 * 
 	 * @param projectSuffix
-	 *            the name of the DSL
+	 *                          the name of the DSL
 	 * @see findNextValidProjectSuffix(String, String)
 	 */
 	protected void setDefaults(String projectSuffix) {
@@ -213,17 +218,22 @@ public class WizardNewXtextProjectCreationPage extends WizardNewProjectCreationP
 			setErrorMessage(Messages.WizardNewXtextProjectCreationPage_ErrorMessageLanguageName + status.getMessage());
 			return false;
 		}
-		
-		if(!languageNameField.getText().contains(".")) { //$NON-NLS-1$
+
+		if (!languageNameField.getText().contains(".")) { //$NON-NLS-1$
 			setErrorMessage(Messages.WizardNewXtextProjectCreationPage_ErrorMessageLanguageNameWithoutPackage);
 			return false;
 		}
-		
+
 		if (extensionsField.getText().length() == 0)
 			return false;
 		if (!PATTERN_EXTENSIONS.matcher(extensionsField.getText()).matches()) {
 			setErrorMessage(Messages.WizardNewXtextProjectCreationPage_ErrorMessageExtensions);
 			return false;
+		}
+		JavaVersion javaVersion = JavaVersion.fromBree(breeCombo.getText());
+		if (javaVersion != null && !javaVersion.isAtLeast(JavaVersion.JAVA8)) {
+			setMessage(Messages.WizardNewXtextProjectCreationPage_MessageAtLeastJava8, IStatus.WARNING);
+			return true;
 		}
 		if (!Sets.newHashSet(JREContainerProvider.getConfiguredBREEs()).contains(breeCombo.getText())) {
 			setMessage(Messages.WizardNewXtextProjectCreationPage_eeInfo_0 + breeCombo.getText()
@@ -242,7 +252,8 @@ public class WizardNewXtextProjectCreationPage extends WizardNewProjectCreationP
 			// https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.8
 			// for historical reasons only underscore and $ are accepted as package name, but not for Xtext projects  
 			if (projectName.contains("$")) {
-				status = new Status(IStatus.ERROR, Activator.getInstance().getBundle().getSymbolicName(), -1, Messages.WizardNewXtextProjectCreationPage_ErrorMessageProjectName, null);
+				status = new Status(IStatus.ERROR, Activator.getInstance().getBundle().getSymbolicName(), -1,
+						Messages.WizardNewXtextProjectCreationPage_ErrorMessageProjectName, null);
 			}
 		}
 		return status;

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/messages.properties
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/messages.properties
@@ -16,6 +16,7 @@ WizardNewXtextProjectCreationPage_EEGrTitle=Java version
 WizardNewXtextProjectCreationPage_eeInfo_0=Selected Execution environment 
 WizardNewXtextProjectCreationPage_eeInfo_1=\ is not properly configured.\n Consider to set a compatible JRE using the 'Environments...' button.
 WizardNewXtextProjectCreationPage_ErrorMessageExtensions=Extensions contains an invalid pattern:\nOnly word characters are allowed. Multiple extensions must be comma-separated.
+WizardNewXtextProjectCreationPage_MessageAtLeastJava8=Selected java should be version 8 or higher.
 WizardNewXtextProjectCreationPage_ErrorMessageLanguageName=Language Name should be a valid qualified Java class name.\n
 WizardNewXtextProjectCreationPage_ErrorMessageLanguageNameWithoutPackage=Language Name must contain a package name.
 WizardNewXtextProjectCreationPage_ErrorMessageProjectName=Project name should be a valid Java package name.\n
@@ -28,9 +29,7 @@ AdvancedNewProjectPage_WindowTitle=Advanced Xtext Configuration
 AdvancedNewProjectPage_Description=Customize your Xtext project.
 AdvancedNewProjectPage_LabelFacets=Facets
 AdvancedNewProjectPage_eclipseAndGradleWarn=Building Eclipse plug-ins with Gradle is not yet supported. An additional Maven Tycho build will be created.
-AdvancedNewProjectPage_ideaAndMavenWarn=Building IntelliJ plug-ins with Maven is not yet supported. An additional Gradle build will be created.
 AdvancedNewProjectPage_p2AndSdkInfo=The creation of an update site will automatically create a feature project.
-AdvancedNewProjectPage_ideaReqGradleInfo=The creation of an IntelliJ IDEA plug-in requires a Gradle build. An additional Gradle build will be created.
 AdvancedNewProjectPage_noBuildship=Gradle integration for Eclipse (Buildship) is not installed. Consider to install Buildship.
 AdvancedNewProjectPage_noM2e=Maven integration for Eclipse (m2e) is not installed. Consider to install m2e.
 AdvancedNewProjectPage_prefBuildSys=Preferred Build System
@@ -43,6 +42,5 @@ AdvancedNewProjectPage_languageServer=Build Language Server
 AdvancedNewProjectPage_languageServer_description=Extends the build of the *.ide project to create a language server.\n\
 Choose either 'Regular' for a distribution with the DSL plugins and their dependencies in separate jars and a start script.\n\
 Or choose 'Fat Jar' to create a single executable jar with all dependencies packed in the jar.
-AdvancedNewProjectPage_projIdea=IntelliJ IDEA plug-in
 AdvancedNewProjectPage_projWeb=Web Integration
 AdvancedNewProjectPage_srcLayout=Source Layout

--- a/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
+++ b/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
@@ -52,8 +52,6 @@ public class AdvancedNewProjectPage extends WizardPage {
   
   private Button createP2Project;
   
-  private Button createIdeaProject;
-  
   private Button createWebProject;
   
   private Button createIdeProject;
@@ -106,27 +104,22 @@ public class AdvancedNewProjectPage extends WizardPage {
         };
         this.createUiProjectSubGroup = this.Group(it_1, _function_3);
         final Procedure1<Button> _function_4 = (Button it_2) -> {
-          it_2.setText(Messages.AdvancedNewProjectPage_projIdea);
-          it_2.setEnabled(true);
-        };
-        this.createIdeaProject = this.CheckBox(it_1, _function_4);
-        final Procedure1<Button> _function_5 = (Button it_2) -> {
           it_2.setText(Messages.AdvancedNewProjectPage_projWeb);
           it_2.setEnabled(true);
         };
-        this.createWebProject = this.CheckBox(it_1, _function_5);
-        final Procedure1<Button> _function_6 = (Button it_2) -> {
+        this.createWebProject = this.CheckBox(it_1, _function_4);
+        final Procedure1<Button> _function_5 = (Button it_2) -> {
           it_2.setText(Messages.AdvancedNewProjectPage_projIde);
           it_2.setEnabled(false);
           this.InfoDecoration(it_2, Messages.AdvancedNewProjectPage_projIde_description);
           GridData _gridData_1 = new GridData(SWT.LEFT, SWT.CENTER, true, false);
           it_2.setLayoutData(_gridData_1);
         };
-        this.createIdeProject = this.CheckBox(it_1, _function_6);
-        final Procedure1<Button> _function_7 = (Button it_2) -> {
+        this.createIdeProject = this.CheckBox(it_1, _function_5);
+        final Procedure1<Button> _function_6 = (Button it_2) -> {
           it_2.setText(Messages.WizardNewXtextProjectCreationPage_TestingSupport);
         };
-        this.createTestProject = this.CheckBox(it_1, _function_7);
+        this.createTestProject = this.CheckBox(it_1, _function_6);
       };
       this.Group(it, _function_1);
       final Procedure1<Group> _function_2 = (Group it_1) -> {
@@ -182,7 +175,7 @@ public class AdvancedNewProjectPage extends WizardPage {
         AdvancedNewProjectPage.this.validate(e);
       }
     };
-    final List<Button> uiButtons = Collections.<Button>unmodifiableList(CollectionLiterals.<Button>newArrayList(this.createUiProject, this.createIdeaProject, this.createWebProject));
+    final List<Button> uiButtons = Collections.<Button>unmodifiableList(CollectionLiterals.<Button>newArrayList(this.createUiProject, this.createWebProject));
     final SelectionAdapter selectionControlUi = new SelectionAdapter() {
       @Override
       public void widgetSelected(final SelectionEvent e) {
@@ -280,7 +273,6 @@ public class AdvancedNewProjectPage extends WizardPage {
     this.sourceLayout.addSelectionListener(selectionControl);
     this.createTestProject.addSelectionListener(selectionControl);
     this.createUiProject.addSelectionListener(selectionControlUi);
-    this.createIdeaProject.addSelectionListener(selectionControlUi);
     this.createWebProject.addSelectionListener(selectionControlUi);
     this.createIdeProject.addSelectionListener(selectionControl);
     this.createSDKProject.addSelectionListener(selectionControl);
@@ -301,7 +293,7 @@ public class AdvancedNewProjectPage extends WizardPage {
   public Procedure0 checkWidgets(final SelectionEvent e) {
     Procedure0 _xblockexpression = null;
     {
-      final List<Button> uiButtons = Collections.<Button>unmodifiableList(CollectionLiterals.<Button>newArrayList(this.createUiProject, this.createIdeaProject, this.createWebProject));
+      final List<Button> uiButtons = Collections.<Button>unmodifiableList(CollectionLiterals.<Button>newArrayList(this.createUiProject, this.createWebProject));
       if ((this.isSelected(this.preferredBuildSystem, BuildSystem.MAVEN) && (!this.isBundleResolved("org.eclipse.m2e.maven.runtime")))) {
         this.<Control>reportIssue(IMessageProvider.WARNING, Messages.AdvancedNewProjectPage_noM2e);
       }
@@ -311,14 +303,6 @@ public class AdvancedNewProjectPage extends WizardPage {
       if ((this.isSelected(this.preferredBuildSystem, BuildSystem.GRADLE) && this.createUiProject.getSelection())) {
         this.<Control>reportIssue(IMessageProvider.WARNING, 
           Messages.AdvancedNewProjectPage_eclipseAndGradleWarn);
-      }
-      if ((this.isSelected(this.preferredBuildSystem, BuildSystem.MAVEN) && this.createIdeaProject.getSelection())) {
-        this.<Control>reportIssue(IMessageProvider.WARNING, 
-          Messages.AdvancedNewProjectPage_ideaAndMavenWarn);
-      }
-      if ((this.isSelected(this.preferredBuildSystem, BuildSystem.NONE) && this.createIdeaProject.getSelection())) {
-        this.<Control>reportIssue(IMessageProvider.INFORMATION, 
-          Messages.AdvancedNewProjectPage_ideaReqGradleInfo);
       }
       if (((this.createUiProject.getSelection() && this.createP2Project.getSelection()) && (!this.createSDKProject.getSelection()))) {
         this.<Control>addIssue(IMessageProvider.INFORMATION, 
@@ -566,7 +550,6 @@ public class AdvancedNewProjectPage extends WizardPage {
     this.createUiProject.setSelection(true);
     this.createIdeProject.setSelection(true);
     this.createTestProject.setSelection(true);
-    this.createIdeaProject.setSelection(false);
     this.createWebProject.setSelection(false);
     this.createSDKProject.setSelection(false);
     this.createP2Project.setSelection(false);
@@ -585,10 +568,6 @@ public class AdvancedNewProjectPage extends WizardPage {
   
   public boolean isCreateIdeProject() {
     return this.createIdeProject.getSelection();
-  }
-  
-  public boolean isCreateIntellijProject() {
-    return this.createIdeaProject.getSelection();
   }
   
   public boolean isCreateWebProject() {


### PR DESCRIPTION
Fix case where unsupported JDK is added to the selection combo in case
it is selected as a default. Instead, in the unlikely case that the
default JDK is not supported, the last JDK from the list is selected.

Remove IDEA from the new project wizard. IDE plugins are not well
maintained any more, no need to bother new users with not working stuff.

Adding "Automatic-Module-Name" to manifest if selected java version is
at least 1.8.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>