### PR TITLE
[eclipse/xtext#1178] bootstrap against 2.14

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -1407,7 +1407,7 @@
             name="org.eclipse.buildship.feature.group"/>
         <requirement
             name="org.eclipse.xtext.xbase.lib.feature.group"
-            versionRange="2.13.0"/>
+            versionRange="2.14.0"/>
         <requirement
             name="org.eclipse.xtext.testing"/>
         <requirement

--- a/releng/org.eclipse.xtext.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtext.tycho.parent/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<tycho-version>1.1.0</tycho-version>
-		<xtend-maven-plugin-version>2.13.0</xtend-maven-plugin-version>
+		<xtend-maven-plugin-version>2.14.0</xtend-maven-plugin-version>
 
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>


### PR DESCRIPTION
[eclipse/xtext#1178] bootstrap against 2.14
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>