### PR TITLE
[#739] Avoid double closing of editors

### DIFF
--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/quickfix/SpellingQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/quickfix/SpellingQuickfixTest.java
@@ -46,12 +46,6 @@ public class SpellingQuickfixTest extends AbstractQuickfixTest {
 		xtextEditor = newXtextEditor(PROJECT_NAME, MODEL_FILE, MODEL_WITH_SPELLING_QUICKFIX_IN_SL_COLMMENT);
 	}
 
-	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-		xtextEditor.close(false);
-	}
-
 	@Test
 	public void testSpellingQuickfixInSlComment() throws Exception {
 		ICompletionProposal[] quickAssistProposals = computeQuickAssistProposals(getDocument().getLength());

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractCompositeHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractCompositeHoverTest.java
@@ -45,12 +45,6 @@ public class AbstractCompositeHoverTest extends AbstractEditorTest {
 	}
 
 	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-		editor.close(false);
-	}
-
-	@Override
 	protected String getEditorId() {
 		return "org.eclipse.xtext.ui.tests.TestLanguage";
 	}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractProblemHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AbstractProblemHoverTest.java
@@ -69,12 +69,6 @@ public class AbstractProblemHoverTest extends AbstractEditorTest {
 	}
 
 	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-		editor.close(false);
-	}
-
-	@Override
 	protected String getEditorId() {
 		return "org.eclipse.xtext.ui.tests.TestLanguage";
 	}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AnnotationWithQuickFixesHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/AnnotationWithQuickFixesHoverTest.java
@@ -75,12 +75,6 @@ public class AnnotationWithQuickFixesHoverTest extends AbstractEditorTest {
 	}
 
 	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-		editor.close(false);
-	}
-
-	@Override
 	protected String getEditorId() {
 		return "org.eclipse.xtext.ui.tests.TestLanguage";
 	}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/DispatchingEObjectTextHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/DispatchingEObjectTextHoverTest.java
@@ -48,12 +48,6 @@ public class DispatchingEObjectTextHoverTest extends AbstractEditorTest {
 	}
 
 	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-		editor.close(false);
-	}
-
-	@Override
 	protected String getEditorId() {
 		return "org.eclipse.xtext.ui.tests.TestLanguage";
 	}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/ProblemHoverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/ProblemHoverTest.java
@@ -79,12 +79,6 @@ public class ProblemHoverTest extends AbstractEditorTest {
 	}
 
 	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-		editor.close(false);
-	}
-
-	@Override
 	protected String getEditorId() {
 		return "org.eclipse.xtext.ui.tests.TestLanguage";
 	}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/html/XtextElementLinksTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/hover/html/XtextElementLinksTest.java
@@ -60,12 +60,6 @@ public class XtextElementLinksTest extends AbstractEditorTest {
 		});	
 	}
 	
-	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-		editor.close(false);
-	}
-	
 	@Test public void testDefaultScheme () throws Exception {
 		String link = elementLinks.createLink (f.getStuff().get(0));
 		assertTrue (isLinkOfType (link, XtextElementLinks.XTEXTDOC_SCHEME));

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/AbstractOutlineWorkbenchTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/AbstractOutlineWorkbenchTest.java
@@ -98,7 +98,6 @@ public abstract class AbstractOutlineWorkbenchTest extends AbstractEditorTest {
 	@Override
 	public void tearDown() throws Exception {
 		super.tearDown();
-		editor.close(false);
 		outlineView.getSite().getPage().hideView(outlineView);
 		executeAsyncDisplayJobs();
 	}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/LinkingErrorTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/LinkingErrorTest.java
@@ -36,12 +36,6 @@ public class LinkingErrorTest extends AbstractQuickfixTest {
 	
 	private XtextEditor xtextEditor;
 
-	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-		xtextEditor.close(false);
-	}
-
 	@Test public void testQuickfixTurnaround() throws Exception {
 		xtextEditor = newXtextEditor(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
 		IXtextDocument document = xtextEditor.getDocument();


### PR DESCRIPTION
[#739] Avoid double closing of editors
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>