### PR TITLE
Prevent NPE in outlines when eObject is null

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/AbstractOutlineNode.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/AbstractOutlineNode.java
@@ -203,28 +203,24 @@ public abstract class AbstractOutlineNode implements IOutlineNode, IOutlineNode.
 
 	@Override
 	public <T> T readOnly(final IUnitOfWork<T, EObject> work) {
-		if (getEObjectURI() != null) {
-			try {
-				return getDocument().readOnly(new IUnitOfWork<T, XtextResource>() {
-					@Override
-					public T exec(XtextResource state) throws Exception {
-						if (state != null) {
-							EObject eObject;
-							if (state.getResourceSet() != null)
-								eObject = state.getResourceSet().getEObject(getEObjectURI(), true);
-							else
-								eObject = state.getEObject(getEObjectURI().fragment());
-							return work.exec(eObject);
-						}
-						return null;
-					}
-	
-				});
-			} catch (RuntimeException e) {
-				LOG.warn(e.getMessage(), e);
-				return null;
-			}
-		} else {
+		if (getEObjectURI() == null) return null;
+
+		try {
+			return getDocument().tryReadOnly(new IUnitOfWork<T, XtextResource>() {
+				@Override
+				public T exec(XtextResource state) throws Exception {
+					EObject eObject;
+					if (state.getResourceSet() != null)
+						eObject = state.getResourceSet().getEObject(getEObjectURI(), true);
+					else
+						eObject = state.getEObject(getEObjectURI().fragment());
+					if (eObject == null) return null;
+
+					return work.exec(eObject);
+				}
+			});
+		} catch (RuntimeException e) {
+			LOG.warn(e.getMessage(), e);
 			return null;
 		}
 	}


### PR DESCRIPTION
This can happen when the `getEObjectURI()` is out of sync with the XtextResource.

It occurred to me in the `getChildren()` call when I was adding a new element to my file and then pressing Ctrl+Z at exactly the right time. This made the `getEObjectURI()` return the new element, but it was queried on an XtextResource that no longer had said item.

Of course you can fix this in your implementation by adding a dispatch for `getChildren()` that handles `Void` items, but this would have to be done for every outline implementation and it doesn't seem useful to me at all to try to create an outline node for a null item.

This PR needs API from https://github.com/eclipse/xtext-core/pull/766.