### PR TITLE
marked old TargetURIConverter as deprecated

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/TargetURIConverter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/TargetURIConverter.java
@@ -11,7 +11,9 @@ import com.google.inject.Singleton;
 
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
+ * @deprecated use {@link org.eclipse.xtext.findReferences.TargetURIConverter} instead.
  */
+@Deprecated
 @Singleton
 public class TargetURIConverter extends org.eclipse.xtext.findReferences.TargetURIConverter {
 }


### PR DESCRIPTION
marked old TargetURIConverter as deprecated
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>