### PR TITLE
[#699] Improve the Formatter of the Xtext State-Machine Example.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.tests/src/org/eclipse/xtext/example/fowlerdsl/tests/StatemachineFormatterTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.tests/src/org/eclipse/xtext/example/fowlerdsl/tests/StatemachineFormatterTest.xtend
@@ -116,6 +116,52 @@ class StatemachineFormatterTest {
 			'''
 		]
 	}
+	
+	@Test def events_commands() {
+		assertFormatted[
+			toBeFormatted = '''
+				events doorClosed D1CL drawerOpened D2OP lightOn L1ON doorOpened D1OP panelClosed PNCL end
+				commands unlockPanel PNUL lockPanel NLK lockDoor D1LK unlockDoor D1UL end
+			'''
+			expectation = '''
+				events
+					doorClosed   D1CL
+					drawerOpened D2OP
+					lightOn      L1ON
+					doorOpened   D1OP
+					panelClosed  PNCL
+				end
+				
+				commands
+					unlockPanel PNUL
+					lockPanel   NLK
+					lockDoor    D1LK
+					unlockDoor  D1UL
+				end
+			'''
+		]
+	}
+
+	@Test def events_state() {
+		assertFormatted[
+			toBeFormatted = '''
+				events doorClosed D1CL drawerOpened D2OP lightOn L1ON doorOpened D1OP panelClosed PNCL end
+				state idle end
+			'''
+			expectation = '''
+				events
+					doorClosed   D1CL
+					drawerOpened D2OP
+					lightOn      L1ON
+					doorOpened   D1OP
+					panelClosed  PNCL
+				end
+				
+				state idle
+				end
+			'''
+		]
+	}
 
 	@Test def events_resetEvents_commands() {
 		assertFormatted[
@@ -142,6 +188,32 @@ class StatemachineFormatterTest {
 					lockPanel   NLK
 					lockDoor    D1LK
 					unlockDoor  D1UL
+				end
+			'''
+		]
+	}
+	
+	@Test def events_resetEvents_state() {
+		assertFormatted[
+			toBeFormatted = '''
+				events doorClosed D1CL drawerOpened D2OP lightOn L1ON doorOpened D1OP panelClosed PNCL end
+				resetEvents doorOpened end state idle doorClosed => active end
+			'''
+			expectation = '''
+				events
+					doorClosed   D1CL
+					drawerOpened D2OP
+					lightOn      L1ON
+					doorOpened   D1OP
+					panelClosed  PNCL
+				end
+				
+				resetEvents
+					doorOpened
+				end
+				
+				state idle
+					doorClosed => active
 				end
 			'''
 		]

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/tests/StatemachineFormatterTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/tests/StatemachineFormatterTest.java
@@ -208,6 +208,96 @@ public class StatemachineFormatterTest {
   }
   
   @Test
+  public void events_commands() {
+    final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("events doorClosed D1CL drawerOpened D2OP lightOn L1ON doorOpened D1OP panelClosed PNCL end");
+      _builder.newLine();
+      _builder.append("commands unlockPanel PNUL lockPanel NLK lockDoor D1LK unlockDoor D1UL end");
+      _builder.newLine();
+      it.setToBeFormatted(_builder);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("events");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("doorClosed   D1CL");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("drawerOpened D2OP");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("lightOn      L1ON");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("doorOpened   D1OP");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("panelClosed  PNCL");
+      _builder_1.newLine();
+      _builder_1.append("end");
+      _builder_1.newLine();
+      _builder_1.newLine();
+      _builder_1.append("commands");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("unlockPanel PNUL");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("lockPanel   NLK");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("lockDoor    D1LK");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("unlockDoor  D1UL");
+      _builder_1.newLine();
+      _builder_1.append("end");
+      _builder_1.newLine();
+      it.setExpectation(_builder_1);
+    };
+    this._formatterTestHelper.assertFormatted(_function);
+  }
+  
+  @Test
+  public void events_state() {
+    final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("events doorClosed D1CL drawerOpened D2OP lightOn L1ON doorOpened D1OP panelClosed PNCL end");
+      _builder.newLine();
+      _builder.append("state idle end");
+      _builder.newLine();
+      it.setToBeFormatted(_builder);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("events");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("doorClosed   D1CL");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("drawerOpened D2OP");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("lightOn      L1ON");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("doorOpened   D1OP");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("panelClosed  PNCL");
+      _builder_1.newLine();
+      _builder_1.append("end");
+      _builder_1.newLine();
+      _builder_1.newLine();
+      _builder_1.append("state idle");
+      _builder_1.newLine();
+      _builder_1.append("end");
+      _builder_1.newLine();
+      it.setExpectation(_builder_1);
+    };
+    this._formatterTestHelper.assertFormatted(_function);
+  }
+  
+  @Test
   public void events_resetEvents_commands() {
     final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
       StringConcatenation _builder = new StringConcatenation();
@@ -260,6 +350,56 @@ public class StatemachineFormatterTest {
       _builder_1.newLine();
       _builder_1.append("\t");
       _builder_1.append("unlockDoor  D1UL");
+      _builder_1.newLine();
+      _builder_1.append("end");
+      _builder_1.newLine();
+      it.setExpectation(_builder_1);
+    };
+    this._formatterTestHelper.assertFormatted(_function);
+  }
+  
+  @Test
+  public void events_resetEvents_state() {
+    final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("events doorClosed D1CL drawerOpened D2OP lightOn L1ON doorOpened D1OP panelClosed PNCL end");
+      _builder.newLine();
+      _builder.append("resetEvents doorOpened end state idle doorClosed => active end");
+      _builder.newLine();
+      it.setToBeFormatted(_builder);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("events");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("doorClosed   D1CL");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("drawerOpened D2OP");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("lightOn      L1ON");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("doorOpened   D1OP");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("panelClosed  PNCL");
+      _builder_1.newLine();
+      _builder_1.append("end");
+      _builder_1.newLine();
+      _builder_1.newLine();
+      _builder_1.append("resetEvents");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("doorOpened");
+      _builder_1.newLine();
+      _builder_1.append("end");
+      _builder_1.newLine();
+      _builder_1.newLine();
+      _builder_1.append("state idle");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("doorClosed => active");
       _builder_1.newLine();
       _builder_1.append("end");
       _builder_1.newLine();

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/formatting2/StatemachineFormatter.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/formatting2/StatemachineFormatter.xtend
@@ -43,7 +43,7 @@ class StatemachineFormatter extends AbstractFormatter2 {
 		
 		events.forEach[format]
 		
-		if(hasResetEvents) {
+		if(hasResetEvents || hasCommands || hasStates) {
 			end.append[setNewLines(2)]
 		}
 	}
@@ -61,7 +61,7 @@ class StatemachineFormatter extends AbstractFormatter2 {
 		
 		end.prepend[newLine]
 		
-		if(hasCommands) {
+		if(hasCommands || hasStates) {
 			end.append[setNewLines(2)]
 		}
 	}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/xtend-gen/org/eclipse/xtext/example/fowlerdsl/formatting2/StatemachineFormatter.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/xtend-gen/org/eclipse/xtext/example/fowlerdsl/formatting2/StatemachineFormatter.java
@@ -56,8 +56,7 @@ public class StatemachineFormatter extends AbstractFormatter2 {
       document.<Event>format(it_1);
     };
     it.getEvents().forEach(_function_2);
-    boolean _hasResetEvents = this.hasResetEvents(it);
-    if (_hasResetEvents) {
+    if (((this.hasResetEvents(it) || this.hasCommands(it)) || this.hasStates(it))) {
       final Procedure1<IHiddenRegionFormatter> _function_3 = (IHiddenRegionFormatter it_1) -> {
         it_1.setNewLines(2);
       };
@@ -84,8 +83,7 @@ public class StatemachineFormatter extends AbstractFormatter2 {
       it_1.newLine();
     };
     document.prepend(end, _function_3);
-    boolean _hasCommands = this.hasCommands(it);
-    if (_hasCommands) {
+    if ((this.hasCommands(it) || this.hasStates(it))) {
       final Procedure1<IHiddenRegionFormatter> _function_4 = (IHiddenRegionFormatter it_1) -> {
         it_1.setNewLines(2);
       };


### PR DESCRIPTION
- Ensure that the formatter inserts an empty line between the events and
the commands block (if no resetEvents block), between the events and the
states block (if no resetEvents block and or commands block), and
between the resetEvents and the states block (if no commands block).
- Implement corresponding StatemachineFormatterTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>