### PR TITLE
[eclipse/xtext#1168] Changed by Xtend compiler

### DIFF
--- a/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
+++ b/org.eclipse.xtext.xbase.junit/xtend-gen/org/eclipse/xtext/xbase/compiler/InMemoryJavaCompiler.java
@@ -227,7 +227,7 @@ public class InMemoryJavaCompiler {
     InMemoryJavaCompiler.ClassLoaderBasedNameEnvironment _classLoaderBasedNameEnvironment = new InMemoryJavaCompiler.ClassLoaderBasedNameEnvironment(parent);
     this.nameEnv = _classLoaderBasedNameEnvironment;
     this.parentClassLoader = parent;
-    Map _map = compilerOptions.getMap();
+    Map<String, String> _map = compilerOptions.getMap();
     CompilerOptions _compilerOptions = new CompilerOptions(_map);
     this.compilerOptions = _compilerOptions;
   }

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/ui/editor/XbaseEditorInputRedirector.java
@@ -47,7 +47,7 @@ public class XbaseEditorInputRedirector {
   public ITypeRoot getTypeRoot(final IEditorInput it) {
     ITypeRoot _xblockexpression = null;
     {
-      final Object adapter = it.getAdapter(IJavaElement.class);
+      final IJavaElement adapter = it.<IJavaElement>getAdapter(IJavaElement.class);
       ITypeRoot _xifexpression = null;
       if ((adapter instanceof ITypeRoot)) {
         _xifexpression = ((ITypeRoot)adapter);


### PR DESCRIPTION
Checking in these sources was not possible before due to compile errors
on Luna target.

See also https://github.com/eclipse/xtext-eclipse/pull/744