### PR TITLE
Fixed typo in PersistentDataAwareDirtyResource

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/PersistentDataAwareDirtyResource.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/PersistentDataAwareDirtyResource.java
@@ -26,11 +26,11 @@ public class PersistentDataAwareDirtyResource extends DocumentBasedDirtyResource
 	
 	@Inject
 	@Named(ResourceDescriptionsProvider.PERSISTED_DESCRIPTIONS)
-	private IResourceDescriptions resourceDesriptions;
+	private IResourceDescriptions resourceDescriptions;
 	
 	@Override
 	protected void initiallyProcessResource(XtextResource resource) {
-		IResourceDescription description = resourceDesriptions.getResourceDescription(resource.getURI());
+		IResourceDescription description = resourceDescriptions.getResourceDescription(resource.getURI());
 		if (description != null) {
 			copyState(description);
 		} else {
@@ -38,11 +38,21 @@ public class PersistentDataAwareDirtyResource extends DocumentBasedDirtyResource
 		}
 	}
 
-	public void setResourceDesriptions(IResourceDescriptions resourceDesriptions) {
-		this.resourceDesriptions = resourceDesriptions;
+	public void setResourceDescriptions(IResourceDescriptions resourceDescriptions) {
+		this.resourceDescriptions = resourceDescriptions;
 	}
 
+	public IResourceDescriptions getResourceDescriptions() {
+		return resourceDescriptions;
+	}
+
+	@Deprecated // use setResourceDescriptions
+	public void setResourceDesriptions(IResourceDescriptions resourceDescriptions) {
+		setResourceDescriptions(resourceDescriptions);
+	}
+
+	@Deprecated // use getResourceDescriptions
 	public IResourceDescriptions getResourceDesriptions() {
-		return resourceDesriptions;
+		return getResourceDescriptions();
 	}
 }

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/PersistentDataAwareDirtyResource.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/PersistentDataAwareDirtyResource.java
@@ -45,14 +45,4 @@ public class PersistentDataAwareDirtyResource extends DocumentBasedDirtyResource
 	public IResourceDescriptions getResourceDescriptions() {
 		return resourceDescriptions;
 	}
-
-	@Deprecated // use setResourceDescriptions
-	public void setResourceDesriptions(IResourceDescriptions resourceDescriptions) {
-		setResourceDescriptions(resourceDescriptions);
-	}
-
-	@Deprecated // use getResourceDescriptions
-	public IResourceDescriptions getResourceDesriptions() {
-		return getResourceDescriptions();
-	}
 }


### PR DESCRIPTION
You can just close this ticket if you don't think it's worth deprecating these methods for the typo. Whatever the response, I'll keep it in mind for future contributions.