### PR TITLE
Improved filtering of annotations for hover

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractProblemHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractProblemHoverTest.java
@@ -13,8 +13,10 @@ package org.eclipse.xtext.ui.tests.editor.hover;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.MarkerTypes;
@@ -34,6 +36,8 @@ import org.junit.Test;
  * @author Christoph Kulla - Initial contribution and API
  */
 public class AbstractProblemHoverTest extends AbstractEditorTest {
+	
+	protected IFile file;
 
 	protected XtextEditor editor;
 	
@@ -47,7 +51,7 @@ public class AbstractProblemHoverTest extends AbstractEditorTest {
 	public void setUp() throws Exception {
 		super.setUp();
 		modelAsText = "stuff mystuff\nstuff yourstuff refs _mystuff// Comment";
-		IFile file = IResourcesSetupUtil.createFile("test/test.testlanguage", modelAsText);
+		file = IResourcesSetupUtil.createFile("test/test.testlanguage", modelAsText);
 		editor = openEditor(file);
 		document = editor.getDocument();
 		hover = TestsActivator.getInstance().getInjector(getEditorId()).getInstance(MockHover.class);
@@ -75,12 +79,65 @@ public class AbstractProblemHoverTest extends AbstractEditorTest {
 		return "org.eclipse.xtext.ui.tests.TestLanguage";
 	}
 
-	@Test public void testAnnotations () {	
-		assertEquals (0, hover.getAnnotations(0,0).size());
-		assertEquals (0, hover.getAnnotations(1,34).size());
-		assertEquals (1, hover.getAnnotations(1,35).size());
-		assertEquals (1, hover.getAnnotations(1,43).size());
-		assertEquals (0, hover.getAnnotations(1,44).size());
+	@Test public void testAnnotations() {	
+		assertEquals(0, hover.getAnnotations(0,0).size());
+		assertEquals(0, hover.getAnnotations(1,34).size());
+		assertEquals(1, hover.getAnnotations(1,35).size());
+		assertEquals(1, hover.getAnnotations(1,43).size());
+		assertEquals(0, hover.getAnnotations(1,44).size());
+	}
+	
+	@Test public void testMultipleAnnotationTypes() throws Exception {
+		IMarker warning = file.createMarker(MarkerTypes.NORMAL_VALIDATION);
+		warning.setAttribute(IMarker.LOCATION, "line: 2 " + file.getFullPath().toString());
+		warning.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+		warning.setAttribute(IMarker.CHAR_START, 14);
+		warning.setAttribute(IMarker.CHAR_END, 19);
+		warning.setAttribute(IMarker.LINE_NUMBER, 2);
+		warning.setAttribute(IMarker.MESSAGE, "Foo");
+		
+		IMarker info = file.createMarker(MarkerTypes.NORMAL_VALIDATION);
+		info.setAttribute(IMarker.LOCATION, "line: 2 " + file.getFullPath().toString());
+		info.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
+		info.setAttribute(IMarker.CHAR_START, 20);
+		info.setAttribute(IMarker.CHAR_END, 29);
+		info.setAttribute(IMarker.LINE_NUMBER, 2);
+		info.setAttribute(IMarker.MESSAGE, "Bar");
+		
+		List<Annotation> annotations = hover.getAnnotations(1, -1);
+		assertEquals(3, annotations.size());
+		// The order of annotations must be stable
+		assertEquals("org.eclipse.xtext.ui.editor.info", annotations.get(0).getType());
+		assertEquals("org.eclipse.xtext.ui.editor.error", annotations.get(1).getType());
+		assertEquals("org.eclipse.xtext.ui.editor.warning", annotations.get(2).getType());
+		
+		List<Annotation> sorted = hover.sortBySeverity(annotations);
+		assertEquals(3, sorted.size());
+		// First errors, then warnings, then the rest
+		assertEquals("org.eclipse.xtext.ui.editor.error", sorted.get(0).getType());
+		assertEquals("org.eclipse.xtext.ui.editor.warning", sorted.get(1).getType());
+		assertEquals("org.eclipse.xtext.ui.editor.info", sorted.get(2).getType());
+		
+		warning.delete();
+		info.delete();
+	}
+	
+	@Test public void testAnnotationOnMultipleLines() throws Exception {
+		IMarker warning = file.createMarker(MarkerTypes.NORMAL_VALIDATION);
+		warning.setAttribute(IMarker.LOCATION, "line: 1 " + file.getFullPath().toString());
+		warning.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+		warning.setAttribute(IMarker.CHAR_START, 0);
+		warning.setAttribute(IMarker.CHAR_END, 43);
+		warning.setAttribute(IMarker.LINE_NUMBER, 1);
+		warning.setAttribute(IMarker.MESSAGE, "Foo");
+		
+		List<Annotation> annotations = hover.getAnnotations(1, 40);
+		assertEquals(2, annotations.size());
+		// The error is on the same line as the requested position, so it should be returned first
+		assertEquals("org.eclipse.xtext.ui.editor.error", annotations.get(0).getType());
+		assertEquals("org.eclipse.xtext.ui.editor.warning", annotations.get(1).getType());
+		
+		warning.delete();
 	}
 
 	protected void activate(IWorkbenchPart part) {
@@ -97,6 +154,14 @@ public class AbstractProblemHoverTest extends AbstractEditorTest {
 		@Override
 		protected Object getHoverInfoInternal(ITextViewer textViewer, int lineNumber, int offset) {
 			return null;
+		}
+		
+		/**
+		 * Override to make this method accessible from the test.
+		 */
+		@Override
+		public List<Annotation> sortBySeverity(List<Annotation> annotations) {
+			return super.sortBySeverity(annotations);
 		}
 
 	}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AbstractProblemHover.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AbstractProblemHover.java
@@ -11,6 +11,7 @@
 package org.eclipse.xtext.ui.editor.hover;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -67,37 +68,65 @@ public abstract class AbstractProblemHover extends AbstractHover {
 		return sourceViewer.getAnnotationModel();
 	}
 
+	/**
+	 * Find annotations that include the given offset. Only annotations for which {@link #isHandled(Annotation)}
+	 * returns {@code true} and {@link #isLineDiffInfo(Annotation)} returns {@code false} are included.
+	 * 
+	 * <p>If there are multiple annotations, those that start on the given line number are put first in the list,
+	 * then those that start one line before, etc.</p>
+	 * 
+	 * <p>The offset can be negative. In that case only annotations that start on the given line number
+	 * are returned.</p>
+	 */
 	public List<Annotation> getAnnotations(final int lineNumber, final int offset) {
 		if (getAnnotationModel() == null) {
 			return Collections.emptyList();
 		}
 		final Iterator<?> iterator = getAnnotationModel().getAnnotationIterator();
 		List<Annotation> result = Lists.newArrayList();
+		List<Integer> lineDiffs = Lists.newArrayList();
 		while (iterator.hasNext()) {
 			final Annotation annotation = (Annotation) iterator.next();
-			if (isHandled(annotation)) {
+			if (isHandled(annotation) && !isLineDiffInfo(annotation)) {
 				Position position = getAnnotationModel().getPosition(annotation);
 				if (position != null) {
 					final int start = position.getOffset();
 					final int end = start + position.getLength();
 
-					if (offset > 0 && !(start <= offset && offset <= end)) {
-						continue;
-					}
-					try {
-						if (lineNumber != getDocument().getLineOfOffset(start)) {
-							continue;
+					if (offset < 0 || start <= offset && offset <= end) {
+						try {
+							int lineDiff = Math.abs(lineNumber - getDocument().getLineOfOffset(start));
+							if (lineDiff == 0 || offset >= 0) {
+								// Insert the annotation according to its line number difference
+								int index = lineDiffs.size();
+								while (index > 0 && lineDiffs.get(index - 1) > lineDiff) {
+									index--;
+								}
+								result.add(index, annotation);
+								lineDiffs.add(index, lineDiff);
+							}
+						} catch (Exception x) {
+							// Skip this annotation
 						}
-					} catch (final Exception x) {
-						continue;
-					}
-					if (!isLineDiffInfo(annotation)) {
-						result.add(annotation);
 					}
 				}
 			}
 		}
 		return result;
+	}
+	
+	/**
+	 * Sort the given annotations such that the resulting list contains first errors, then warnings, and then the rest.
+	 */
+	protected List<Annotation> sortBySeverity(List<Annotation> annotations) {
+		if (annotations == null)
+			return Collections.emptyList();
+		if (annotations.size() <= 1)
+			return annotations;
+		List<Annotation> sorted = Lists.newArrayList(annotations);
+		Collections.sort(sorted, Comparator.comparing(this::isError).reversed()
+				.thenComparing(Comparator.comparing(this::isWarning).reversed()));
+		return sorted;
 	}
 
 	protected boolean isLineDiffInfo(Annotation annotation) {
@@ -110,11 +139,27 @@ public abstract class AbstractProblemHover extends AbstractHover {
 	protected boolean isHandled(Annotation annotation) {
 		return null != annotation
 				&& !annotation.isMarkedDeleted()
-				&& (markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.error") 
-						|| markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.warning")
-						|| markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.info")
-						|| markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.bookmark")
-						|| markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.spelling"));
+				&& (isError(annotation) || isWarning(annotation) || isInfo(annotation) || isBookmark(annotation) || isSpelling(annotation));
+	}
+	
+	protected boolean isError(Annotation annotation) {
+		return markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.error");
+	}
+	
+	protected boolean isWarning(Annotation annotation) {
+		return markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.warning");
+	}
+	
+	protected boolean isInfo(Annotation annotation) {
+		return markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.info");
+	}
+	
+	protected boolean isBookmark(Annotation annotation) {
+		return markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.bookmark");
+	}
+	
+	protected boolean isSpelling(Annotation annotation) {
+		return markerAnnotationAccess.isSubtype(annotation.getType(), "org.eclipse.ui.workbench.texteditor.spelling");
 	}
 
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AnnotationWithQuickFixesHover.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AnnotationWithQuickFixesHover.java
@@ -672,13 +672,11 @@ public class AnnotationWithQuickFixesHover extends AbstractProblemHover {
 	protected Region getHoverRegionInternal(final int lineNumber, final int offset) {
 		recentAnnotationInfo = null;
 		List<Annotation> annotations = getAnnotations(lineNumber, offset);
-		if (annotations != null) {
-			for (Annotation annotation : annotations) {
-				Position position = sourceViewer.getAnnotationModel().getPosition(annotation);
-				if (position != null) {
-					final int start = position.getOffset();
-					return new Region (start, position.getLength());	
-				}
+		for (Annotation annotation : sortBySeverity(annotations)) {
+			Position position = sourceViewer.getAnnotationModel().getPosition(annotation);
+			if (position != null) {
+				final int start = position.getOffset();
+				return new Region(start, position.getLength());	
 			}
 		}
 		return null;
@@ -693,23 +691,21 @@ public class AnnotationWithQuickFixesHover extends AbstractProblemHover {
 		if (result != null)
 			return result;
 		List<Annotation> annotations = getAnnotations(lineNumber, offset);
-		if (annotations != null) {
-			for (Annotation annotation : annotations) {
-				Position position = getAnnotationModel().getPosition(annotation);
-				if (annotation.getText() != null && position != null) {
-					final QuickAssistInvocationContext invocationContext = new QuickAssistInvocationContext(sourceViewer, position.getOffset(), position.getLength(), true);
-					CompletionProposalRunnable runnable = new CompletionProposalRunnable(invocationContext);	
-					// Note: the resolutions have to be retrieved from the UI thread, otherwise
-					// workbench.getActiveWorkbenchWindow() will return null in LanguageSpecificURIEditorOpener and
-					// cause an exception
-					Display.getDefault().syncExec(runnable);
-					if (invocationContext.isMarkedCancelled()) {
-						return null;
-					}
-					result = new AnnotationInfo (annotation, position, sourceViewer, runnable.proposals);
-					recentAnnotationInfo = result;
-					return result;
+		for (Annotation annotation : sortBySeverity(annotations)) {
+			Position position = getAnnotationModel().getPosition(annotation);
+			if (annotation.getText() != null && position != null) {
+				final QuickAssistInvocationContext invocationContext = new QuickAssistInvocationContext(sourceViewer, position.getOffset(), position.getLength(), true);
+				CompletionProposalRunnable runnable = new CompletionProposalRunnable(invocationContext);
+				// Note: the resolutions have to be retrieved from the UI thread, otherwise
+				// workbench.getActiveWorkbenchWindow() will return null in LanguageSpecificURIEditorOpener and
+				// cause an exception
+				Display.getDefault().syncExec(runnable);
+				if (invocationContext.isMarkedCancelled()) {
+					return null;
 				}
+				result = new AnnotationInfo(annotation, position, sourceViewer, runnable.proposals);
+				recentAnnotationInfo = result;
+				return result;
 			}
 		}
 		return null;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/ProblemAnnotationHover.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/ProblemAnnotationHover.java
@@ -47,11 +47,11 @@ public class ProblemAnnotationHover extends AbstractProblemHover implements IAnn
 	@Override
 	protected Region getHoverRegionInternal(final int lineNumber, final int offset) {
 		List<Annotation> annotations = getAnnotations(lineNumber, offset);
-		for (Annotation annotation : annotations) {
+		for (Annotation annotation : sortBySeverity(annotations)) {
 			Position position = sourceViewer.getAnnotationModel().getPosition(annotation);
 			if (position != null) {
 				final int start = position.getOffset();
-				return new Region (start, position.getLength());	
+				return new Region(start, position.getLength());	
 			}
 		}
 		return null;
@@ -67,7 +67,7 @@ public class ProblemAnnotationHover extends AbstractProblemHover implements IAnn
 				messages.add(text.trim());
 			}
 		}
-		if (messages.size()>0)
+		if (messages.size() > 0)
 			return formatInfo(messages);
 		return null;
 	}


### PR DESCRIPTION
Fixes #649.

 * `AbstractProblemHover.getAnnotations(int, int)` now returns all annotations that include the given offset (if it is ≥ 0). Those that match the given line number are put first in the list so consumers of that method will favor them over annotations that start on preceding lines.
 * `ProblemAnnotationHover` and `AnnotationWithQuickFixesHover` further sort the list of annotations such that they first consider errors, then warnings, then the rest.