### PR TITLE
Fixing typo: 'catched' -> 'caught'

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/autoedit/SingleLineTerminalsStrategy.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/autoedit/SingleLineTerminalsStrategy.java
@@ -44,7 +44,7 @@ public class SingleLineTerminalsStrategy extends AbstractTerminalsEditStrategy {
 		/**
 		 * @return whether the closing terminal should be inserted, based on the cursor position
 		 * @throws BadLocationException
-		 *             exceptions are not thrown, thrown exceptions are catched and interpreted like return
+		 *             exceptions are not thrown, thrown exceptions are caught and interpreted like return
 		 *             <code>true</code>
 		 */
 		boolean isInsertClosingBracket(IDocument doc, int offset) throws BadLocationException;

--- a/org.eclipse.xtext.xtext.ui.examples/projects/xbase.tutorial/src/Xbase09_Exceptions.xbase
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/xbase.tutorial/src/Xbase09_Exceptions.xbase
@@ -1,7 +1,7 @@
 /*
  * Xbase supports Exception handling using the same syntax as is used 
  * in Java. There are two differences:
- * 1) Checked exceptions must not be catched in closures.
+ * 1) Checked exceptions must not be caught in closures.
  * 2) Try-catch is an expression and can therefore be used in a deeply 
  *    nested way 
  */


### PR DESCRIPTION
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>