### PR TITLE
https://github.com/eclipse/xtext-xtend/issues/459

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/preferences/BuilderConfigurationBlock.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/preferences/BuilderConfigurationBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.IDialogSettings;
-import org.eclipse.jface.layout.PixelConverter;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.TableEditor;
@@ -76,7 +75,6 @@ public class BuilderConfigurationBlock extends OptionsConfigurationBlock {
 	
 	@Override
 	protected Control doCreateContents(Composite parent) {
-		PixelConverter pixelConverter = new PixelConverter(parent);
 		setShell(parent.getShell());
 		Composite mainComp = new Composite(parent, SWT.NONE);
 		mainComp.setFont(parent.getFont());
@@ -86,7 +84,6 @@ public class BuilderConfigurationBlock extends OptionsConfigurationBlock {
 		mainComp.setLayout(layout);
 		Composite othersComposite = createBuildPathTabContent(mainComp);
 		GridData gridData = new GridData(GridData.FILL, GridData.FILL, true, true);
-		gridData.heightHint = pixelConverter.convertHeightInCharsToPixels(20);
 		othersComposite.setLayoutData(gridData);
 		validateSettings(null, null, null);
 		return mainComp;
@@ -199,15 +196,24 @@ public class BuilderConfigurationBlock extends OptionsConfigurationBlock {
 
 	private Table createOutputFolderTable(Composite othersComposite, final OutputConfiguration outputConfiguration, final Text defaultDirectoryField) {
 		final Table table = new Table(othersComposite, SWT.BORDER | SWT.FULL_SELECTION);
+		
+		/*
+		 * Ensure that output configuration table widget expands horizontally
+		 * over all the 3 columns and not only resides in the first column.
+		 */
+		GridData layoutData = new GridData();
+		layoutData.horizontalSpan = 3;
+		table.setLayoutData(layoutData);
+		
 		new TableColumn(table, SWT.NONE).setText(Messages.OutputConfigurationPage_IgnoreSourceFolder);
 		new TableColumn(table, SWT.NONE).setText(Messages.OutputConfigurationPage_SourceFolder);
 		new TableColumn(table, SWT.NONE).setText(Messages.OutputConfigurationPage_OutputDirectory);
 		table.getColumn(0).setWidth(75);
 		table.getColumn(1).setWidth(200);
 		table.getColumn(2).setWidth(200);
-		table.pack();
 		table.setHeaderVisible(true);
 		table.setLinesVisible(true);
+		table.pack();
 
 		for (final String source : outputConfiguration.getSourceFolders()) {
 			String outputForSourceFolderKey = BuilderPreferenceAccess.getOutputForSourceFolderKey(outputConfiguration, source);


### PR DESCRIPTION
- Ensure that output configuration table widget expands horizontally
over all the 3 columns and not only resides in the first column.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>