### PR TITLE
Fixed possible NPE

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/EditorResourceAccess.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/EditorResourceAccess.java
@@ -31,7 +31,7 @@ public class EditorResourceAccess implements IReferenceFinder.ILocalResourceAcce
 	public <R> R readOnly(final URI targetURI, final IUnitOfWork<R, ResourceSet> work) {
 		IXtextDocument document = openDocumentTracker.getOpenDocument(targetURI.trimFragment());
 		if (document != null) {
-			return document.readOnly(new IUnitOfWork<R, XtextResource>() {
+			return document.tryReadOnly(new IUnitOfWork<R, XtextResource>() {
 				@Override
 				public R exec(XtextResource state) throws Exception {
 					ResourceSet localContext = state.getResourceSet();
@@ -39,7 +39,7 @@ public class EditorResourceAccess implements IReferenceFinder.ILocalResourceAcce
 						return work.exec(localContext);
 					return null;
 				}
-			});
+			}, () -> { return null; });
 		} else {
 			return delegate.readOnly(targetURI, work);
 		}


### PR DESCRIPTION
I have no way to reproduce this but you can find a stacktrace we encountered below
```
Unhandled event loop exception
java.lang.NullPointerException

 at org.eclipse.xtext.ui.editor.findrefs.EditorResourceAccess$1.exec(EditorResourceAccess.java:37)
    at org.eclipse.xtext.ui.editor.findrefs.EditorResourceAccess$1.exec(EditorResourceAccess.java:1)
    at org.eclipse.xtext.resource.OutdatedStateManager.exec(OutdatedStateManager.java:91)
    at org.eclipse.xtext.ui.editor.model.XtextDocument$XtextDocumentLocker.internalReadOnly(XtextDocument.java:520)
    at org.eclipse.xtext.ui.editor.model.XtextDocument$XtextDocumentLocker.readOnly(XtextDocument.java:492)
    at org.eclipse.xtext.ui.editor.model.XtextDocument.readOnly(XtextDocument.java:133)
    at org.eclipse.xtext.ui.editor.findrefs.EditorResourceAccess.readOnly(EditorResourceAccess.java:34)
    at org.eclipse.xtext.findReferences.ReferenceFinder.findReferences(ReferenceFinder.java:154)
    at org.eclipse.xtext.findReferences.ReferenceFinder.findAllReferences(ReferenceFinder.java:181)
    at org.eclipse.xtext.ui.editor.findrefs.DelegatingReferenceFinder.findAllReferences(DelegatingReferenceFinder.java:62)
    at org.eclipse.xtext.ui.editor.findrefs.ReferenceQuery.run(ReferenceQuery.java:78)
```