### PR TITLE
More tests for QuickFixes that don't update CrossRefs.

### DIFF
--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/ui/quickfix/QuickfixCrossrefTestLanguageQuickfixProvider.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/ui/quickfix/QuickfixCrossrefTestLanguageQuickfixProvider.java
@@ -33,6 +33,7 @@ public class QuickfixCrossrefTestLanguageQuickfixProvider extends DefaultQuickfi
 	@Fix(QuickfixCrossrefTestLanguageValidator.MULTIFIXABLE_ISSUE)
 	public void addDocumentation(final Issue issue, IssueResolutionAcceptor acceptor) {
 		acceptor.acceptMulti(issue, "Multi fix", "Multi fix", null, (Element main, ICompositeModificationContext<Element> ctx) -> {
+			ctx.setUpdateCrossReferences(false);
 			ctx.addModification(main, (obj) -> {
 				main.setDoc("Better documentation");
 			});
@@ -64,6 +65,16 @@ public class QuickfixCrossrefTestLanguageQuickfixProvider extends DefaultQuickfi
 					e.setName("goodname");
 				});
 			}
+		});
+	}
+	
+	@Fix(QuickfixCrossrefTestLanguageValidator.FIXABLE)
+	public void renameFixable(final Issue issue, IssueResolutionAcceptor acceptor) {
+		acceptor.acceptMulti(issue, "rename fixable", "rename fixable", null, (Element main, ICompositeModificationContext<Element> ctx) -> {
+			ctx.setUpdateCrossReferences(false);
+			ctx.addModification(main, (obj) -> {
+				main.setName("fixedName");
+			});
 		});
 	}
 }

--- a/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/validation/QuickfixCrossrefTestLanguageValidator.java
+++ b/org.eclipse.xtext.ui.tests/src/org/eclipse/xtext/ui/tests/quickfix/validation/QuickfixCrossrefTestLanguageValidator.java
@@ -28,6 +28,7 @@ public class QuickfixCrossrefTestLanguageValidator extends AbstractQuickfixCross
 	public static final String MULTIFIXABLE_ISSUE = "multiFixableIssue";
 	public static final String MULTIFIXABLE_ISSUE_2 = "multiFixableIssue2";
 	public static final String BAD_NAME_IN_SUBELEMENTS = "badNameInSubelements";
+	public static final String FIXABLE = "fixable";
 		
 	public static final String ISSUE_DATA_0 = "data0";
 	public static final String ISSUE_DATA_1 = "data1";
@@ -76,6 +77,13 @@ public class QuickfixCrossrefTestLanguageValidator extends AbstractQuickfixCross
 				warning(BAD_NAME_IN_SUBELEMENTS, root, QuickfixCrossrefPackage.Literals.ELEMENT__NAME,
 						ValidationMessageAcceptor.INSIGNIFICANT_INDEX, BAD_NAME_IN_SUBELEMENTS, Joiner.on(";").join(fragments));
 			}
+		}
+	}
+	
+	@Check(CheckType.FAST)
+	public void checkFixable(Element ele) {
+		if (ele.getName().startsWith("fixable")) {
+			warning(FIXABLE, ele, QuickfixCrossrefPackage.Literals.ELEMENT__NAME, ValidationMessageAcceptor.INSIGNIFICANT_INDEX, FIXABLE);
 		}
 	}
 }

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
@@ -161,5 +161,20 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 			a {	badname { bar {} } }
 		'''.toString, editor.document.get)
 	}
+	
+	@Test
+	def void testNoCrossRef() throws Exception {
+		val editor = createGeneralXtextProject("myProject").newXtextEditor("test.quickfixcrossreftestlanguage", '''
+			fixable_a {	ref fixable_b }
+			fixable_b {	ref fixable_a }
+		''')
+		val proposals = computeQuickAssistProposals(editor, 1)
+		assertEquals('''rename fixable'''.toString, proposals.map[displayString].join("\n"))
+		proposals.head.apply(editor.document)
+		assertEquals('''
+			fixedName {	ref fixable_b }
+			fixable_b {	ref fixable_a }
+		'''.toString, editor.document.get)
+	}
 
 }

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
@@ -275,4 +275,29 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder_2.newLine();
     Assert.assertEquals(_builder_2.toString(), editor.getDocument().get());
   }
+  
+  @Test
+  public void testNoCrossRef() throws Exception {
+    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("fixable_a {\tref fixable_b }");
+    _builder.newLine();
+    _builder.append("fixable_b {\tref fixable_a }");
+    _builder.newLine();
+    final XtextEditor editor = this.newXtextEditor(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final ICompletionProposal[] proposals = this.computeQuickAssistProposals(editor, 1);
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("rename fixable");
+    final Function1<ICompletionProposal, String> _function = (ICompletionProposal it) -> {
+      return it.getDisplayString();
+    };
+    Assert.assertEquals(_builder_1.toString(), IterableExtensions.join(ListExtensions.<ICompletionProposal, String>map(((List<ICompletionProposal>)Conversions.doWrapArray(proposals)), _function), "\n"));
+    IterableExtensions.<ICompletionProposal>head(((Iterable<ICompletionProposal>)Conversions.doWrapArray(proposals))).apply(editor.getDocument());
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("fixedName {\tref fixable_b }");
+    _builder_2.newLine();
+    _builder_2.append("fixable_b {\tref fixable_a }");
+    _builder_2.newLine();
+    Assert.assertEquals(_builder_2.toString(), editor.getDocument().get());
+  }
 }


### PR DESCRIPTION
Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>