### PR TITLE
fix mwe range that breaks once the 2.9.2 snapshot will be available

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/pom.xml
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/pom.xml
@@ -40,7 +40,7 @@
 					<dependency>
 						<groupId>org.eclipse.emf</groupId>
 						<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-						<version>[2.9.1, 3)</version>
+						<version>2.9.1.201705291010</version>
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>


### PR DESCRIPTION
fix mwe range that breaks once the 2.9.2 snapshot will be available
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>