### PR TITLE
Improve the SerializerTest of the Xtext Homeautomation Example.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.tests/src/org/eclipse/xtext/example/homeautomation/tests/SerializerTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.tests/src/org/eclipse/xtext/example/homeautomation/tests/SerializerTest.xtend
@@ -6,6 +6,7 @@ import javax.inject.Provider
 import org.eclipse.emf.common.util.URI
 import org.eclipse.xtext.example.homeautomation.ruleEngine.Device
 import org.eclipse.xtext.example.homeautomation.ruleEngine.RuleEngineFactory
+import org.eclipse.xtext.resource.FileExtensionProvider
 import org.eclipse.xtext.resource.SaveOptions
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.serializer.ISerializer
@@ -19,9 +20,11 @@ import org.junit.runner.RunWith
 @RunWith(XtextRunner)
 @InjectWith(RuleEngineInjectorProvider)
 class SerializerTest extends Assert {
+	
 	@Inject ISerializer serializer
 	extension RuleEngineFactory = RuleEngineFactory.eINSTANCE
 	extension XbaseFactory = XbaseFactory.eINSTANCE
+	@Inject extension FileExtensionProvider
 	@Inject Provider<XtextResourceSet> rsProvider
 	
 	@Test
@@ -55,7 +58,7 @@ class SerializerTest extends Assert {
 			]
 		]
 		
-		val resource = rs.createResource(URI.createURI("heater.rules"))
+		val resource = rs.createResource(URI.createURI("heater." + primaryFileExtension))
 		resource.contents += model
 		
 		val sw = new StringWriter

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/tests/SerializerTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/tests/SerializerTest.java
@@ -18,6 +18,7 @@ import org.eclipse.xtext.example.homeautomation.ruleEngine.Rule;
 import org.eclipse.xtext.example.homeautomation.ruleEngine.RuleEngineFactory;
 import org.eclipse.xtext.example.homeautomation.ruleEngine.State;
 import org.eclipse.xtext.example.homeautomation.tests.RuleEngineInjectorProvider;
+import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.resource.SaveOptions;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.serializer.ISerializer;
@@ -53,6 +54,10 @@ public class SerializerTest extends Assert {
   
   @Extension
   private XbaseFactory _xbaseFactory = XbaseFactory.eINSTANCE;
+  
+  @Inject
+  @Extension
+  private FileExtensionProvider _fileExtensionProvider;
   
   @Inject
   private Provider<XtextResourceSet> rsProvider;
@@ -136,7 +141,9 @@ public class SerializerTest extends Assert {
       };
       Rule _doubleArrow_2 = ObjectExtensions.<Rule>operator_doubleArrow(_createRule, _function_2);
       _declarations_2.add(_doubleArrow_2);
-      final Resource resource = rs.createResource(URI.createURI("heater.rules"));
+      String _primaryFileExtension = this._fileExtensionProvider.getPrimaryFileExtension();
+      String _plus = ("heater." + _primaryFileExtension);
+      final Resource resource = rs.createResource(URI.createURI(_plus));
       EList<EObject> _contents = resource.getContents();
       _contents.add(model);
       final StringWriter sw = new StringWriter();


### PR DESCRIPTION
- Use the FileExtensionProvider.primaryFileExtension method to access
the file extension instead of using the hard-coded '.rules' literal.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>