### PR TITLE
[eclipse/xtext-core#824] remove superfluous dependency to xpand

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel-photon.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel-photon.target
@@ -32,11 +32,5 @@
       <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201606061308"/>
       <repository location="http://download.eclipse.org/tools/gef/updates/legacy/releases"/>
     </location>
-    <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.xpand" version="2.0.0.v201406030414"/>
-      <unit id="org.eclipse.xtend" version="2.0.0.v201406030414"/>
-      <unit id="org.eclipse.xtend.typesystem.emf" version="2.0.0.v201406030414"/>
-      <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/xpand/R201406030414"/>
-    </location>
   </locations>
 </target>

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel-photon.tpd
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel-photon.tpd
@@ -41,9 +41,3 @@ location "http://download.eclipse.org/tools/orbit/downloads/drops/R2018060614512
 location "http://download.eclipse.org/tools/gef/updates/legacy/releases" {
 	org.eclipse.draw2d.feature.group	
 }
-
-location "http://download.eclipse.org/modeling/tmf/xtext/updates/releases/xpand/R201406030414" {
-	org.eclipse.xpand
-	org.eclipse.xtend
-	org.eclipse.xtend.typesystem.emf	
-}


### PR DESCRIPTION
[eclipse/xtext-core#824] remove superfluous dependency to xpand
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>