### PR TITLE
Fixed bad equals in DontAskAgainPreferences

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainPreferences.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/DontAskAgainPreferences.java
@@ -49,7 +49,7 @@ public class DontAskAgainPreferences {
 	 * @return Whether to show the question again or not
 	 */
 	public boolean shouldAskAgain(String key) {
-		return getUserDecision(key) != MessageDialogWithToggle.NEVER;
+		return !MessageDialogWithToggle.NEVER.equals(getUserDecision(key));
 	}
 
 	/**


### PR DESCRIPTION
Usually comparing to a constant is the way.
However, we're comparing to a String that's being pulled from an on disk preference file thus it will obviously not be the same instance as the constant.