### PR TITLE
[#736] Add syntactical/semantical highlighting ui test infrastructure.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.xtend
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ui.testing
+
+import com.google.inject.Inject
+import org.eclipse.core.resources.IFile
+import org.eclipse.swt.custom.StyleRange
+import org.eclipse.swt.custom.StyledText
+import org.eclipse.swt.graphics.Color
+import org.eclipse.xtext.resource.FileExtensionProvider
+import org.eclipse.xtext.ui.XtextProjectHelper
+import org.eclipse.xtext.ui.editor.XtextEditorInfo
+import org.eclipse.xtext.ui.editor.utils.TextStyle
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
+
+import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.addNature
+
+/**
+ * @since 2.15
+ */
+abstract class AbstractHighlightingTest extends AbstractEditorTest {
+
+	@Inject XtextEditorInfo editorInfo
+
+	@Inject extension SyncUtil
+	@Inject extension FileExtensionProvider
+
+	override protected getEditorId() {
+		editorInfo.getEditorId
+	}
+
+	/**
+	 * @param it The editor's input text. The input text must contain the given <code>text</code>.
+	 * @param text The text that's highlighting style is to test.
+	 * @param style The expected highlighting configuration text style used when highlighting the given <code>text</code>. 
+	 */
+	def testHighlighting(CharSequence it, String text, TextStyle style) {
+		testHighlighting(text, style.style, 
+			if (style.color===null) 0 else style.color.red,
+			if (style.color===null) 0 else style.color.green,
+			if (style.color===null) 0 else style.color.blue,
+			if (style.backgroundColor===null) 255 else style.backgroundColor.red,
+			if (style.backgroundColor===null) 255 else style.backgroundColor.green,
+			if (style.backgroundColor===null) 255 else style.backgroundColor.blue
+		)
+	}
+
+	/**
+	 * @param it The editor's input text. The input text must contain the given <code>text</code>.
+	 * @param text The text that's highlighting style is to test.
+	 * @param fontStyle The expected font style used when highlighting the given <code>text</code>. 
+	 * @param foregroundR The red component of the expected foreground color when highlighting the given <code>text</code>.
+	 * @param foregroundG The green component of the expected foreground color when highlighting the given <code>text</code>.
+	 * @param foregroundB The blue component of the expected foreground color when highlighting the given <code>text</code>.
+	 */
+	def testHighlighting(CharSequence it, String text, int fontStyle, int foregroundR, int foregroundG, int foregroundB) {
+		testHighlighting(text, fontStyle, foregroundR, foregroundG, foregroundB, 255, 255, 255)
+	}
+
+	/**
+	 * @param it The editor's input text. The input text must contain the given <code>text</code>.
+	 * @param text The text that's highlighting style is to test.
+	 * @param fontStyle The expected font style used when highlighting the given <code>text</code>. 
+	 * @param foregroundR The red component of the expected foreground color when highlighting the given <code>text</code>.
+	 * @param foregroundG The green component of the expected foreground color when highlighting the given <code>text</code>.
+	 * @param foregroundB The blue component of the expected foreground color when highlighting the given <code>text</code>.
+	 * @param backgroundR The red component of the expected background color when highlighting the given <code>text</code>.
+	 * @param backgroundG The green component of the expected background color when highlighting the given <code>text</code>.
+	 * @param backgroundB The blue component of the expected background color when highlighting the given <code>text</code>.
+	 */
+	def testHighlighting(CharSequence it, String text, int fontStyle,
+		int foregroundR, int foregroundG, int foregroundB, 
+		int backgroundR, int backgroundG, int backgroundB) {
+		dslFile.openInEditor.testHighlighting(
+			text, fontStyle,
+			foregroundR, foregroundG, foregroundB,
+			backgroundR, backgroundG, backgroundB
+		)
+	}
+
+	protected def dslFile(CharSequence content) {
+		val file = IResourcesSetupUtil.createFile(projectName, fileName, fileExtension, content.toString)
+		
+		/*
+		 * TODO: find a better (with good performance) solution
+		 * to set the Xtext nature on the test project.
+		 */
+		val project = file.project
+		if(!project.hasNature(XtextProjectHelper.NATURE_ID)) {
+			project.addNature(XtextProjectHelper.NATURE_ID)
+		}
+		
+		file
+	}
+
+	protected def String getProjectName() '''HighlightingTestProject'''
+
+	protected def String getFileName() '''highlighting'''
+
+	protected def getFileExtension() {
+		primaryFileExtension
+	}
+
+	protected def openInEditor(IFile dslFile) {
+		val editor = dslFile.openEditor
+		
+		/*
+		 * wait for the Xtext framework HighlightingPresenter.updatePresentation()
+		 * to apply the semantic highlighting executed asynchronously
+		 */
+		editor.waitForReconciler
+	
+		editor.internalSourceViewer.textWidget
+	}
+
+	protected def testHighlighting(StyledText styledText, String text, int fontStyle,
+		int foregroundR, int foregroundG, int foregroundB, 
+		int backgroundR, int backgroundG, int backgroundB) {
+
+		val expectedForegroundColor = new Color(null, foregroundR, foregroundG, foregroundB)
+		val expectedBackgroundColor = new Color(null, backgroundR, backgroundG, backgroundB)
+
+		val content = styledText.text
+		val offset = content.indexOf(text)
+		assertNotEquals('''Cannot locate '«text»' in «content»''', -1, offset)
+		
+		for (var i = 0; i < text.length; i++) {
+			val currentPosition = offset + i
+			val character = styledText.getTextRange(currentPosition, 1)
+			val styleRange = styledText.getStyleRangeAtOffset(currentPosition)
+			if (character.isRelevant) {
+				styleRange => [
+					assertFontStyle(character, fontStyle)
+					assertForegroundColor(character, expectedForegroundColor)
+					assertBackgroundColor(character, expectedBackgroundColor)
+				]
+			}
+		}
+	}
+
+	protected def isRelevant(String character) {
+		// skipping the whitespace characters
+		character == character.trim 
+	}
+
+	protected def assertFontStyle(StyleRange it, String character, int expected) {
+		val actual = fontStyle
+		assertEquals('''Expected font style does not correspond to the actual font style on character «character»''',
+			expected, actual)
+	}
+
+	protected def assertForegroundColor(StyleRange it, String character, Color expected) {
+		val actual = foreground ?: new Color(null, 0, 0, 0) // the default foreground color is black 
+		assertEquals('''Expected foreground color does not correspond to the actual foreground color on character «character»''',
+			expected, actual)
+	}
+
+	protected def assertBackgroundColor(StyleRange it, String character, Color expected) {
+		val actual = background ?: new Color(null, 255, 255, 255) // the default background color is white 
+		assertEquals('''Expected background color does not correspond to the actual background color on character «character»''',
+			expected, actual)
+	}
+
+}

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.java
@@ -1,0 +1,259 @@
+/**
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ui.testing;
+
+import com.google.common.base.Objects;
+import com.google.inject.Inject;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.resource.FileExtensionProvider;
+import org.eclipse.xtext.ui.XtextProjectHelper;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.eclipse.xtext.ui.editor.XtextEditorInfo;
+import org.eclipse.xtext.ui.editor.utils.TextStyle;
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
+import org.eclipse.xtext.ui.testing.AbstractEditorTest;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+
+/**
+ * @since 2.15
+ */
+@SuppressWarnings("all")
+public abstract class AbstractHighlightingTest extends AbstractEditorTest {
+  @Inject
+  private XtextEditorInfo editorInfo;
+  
+  @Inject
+  @Extension
+  private SyncUtil _syncUtil;
+  
+  @Inject
+  @Extension
+  private FileExtensionProvider _fileExtensionProvider;
+  
+  @Override
+  protected String getEditorId() {
+    return this.editorInfo.getEditorId();
+  }
+  
+  /**
+   * @param it The editor's input text. The input text must contain the given <code>text</code>.
+   * @param text The text that's highlighting style is to test.
+   * @param style The expected highlighting configuration text style used when highlighting the given <code>text</code>.
+   */
+  public void testHighlighting(final CharSequence it, final String text, final TextStyle style) {
+    int _style = style.getStyle();
+    int _xifexpression = (int) 0;
+    RGB _color = style.getColor();
+    boolean _tripleEquals = (_color == null);
+    if (_tripleEquals) {
+      _xifexpression = 0;
+    } else {
+      _xifexpression = style.getColor().red;
+    }
+    int _xifexpression_1 = (int) 0;
+    RGB _color_1 = style.getColor();
+    boolean _tripleEquals_1 = (_color_1 == null);
+    if (_tripleEquals_1) {
+      _xifexpression_1 = 0;
+    } else {
+      _xifexpression_1 = style.getColor().green;
+    }
+    int _xifexpression_2 = (int) 0;
+    RGB _color_2 = style.getColor();
+    boolean _tripleEquals_2 = (_color_2 == null);
+    if (_tripleEquals_2) {
+      _xifexpression_2 = 0;
+    } else {
+      _xifexpression_2 = style.getColor().blue;
+    }
+    int _xifexpression_3 = (int) 0;
+    RGB _backgroundColor = style.getBackgroundColor();
+    boolean _tripleEquals_3 = (_backgroundColor == null);
+    if (_tripleEquals_3) {
+      _xifexpression_3 = 255;
+    } else {
+      _xifexpression_3 = style.getBackgroundColor().red;
+    }
+    int _xifexpression_4 = (int) 0;
+    RGB _backgroundColor_1 = style.getBackgroundColor();
+    boolean _tripleEquals_4 = (_backgroundColor_1 == null);
+    if (_tripleEquals_4) {
+      _xifexpression_4 = 255;
+    } else {
+      _xifexpression_4 = style.getBackgroundColor().green;
+    }
+    int _xifexpression_5 = (int) 0;
+    RGB _backgroundColor_2 = style.getBackgroundColor();
+    boolean _tripleEquals_5 = (_backgroundColor_2 == null);
+    if (_tripleEquals_5) {
+      _xifexpression_5 = 255;
+    } else {
+      _xifexpression_5 = style.getBackgroundColor().blue;
+    }
+    this.testHighlighting(it, text, _style, _xifexpression, _xifexpression_1, _xifexpression_2, _xifexpression_3, _xifexpression_4, _xifexpression_5);
+  }
+  
+  /**
+   * @param it The editor's input text. The input text must contain the given <code>text</code>.
+   * @param text The text that's highlighting style is to test.
+   * @param fontStyle The expected font style used when highlighting the given <code>text</code>.
+   * @param foregroundR The red component of the expected foreground color when highlighting the given <code>text</code>.
+   * @param foregroundG The green component of the expected foreground color when highlighting the given <code>text</code>.
+   * @param foregroundB The blue component of the expected foreground color when highlighting the given <code>text</code>.
+   */
+  public void testHighlighting(final CharSequence it, final String text, final int fontStyle, final int foregroundR, final int foregroundG, final int foregroundB) {
+    this.testHighlighting(it, text, fontStyle, foregroundR, foregroundG, foregroundB, 255, 255, 255);
+  }
+  
+  /**
+   * @param it The editor's input text. The input text must contain the given <code>text</code>.
+   * @param text The text that's highlighting style is to test.
+   * @param fontStyle The expected font style used when highlighting the given <code>text</code>.
+   * @param foregroundR The red component of the expected foreground color when highlighting the given <code>text</code>.
+   * @param foregroundG The green component of the expected foreground color when highlighting the given <code>text</code>.
+   * @param foregroundB The blue component of the expected foreground color when highlighting the given <code>text</code>.
+   * @param backgroundR The red component of the expected background color when highlighting the given <code>text</code>.
+   * @param backgroundG The green component of the expected background color when highlighting the given <code>text</code>.
+   * @param backgroundB The blue component of the expected background color when highlighting the given <code>text</code>.
+   */
+  public void testHighlighting(final CharSequence it, final String text, final int fontStyle, final int foregroundR, final int foregroundG, final int foregroundB, final int backgroundR, final int backgroundG, final int backgroundB) {
+    this.testHighlighting(this.openInEditor(this.dslFile(it)), text, fontStyle, foregroundR, foregroundG, foregroundB, backgroundR, backgroundG, backgroundB);
+  }
+  
+  protected IFile dslFile(final CharSequence content) {
+    try {
+      IFile _xblockexpression = null;
+      {
+        final IFile file = IResourcesSetupUtil.createFile(this.getProjectName(), this.getFileName(), this.getFileExtension(), content.toString());
+        final IProject project = file.getProject();
+        boolean _hasNature = project.hasNature(XtextProjectHelper.NATURE_ID);
+        boolean _not = (!_hasNature);
+        if (_not) {
+          IResourcesSetupUtil.addNature(project, XtextProjectHelper.NATURE_ID);
+        }
+        _xblockexpression = file;
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected String getProjectName() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("HighlightingTestProject");
+    return _builder.toString();
+  }
+  
+  protected String getFileName() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("highlighting");
+    return _builder.toString();
+  }
+  
+  protected String getFileExtension() {
+    return this._fileExtensionProvider.getPrimaryFileExtension();
+  }
+  
+  protected StyledText openInEditor(final IFile dslFile) {
+    try {
+      StyledText _xblockexpression = null;
+      {
+        final XtextEditor editor = this.openEditor(dslFile);
+        this._syncUtil.waitForReconciler(editor);
+        _xblockexpression = editor.getInternalSourceViewer().getTextWidget();
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected void testHighlighting(final StyledText styledText, final String text, final int fontStyle, final int foregroundR, final int foregroundG, final int foregroundB, final int backgroundR, final int backgroundG, final int backgroundB) {
+    final Color expectedForegroundColor = new Color(null, foregroundR, foregroundG, foregroundB);
+    final Color expectedBackgroundColor = new Color(null, backgroundR, backgroundG, backgroundB);
+    final String content = styledText.getText();
+    final int offset = content.indexOf(text);
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Cannot locate \'");
+    _builder.append(text);
+    _builder.append("\' in ");
+    _builder.append(content);
+    Assert.assertNotEquals(_builder.toString(), (-1), offset);
+    for (int i = 0; (i < text.length()); i++) {
+      {
+        final int currentPosition = (offset + i);
+        final String character = styledText.getTextRange(currentPosition, 1);
+        final StyleRange styleRange = styledText.getStyleRangeAtOffset(currentPosition);
+        boolean _isRelevant = this.isRelevant(character);
+        if (_isRelevant) {
+          final Procedure1<StyleRange> _function = (StyleRange it) -> {
+            this.assertFontStyle(it, character, fontStyle);
+            this.assertForegroundColor(it, character, expectedForegroundColor);
+            this.assertBackgroundColor(it, character, expectedBackgroundColor);
+          };
+          ObjectExtensions.<StyleRange>operator_doubleArrow(styleRange, _function);
+        }
+      }
+    }
+  }
+  
+  protected boolean isRelevant(final String character) {
+    String _trim = character.trim();
+    return Objects.equal(character, _trim);
+  }
+  
+  protected void assertFontStyle(final StyleRange it, final String character, final int expected) {
+    final int actual = it.fontStyle;
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Expected font style does not correspond to the actual font style on character ");
+    _builder.append(character);
+    Assert.assertEquals(_builder.toString(), expected, actual);
+  }
+  
+  protected void assertForegroundColor(final StyleRange it, final String character, final Color expected) {
+    Color _elvis = null;
+    if (it.foreground != null) {
+      _elvis = it.foreground;
+    } else {
+      Color _color = new Color(null, 0, 0, 0);
+      _elvis = _color;
+    }
+    final Color actual = _elvis;
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Expected foreground color does not correspond to the actual foreground color on character ");
+    _builder.append(character);
+    Assert.assertEquals(_builder.toString(), expected, actual);
+  }
+  
+  protected void assertBackgroundColor(final StyleRange it, final String character, final Color expected) {
+    Color _elvis = null;
+    if (it.background != null) {
+      _elvis = it.background;
+    } else {
+      Color _color = new Color(null, 255, 255, 255);
+      _elvis = _color;
+    }
+    final Color actual = _elvis;
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Expected background color does not correspond to the actual background color on character ");
+    _builder.append(character);
+    Assert.assertEquals(_builder.toString(), expected, actual);
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHighlightingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHighlightingTest.xtend
@@ -1,0 +1,182 @@
+package org.eclipse.xtext.example.fowlerdsl.ui.tests
+
+import org.eclipse.swt.SWT
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHighlightingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(XtextRunner)
+@InjectWith(StatemachineUiInjectorProvider)
+class StatemachineHighlightingTest extends AbstractHighlightingTest {
+
+	@Test def events_keyword() {
+		'''
+			events
+				doorClosed   D1CL
+				drawerOpened D2OP
+				lightOn      L1ON
+				doorOpened   D1OP
+				panelClosed  PNCL
+			end
+		'''.testHighlighting("events", SWT.BOLD, 127, 0, 85)
+	}
+
+	@Test def end_keyword() {
+		'''
+			events
+				doorClosed   D1CL
+				drawerOpened D2OP
+				lightOn      L1ON
+				doorOpened   D1OP
+				panelClosed  PNCL
+			end
+		'''.testHighlighting("end", SWT.BOLD, 127, 0, 85)
+	}
+
+	@Test def resetEvents_keyword() {
+		'''
+			events
+				doorClosed   D1CL
+				drawerOpened D2OP
+				lightOn      L1ON
+				doorOpened   D1OP
+				panelClosed  PNCL
+			end
+			
+			resetEvents
+				doorOpened doorClosed
+			end
+		'''.testHighlighting("resetEvents", SWT.BOLD, 127, 0, 85)
+	}
+
+	@Test def commands_keyword() {
+		'''
+			commands
+				unlockPanel PNUL
+				lockPanel   NLK
+				lockDoor    D1LK
+				unlockDoor  D1UL
+			end
+		'''.testHighlighting("commands", SWT.BOLD, 127, 0, 85)
+	}
+
+	@Test def state_keyword() {
+		'''
+			events
+				doorClosed   D1CL
+				drawerOpened D2OP
+				lightOn      L1ON
+				doorOpened   D1OP
+				panelClosed  PNCL
+			end
+			
+			resetEvents
+				doorOpened
+				doorClosed
+			end
+			
+			commands
+				unlockPanel PNUL
+				lockPanel   NLK
+				lockDoor    D1LK
+				unlockDoor  D1UL
+			end
+			
+			state idle
+				actions {unlockDoor lockPanel}
+				doorClosed => active
+			end
+			
+			state active
+				drawerOpened => waitingForLight
+				lightOn      => waitingForDrawer
+			end
+			
+			state waitingForLight
+				lightOn => unlockedPanel
+			end
+			
+			state waitingForDrawer
+				drawerOpened => unlockedPanel
+			end
+			
+			state unlockedPanel
+				actions {unlockPanel lockDoor}
+				panelClosed => idle
+			end
+		'''.testHighlighting("state", SWT.BOLD, 127, 0, 85)
+	}
+
+	@Test def actions_keyword() {
+		'''
+			events
+				doorClosed   D1CL
+				drawerOpened D2OP
+				lightOn      L1ON
+				doorOpened   D1OP
+				panelClosed  PNCL
+			end
+			
+			resetEvents
+				doorOpened
+				doorClosed
+			end
+			
+			commands
+				unlockPanel PNUL
+				lockPanel   NLK
+				lockDoor    D1LK
+				unlockDoor  D1UL
+			end
+			
+			state idle
+				actions {unlockDoor lockPanel}
+				doorClosed => active
+			end
+			
+			state active
+				drawerOpened => waitingForLight
+				lightOn      => waitingForDrawer
+			end
+			
+			state waitingForLight
+				lightOn => unlockedPanel
+			end
+			
+			state waitingForDrawer
+				drawerOpened => unlockedPanel
+			end
+			
+			state unlockedPanel
+				actions {unlockPanel lockDoor}
+				panelClosed => idle
+			end
+		'''.testHighlighting("actions", SWT.BOLD, 127, 0, 85)
+	}
+
+	@Test def single_line_comment() {
+		'''
+			// An implementation of Martin Fowler's secret compartment state machine
+		'''.testHighlighting("An implementation of Martin Fowler's secret compartment state machine",
+				SWT.NORMAL, 63, 127, 95
+		)
+	}
+
+	@Test def multi_line_comment() {
+		'''
+			/*
+			 * An implementation of Martin Fowler's secret compartment state machine
+			 * 
+			 * http://martinfowler.com/dslwip/Intro.html
+			 */
+		'''.testHighlighting('''
+			/*
+			 * An implementation of Martin Fowler's secret compartment state machine
+			 * 
+			 * http://martinfowler.com/dslwip/Intro.html
+			 */
+		''', SWT.NORMAL, 63, 127, 95)
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHighlightingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHighlightingTest.java
@@ -1,0 +1,368 @@
+package org.eclipse.xtext.example.fowlerdsl.ui.tests;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.fowlerdsl.ui.tests.StatemachineUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHighlightingTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(XtextRunner.class)
+@InjectWith(StatemachineUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class StatemachineHighlightingTest extends AbstractHighlightingTest {
+  @Test
+  public void events_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed   D1CL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened D2OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      L1ON");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened   D1OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed  PNCL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    this.testHighlighting(_builder, "events", SWT.BOLD, 127, 0, 85);
+  }
+  
+  @Test
+  public void end_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed   D1CL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened D2OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      L1ON");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened   D1OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed  PNCL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    this.testHighlighting(_builder, "end", SWT.BOLD, 127, 0, 85);
+  }
+  
+  @Test
+  public void resetEvents_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed   D1CL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened D2OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      L1ON");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened   D1OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed  PNCL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("resetEvents");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened doorClosed");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    this.testHighlighting(_builder, "resetEvents", SWT.BOLD, 127, 0, 85);
+  }
+  
+  @Test
+  public void commands_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("commands");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockPanel PNUL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockPanel   NLK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockDoor    D1LK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockDoor  D1UL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    this.testHighlighting(_builder, "commands", SWT.BOLD, 127, 0, 85);
+  }
+  
+  @Test
+  public void state_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed   D1CL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened D2OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      L1ON");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened   D1OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed  PNCL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("resetEvents");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("commands");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockPanel PNUL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockPanel   NLK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockDoor    D1LK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockDoor  D1UL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state idle");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("actions {unlockDoor lockPanel}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed => active");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state active");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened => waitingForLight");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      => waitingForDrawer");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state waitingForLight");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn => unlockedPanel");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state waitingForDrawer");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened => unlockedPanel");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state unlockedPanel");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("actions {unlockPanel lockDoor}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed => idle");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    this.testHighlighting(_builder, "state", SWT.BOLD, 127, 0, 85);
+  }
+  
+  @Test
+  public void actions_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed   D1CL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened D2OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      L1ON");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened   D1OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed  PNCL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("resetEvents");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("commands");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockPanel PNUL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockPanel   NLK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockDoor    D1LK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockDoor  D1UL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state idle");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("actions {unlockDoor lockPanel}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed => active");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state active");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened => waitingForLight");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      => waitingForDrawer");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state waitingForLight");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn => unlockedPanel");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state waitingForDrawer");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened => unlockedPanel");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state unlockedPanel");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("actions {unlockPanel lockDoor}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed => idle");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    this.testHighlighting(_builder, "actions", SWT.BOLD, 127, 0, 85);
+  }
+  
+  @Test
+  public void single_line_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("// An implementation of Martin Fowler\'s secret compartment state machine");
+    _builder.newLine();
+    this.testHighlighting(_builder, "An implementation of Martin Fowler\'s secret compartment state machine", 
+      SWT.NORMAL, 63, 127, 95);
+  }
+  
+  @Test
+  public void multi_line_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/*");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* An implementation of Martin Fowler\'s secret compartment state machine");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* ");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* http://martinfowler.com/dslwip/Intro.html");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("/*");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* An implementation of Martin Fowler\'s secret compartment state machine");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* ");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* http://martinfowler.com/dslwip/Intro.html");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    this.testHighlighting(_builder, _builder_1.toString(), SWT.NORMAL, 63, 127, 95);
+  }
+}


### PR DESCRIPTION
- Extend the 'Xtext UI Testing' test infrastructure by the
AbstractHighlightingTest abstract class to provide a base infrastructure
for testing the (customized) syntactical/semantical highlighting
behaviour.
- Extend the State-Machine Xtext example by the
StatemachineHighlightingTest to demonstrate the usage of the
AbstractHighlightingTest test class.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>