### PR TITLE
[#768] Ensure that the Run As -> JUnit Test occurs on inherited tests.

### DIFF
--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateJunitLaunch.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateJunitLaunch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,11 +9,13 @@ package org.eclipse.xtext.xbase.ui.launching;
 
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
@@ -31,22 +33,50 @@ public class JavaElementDelegateJunitLaunch extends JavaElementDelegate {
 		}
 		try {
 			ICompilationUnit cu = (ICompilationUnit) element;
-			for (IType type : cu.getAllTypes()) {
-				for (IMethod method : type.getMethods()) {
-					int flags = method.getFlags();
-					if (Modifier.isPublic(flags) && !Modifier.isStatic(flags) &&
-							method.getNumberOfParameters() == 0 && Signature.SIG_VOID.equals(method.getReturnType()) &&
-							method.getElementName().startsWith("test")) { //$NON-NLS-1$
-						return true;
-					}
-					IAnnotation annotation= method.getAnnotation("Test"); //$NON-NLS-1$
-					if (annotation.exists())
-						return true;
+			
+			IType[] allTypes = cu.getAllTypes();
+			
+			for (IType type : allTypes) {
+				if(containsJUnitTestMethod(type)) {
+					return true;
 				}
 			}
+			
+			for (IType type : allTypes) {
+				for(IType superType : getAllSuperTypes(type)) {
+					if(containsJUnitTestMethod(superType)) {
+						return true;
+					}
+				}
+			}
+			
 		} catch (JavaModelException e) {
 			log.error(e.getMessage() ,e);
 		}
 		return super.containsElementsSearchedFor(file);
+	}
+	
+	protected boolean containsJUnitTestMethod(IType type) throws JavaModelException {
+		for (IMethod method : type.getMethods()) {
+			int flags = method.getFlags();
+			if (Modifier.isPublic(flags) && !Modifier.isStatic(flags) &&
+					method.getNumberOfParameters() == 0 && Signature.SIG_VOID.equals(method.getReturnType()) &&
+					method.getElementName().startsWith("test")) { //$NON-NLS-1$
+				return true;
+			}
+			IAnnotation annotation= method.getAnnotation("Test"); //$NON-NLS-1$
+			if (annotation.exists())
+				return true;
+		}
+		return false;
+	}
+	
+	protected IType[] getAllSuperTypes(IType type) throws JavaModelException {
+		/*
+		 * https://stackoverflow.com/questions/49611587/developing-a-eclipse-how-to-get-all-inherited-methods-from-a-icompilationunit
+		 */
+		ITypeHierarchy th = type.newTypeHierarchy(new NullProgressMonitor());
+		IType[] superTypes = th.getAllSuperclasses(type);
+		return superTypes;
 	}
 }


### PR DESCRIPTION
- Modify the JavaElementDelegateJunitLaunch to consider the type
hierarchy (inherited test methods) by determining if an Xtend file
contains a JUnit test method.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>