### PR TITLE
Made printing of source code on error overridable

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextDocumentReconcileStrategy.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextDocumentReconcileStrategy.java
@@ -213,14 +213,23 @@ public class XtextDocumentReconcileStrategy implements IReconcilingStrategy, IRe
 		} catch(OperationCanceledException e) {
 			throw e;
 		} catch(RuntimeException e) {
-			String message = "Error post-processing resource with content";
-			IParseResult parseResult = resource.getParseResult();
-			if (parseResult != null && parseResult.getRootNode() != null) {
-				message = message + ":\n" + parseResult.getRootNode().getText();
-			}
+			String message = createPostParseErrorMessage(resource);
 			log.error(message, e);
 			resource.getCache().clear(resource);
 		}
 	}
-	
+
+	/**
+	 * Creates an error message containing the source code of the {@code resource}
+	 * 
+	 * @since 2.15
+	 */
+	protected String createPostParseErrorMessage(XtextResource resource) {
+		String message = "Error post-processing resource with content";
+		IParseResult parseResult = resource.getParseResult();
+		if (parseResult != null && parseResult.getRootNode() != null) {
+			message += ":\n" + parseResult.getRootNode().getText();
+		}
+		return message;
+	}
 }


### PR DESCRIPTION
Printing source code is not always something that is acceptable thus there should be a way to disable this behaviour. Extracting the message creation to an overridable function achieves this purpose.