### PR TITLE
Bugfix related to move refactoring of non-Xtext resources

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
@@ -87,7 +87,7 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 	protected def dispatch void handleReplacements(IEmfResourceChange change) {
 		val outputStream = new ByteArrayOutputStream
 		tryWith(outputStream) [
-			val file = change.resource.URI.toFile
+			val file = change.oldURI.toFile
 			if (!file.canWrite) 
 				issues.add(Severity.ERROR, '''Affected file '«file.fullPath»' is read-only''')
 			file.checkDerived

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
@@ -123,7 +123,7 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
     final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     final Procedure0 _function = () -> {
       try {
-        final IFile file = this.resourceUriConverter.toFile(change.getResource().getURI());
+        final IFile file = this.resourceUriConverter.toFile(change.getOldURI());
         boolean _canWrite = this.canWrite(file);
         boolean _not = (!_canWrite);
         if (_not) {


### PR DESCRIPTION
Since the refactoring applies content changes before applying move
changes, the content changes must be applied to the old URI.

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>