### PR TITLE
[#681] Clear interrupted state of test tread at start of method.

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.xtend
@@ -76,6 +76,7 @@ class DocumentLockerTest extends AbstractXtextDocumentTest {
 	}
 	
 	@Test def void testPriorityReadOnlyCancelsReaders() {
+		Thread.currentThread.interrupted // prevent random test failures: https://github.com/junit-team/junit4/issues/1365
 		val document = new XtextDocument(createTokenSource(), null, outdatedStateManager, operationCanceledManager)
 		document.input = new XtextResource => [
 			new XtextResourceSet().resources += it

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.java
@@ -116,6 +116,7 @@ public class DocumentLockerTest extends AbstractXtextDocumentTest {
   @Test
   public void testPriorityReadOnlyCancelsReaders() {
     try {
+      Thread.currentThread().isInterrupted();
       DocumentTokenSource _createTokenSource = this.createTokenSource();
       final XtextDocument document = new XtextDocument(_createTokenSource, null, this.outdatedStateManager, this.operationCanceledManager);
       XtextResource _xtextResource = new XtextResource();


### PR DESCRIPTION
It looks as if the test runner thread is interrupted. I can't say why.
The test is failing after only 4ms of execution time. Looks like the
test thread is interrupted at the start of the method already. It might
be that we are bitten by a JUnit bug here: junit-team/junit4#1365

Insert a "Thread.currentThread.interrupted" at the start of the test
case to ensure the interrupted flag is cleared.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>