### PR TITLE
State-Machine Example QuickfixProvider - Use more meaningful method name.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/quickfix/StatemachineQuickfixProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/quickfix/StatemachineQuickfixProvider.xtend
@@ -17,7 +17,7 @@ import org.eclipse.xtext.example.fowlerdsl.validation.StatemachineValidator
 class StatemachineQuickfixProvider extends DefaultQuickfixProvider {
 
 	@Fix(StatemachineValidator.INVALID_NAME)
-	def capitalizeName(Issue issue, IssueResolutionAcceptor acceptor) {
+	def convertNameToFirstLowerCase(Issue issue, IssueResolutionAcceptor acceptor) {
 		acceptor.accept(issue, "Change to '"+issue.data.head.toFirstLower+"'.", "Change to '"+issue.data.head.toFirstLower+"'.", 'upcase.png') [
 			val firstLetter = xtextDocument.get(issue.offset, 1)
 			xtextDocument.replace(issue.offset, 1, firstLetter.toLowerCase)

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/quickfix/StatemachineQuickfixProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/quickfix/StatemachineQuickfixProvider.java
@@ -22,7 +22,7 @@ import org.eclipse.xtext.xbase.lib.StringExtensions;
 @SuppressWarnings("all")
 public class StatemachineQuickfixProvider extends DefaultQuickfixProvider {
   @Fix(StatemachineValidator.INVALID_NAME)
-  public void capitalizeName(final Issue issue, final IssueResolutionAcceptor acceptor) {
+  public void convertNameToFirstLowerCase(final Issue issue, final IssueResolutionAcceptor acceptor) {
     String _firstLower = StringExtensions.toFirstLower(IterableExtensions.<String>head(((Iterable<String>)Conversions.doWrapArray(issue.getData()))));
     String _plus = ("Change to \'" + _firstLower);
     String _plus_1 = (_plus + "\'.");


### PR DESCRIPTION
- Change the methode name from 'capitalizeName' to
'convertNameToFirstLowerCase' to better indicate what the quickfix does.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>