### PR TITLE
[#681] Clear interrupted state of test tread at start of method.

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.xtend
@@ -76,7 +76,7 @@ class DocumentLockerTest extends AbstractXtextDocumentTest {
 	}
 	
 	@Test def void testPriorityReadOnlyCancelsReaders() {
-		Thread.currentThread.interrupted // prevent random test failures: https://github.com/junit-team/junit4/issues/1365
+		Thread.interrupted // prevent random test failures: https://github.com/junit-team/junit4/issues/1365
 		val document = new XtextDocument(createTokenSource(), null, outdatedStateManager, operationCanceledManager)
 		document.input = new XtextResource => [
 			new XtextResourceSet().resources += it

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/model/DocumentLockerTest.java
@@ -116,7 +116,7 @@ public class DocumentLockerTest extends AbstractXtextDocumentTest {
   @Test
   public void testPriorityReadOnlyCancelsReaders() {
     try {
-      Thread.currentThread().isInterrupted();
+      Thread.interrupted();
       DocumentTokenSource _createTokenSource = this.createTokenSource();
       final XtextDocument document = new XtextDocument(_createTokenSource, null, this.outdatedStateManager, this.operationCanceledManager);
       XtextResource _xtextResource = new XtextResource();


### PR DESCRIPTION
I can reproduce the issue, it is this bug junit-team/junit4#1365

But we have to call the static version of "interrupted", the non-static
version does not reset the state.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>