### PR TITLE
Extract the Xtext Example plugin descriptions to the plugin.properties.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/plugin.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2008-2012 itemis AG (http://www.itemis.eu) and others.
+# Copyright (c) 2008-2018 itemis AG (http://www.itemis.eu) and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -26,3 +26,9 @@ XtendTutorial_name=Xtend Tutorial
 XtendTutorial_description=A hands-on tutorial Xtend
 XtextTutorial_name=Step By Step Xtext Tutorial
 XtextTutorial_description=Domain Specific Languages for Java Developers - A Step-By-Step Experience
+RuntimePlugin_description=Contains the parser, serializer, linker, etc.
+IdePlugin_description=Contains the Generic IDE services.
+RuntimeTestsPlugin_description=Contains the runtime tests for the language.
+UiPlugin_description=Contains the Eclipse IDE integration (i.e. editor).
+UiTestsPlugin_description=Contains the Eclipse IDE integration tests.
+RelengPlugin_description=Release Engineering: Maven Parent, Target Platform Definition.

--- a/org.eclipse.xtext.xtext.ui.examples/plugin.xml
+++ b/org.eclipse.xtext.xtext.ui.examples/plugin.xml
@@ -35,12 +35,12 @@
 	</extension>
 	<extension point="org.eclipse.emf.common.ui.examples">
 		<example wizardID="org.eclipse.xtext.examples.NewDomainModelExampleWizard" pageImage="icons/genproject.gif">
-			<projectDescriptor name="org.eclipse.xtext.example.domainmodel" contentURI="contents/org.eclipse.xtext.example.domainmodel.zip" description="Contains the parser, serializer, linker, etc."/>
-			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.ide" contentURI="contents/org.eclipse.xtext.example.domainmodel.ide.zip" description="Contains the Generic IDE services."/>
-			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.tests" contentURI="contents/org.eclipse.xtext.example.domainmodel.tests.zip" description="Contains the runtime tests for the language."/>
-			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.ui" contentURI="contents/org.eclipse.xtext.example.domainmodel.ui.zip" description="Contains the Eclipse IDE integration (i.e. editor)."/>
-			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.ui.tests" contentURI="contents/org.eclipse.xtext.example.domainmodel.ui.tests.zip" description="Contains the Eclipse IDE integration tests."/>
-			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.releng" contentURI="contents/org.eclipse.xtext.example.domainmodel.releng.zip" description="Release Engineering: Maven Parent, Target Platform Definition."/>
+			<projectDescriptor name="org.eclipse.xtext.example.domainmodel" contentURI="contents/org.eclipse.xtext.example.domainmodel.zip" description="%RuntimePlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.ide" contentURI="contents/org.eclipse.xtext.example.domainmodel.ide.zip" description="%IdePlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.tests" contentURI="contents/org.eclipse.xtext.example.domainmodel.tests.zip" description="%RuntimeTestsPlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.ui" contentURI="contents/org.eclipse.xtext.example.domainmodel.ui.zip" description="%UiPlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.ui.tests" contentURI="contents/org.eclipse.xtext.example.domainmodel.ui.tests.zip" description="%UiTestsPlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.domainmodel.releng" contentURI="contents/org.eclipse.xtext.example.domainmodel.releng.zip" description="%RelengPlugin_description"/>
 			<fileToOpen location="org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/Domainmodel.xtext"/>
 			<fileToOpen location="org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/jvmmodel/DomainmodelJvmModelInferrer.xtend"/>
 			<fileToOpen location="org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/validation/DomainmodelJavaValidator.java"/>
@@ -70,10 +70,10 @@
 	</extension>
 	<extension point="org.eclipse.emf.common.ui.examples">
 		<example wizardID="org.eclipse.xtext.examples.NewFowlerDSLExampleWizard" pageImage="icons/genproject.gif">
-			<projectDescriptor name="org.eclipse.xtext.example.fowlerdsl" contentURI="contents/org.eclipse.xtext.example.fowlerdsl.zip" description="Contains the parser, serializer, linker, etc."/>
-			<projectDescriptor name="org.eclipse.xtext.example.fowlerdsl.ide" contentURI="contents/org.eclipse.xtext.example.fowlerdsl.ide.zip" description="Contains the Generic IDE services."/>
-			<projectDescriptor name="org.eclipse.xtext.example.fowlerdsl.tests" contentURI="contents/org.eclipse.xtext.example.fowlerdsl.tests.zip" description="Contains the runtime tests for the language."/>
-			<projectDescriptor name="org.eclipse.xtext.example.fowlerdsl.ui" contentURI="contents/org.eclipse.xtext.example.fowlerdsl.ui.zip"  description="Contains the Eclipse IDE integration (i.e. editor)."/>
+			<projectDescriptor name="org.eclipse.xtext.example.fowlerdsl" contentURI="contents/org.eclipse.xtext.example.fowlerdsl.zip" description="%RuntimePlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.fowlerdsl.ide" contentURI="contents/org.eclipse.xtext.example.fowlerdsl.ide.zip" description="%IdePlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.fowlerdsl.tests" contentURI="contents/org.eclipse.xtext.example.fowlerdsl.tests.zip" description="%RuntimeTestsPlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.fowlerdsl.ui" contentURI="contents/org.eclipse.xtext.example.fowlerdsl.ui.zip"  description="%UiPlugin_description"/>
 			<fileToOpen location="org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/Statemachine.xtext"/>
 			<fileToOpen location="org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/generator/StatemachineGenerator.xtend"/>
 		</example>
@@ -102,11 +102,11 @@
 	</extension>
 	<extension point="org.eclipse.emf.common.ui.examples">
 		<example wizardID="org.eclipse.xtext.examples.NewArithmeticsExampleWizard" pageImage="icons/genproject.gif">
-			<projectDescriptor name="org.eclipse.xtext.example.arithmetics" contentURI="contents/org.eclipse.xtext.example.arithmetics.zip" description="Contains the parser, serializer, linker, etc."/>
-			<projectDescriptor name="org.eclipse.xtext.example.arithmetics.ide" contentURI="contents/org.eclipse.xtext.example.arithmetics.ide.zip" description="Contains the Generic IDE services."/>
-			<projectDescriptor name="org.eclipse.xtext.example.arithmetics.tests" contentURI="contents/org.eclipse.xtext.example.arithmetics.tests.zip" description="Contains the runtime tests for the language."/>
-			<projectDescriptor name="org.eclipse.xtext.example.arithmetics.ui" contentURI="contents/org.eclipse.xtext.example.arithmetics.ui.zip"  description="Contains the Eclipse IDE integration (i.e. editor)."/>
-			<projectDescriptor name="org.eclipse.xtext.example.arithmetics.ui.tests" contentURI="contents/org.eclipse.xtext.example.arithmetics.ui.tests.zip"  description="Contains the Eclipse IDE integration tests."/>
+			<projectDescriptor name="org.eclipse.xtext.example.arithmetics" contentURI="contents/org.eclipse.xtext.example.arithmetics.zip" description="%RuntimePlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.arithmetics.ide" contentURI="contents/org.eclipse.xtext.example.arithmetics.ide.zip" description="%IdePlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.arithmetics.tests" contentURI="contents/org.eclipse.xtext.example.arithmetics.tests.zip" description="%RuntimeTestsPlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.arithmetics.ui" contentURI="contents/org.eclipse.xtext.example.arithmetics.ui.zip"  description="%UiPlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.arithmetics.ui.tests" contentURI="contents/org.eclipse.xtext.example.arithmetics.ui.tests.zip"  description="%UiTestsPlugin_description"/>
 			<fileToOpen location="org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/Arithmetics.xtext"/>
 		</example>
 	</extension>
@@ -134,10 +134,10 @@
 	</extension>
 	<extension point="org.eclipse.emf.common.ui.examples">
 		<example wizardID="org.eclipse.xtext.examples.NewHomeAutomationExampleWizard" pageImage="icons/genproject.gif">
-			<projectDescriptor name="org.eclipse.xtext.example.homeautomation" contentURI="contents/org.eclipse.xtext.example.homeautomation.zip" description="Contains the parser, serializer, linker, etc."/>
-			<projectDescriptor name="org.eclipse.xtext.example.homeautomation.tests" contentURI="contents/org.eclipse.xtext.example.homeautomation.tests.zip" description="Contains the runtime tests for the language."/>
-			<projectDescriptor name="org.eclipse.xtext.example.homeautomation.ide" contentURI="contents/org.eclipse.xtext.example.homeautomation.ide.zip" description="Contains the Generic IDE services."/>
-			<projectDescriptor name="org.eclipse.xtext.example.homeautomation.ui" contentURI="contents/org.eclipse.xtext.example.homeautomation.ui.zip" description="Contains the Eclipse IDE integration (i.e. editor)."/>
+			<projectDescriptor name="org.eclipse.xtext.example.homeautomation" contentURI="contents/org.eclipse.xtext.example.homeautomation.zip" description="%RuntimePlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.homeautomation.tests" contentURI="contents/org.eclipse.xtext.example.homeautomation.tests.zip" description="%RuntimeTestsPlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.homeautomation.ide" contentURI="contents/org.eclipse.xtext.example.homeautomation.ide.zip" description="%IdePlugin_description"/>
+			<projectDescriptor name="org.eclipse.xtext.example.homeautomation.ui" contentURI="contents/org.eclipse.xtext.example.homeautomation.ui.zip" description="%UiPlugin_description"/>
 			<fileToOpen location="org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/RuleEngine.xtext"/>
 			<fileToOpen location="org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/formatting2/RuleEngineFormatter.xtend"/>
 			<fileToOpen location="org.eclipse.xtext.example.homeautomation/src/org/eclipse/xtext/example/homeautomation/jvmmodel/RuleEngineJvmModelInferrer.xtend"/>


### PR DESCRIPTION
- Move the description text from the plugin.xml into the
plugin.properties to eliminate the usage of duplicated text literals.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>