### PR TITLE
[eclipse/xtext-eclipse#759] made AbstractWordAwareDoubleClickStrategy compatible with newer ICU versions

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/doubleClicking/AbstractWordAwareDoubleClickStrategy.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/doubleClicking/AbstractWordAwareDoubleClickStrategy.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.editor.doubleClicking;
 
+
+import java.text.CharacterIterator;
+
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DefaultTextDoubleClickStrategy;
 import org.eclipse.jface.text.IDocument;
@@ -36,7 +39,8 @@ public class AbstractWordAwareDoubleClickStrategy extends DefaultTextDoubleClick
 				return null;
 
 			com.ibm.icu.text.BreakIterator breakIter = createBreakIterator();
-			breakIter.setText(new DocumentCharacterIterator(document));
+			CharacterIterator characterIterator = new DocumentCharacterIterator(document);
+			breakIter.setText(characterIterator);
 			int start = breakIter.preceding(offset);
 			if (start == BreakIterator.DONE)
 				start = line.getOffset();


### PR DESCRIPTION
[eclipse/xtext-eclipse#759] made AbstractWordAwareDoubleClickStrategy compatible with newer ICU versions

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>