### PR TITLE
Rename getJUnitVersion => getSelectedJUnitVersion

### DIFF
--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.xtend
@@ -441,7 +441,7 @@ class AdvancedNewProjectPage extends WizardPage {
 		LanguageServer.values.get(createLanguageServer.selectionIndex)
 	}
 	
-	def JUnitVersion getJUnitVersion () {
+	def JUnitVersion getSelectedJUnitVersion () {
 		if (junitVersion4.selection) {
 			return JUnitVersion.JUNIT_4;
 		} else if (junitVersion5.selection) {

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/NewXtextProjectWizard.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/NewXtextProjectWizard.java
@@ -97,7 +97,7 @@ public class NewXtextProjectWizard extends XtextNewProjectWizard {
 		projectInfo.getSdkProject().setEnabled(advancedPage.isCreateSdkProject());
 		projectInfo.getP2Project().setEnabled(advancedPage.isCreateP2Project());
 		projectInfo.setLanguageServer(advancedPage.getLanguageServer());
-		projectInfo.setJunitVersion(advancedPage.getJUnitVersion());
+		projectInfo.setJunitVersion(advancedPage.getSelectedJUnitVersion());
 		
 		if (advancedPage.isCreateTestProject()) {
 			for (ProjectDescriptor project : projectInfo.getEnabledProjects()) {

--- a/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
+++ b/org.eclipse.xtext.xtext.ui/xtend-gen/org/eclipse/xtext/xtext/ui/wizard/project/AdvancedNewProjectPage.java
@@ -652,7 +652,7 @@ public class AdvancedNewProjectPage extends WizardPage {
     return _xblockexpression;
   }
   
-  public JUnitVersion getJUnitVersion() {
+  public JUnitVersion getSelectedJUnitVersion() {
     boolean _selection = this.junitVersion4.getSelection();
     if (_selection) {
       return JUnitVersion.JUNIT_4;


### PR DESCRIPTION
Resolves name ambiguity compile warning

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>