### PR TITLE
[eclipse/xtext#1224] Detect local Jenkins environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ node {
 			targetProfile = "-Pphoton"
 		}
 		wrap([$class:'Xvnc', useXauthority: true]) {
-			sh "${mvnHome}/bin/mvn --batch-mode -fae -Dmaven.test.failure.ignore=true -Dmaven.repo.local=.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn ${targetProfile} clean install"
+			sh "${mvnHome}/bin/mvn --batch-mode -fae -Dmaven.test.failure.ignore=true -Dmaven.repo.local=.m2/repository -DJENKINS_URL=$JENKINS_URL -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn ${targetProfile} clean install"
 		}
 		step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/*.xml'])
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,12 @@ node {
 	])
 	
 	stage('Checkout') {
+		sh '''
+			if [ -d ".git" ]; then
+				git reset --hard
+			fi
+		'''
+
 		checkout scm
 		if ("latest" == params.target_platform) {
 			currentBuild.displayName = "#${BUILD_NUMBER}(x)"
@@ -20,6 +26,31 @@ node {
 		dir('build') { deleteDir() }
 		dir('.m2/repository/org/eclipse/xtext') { deleteDir() }
 		dir('.m2/repository/org/eclipse/xtend') { deleteDir() }
+
+		sh '''
+			branchname=${1:-master}
+			
+			escaped() {
+				echo $branchname | sed 's/\\//%252F/g'
+			}
+			
+			escapedBranch=$(escaped)
+			
+			sed_inplace() {
+				if [[ "$OSTYPE" == "darwin"* ]]; then
+					sed -i '' "$@"
+				else
+					sed -i "$@" 
+				fi	
+			}
+			
+			targetfiles="$(find releng -type f -iname '*.target')"
+			for targetfile in $targetfiles
+			do
+				echo "Redirecting target platforms in $targetfile to $branchname"
+				sed_inplace "s?<repository location=\\".*/job/\\([^/]*\\)/job/[^/]*/?<repository location=\\"$JENKINS_URL/job/\\1/job/$escapedBranch/?" $targetfile
+			done
+		'''
 	}
 	
 	stage('Maven Build') {

--- a/releng/org.eclipse.xtext.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtext.tycho.parent/pom.xml
@@ -19,6 +19,7 @@
 		<sign.skip>true</sign.skip>
 
 		<target-platform-classifier></target-platform-classifier>
+		<JENKINS_URL>http://services.typefox.io/open-source/jenkins</JENKINS_URL>
 	</properties>
 
 	<profiles>
@@ -59,7 +60,7 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>xtend-bootstrap</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/xtend-bootstrap/lastStableBuild/artifact/build-result/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtend-bootstrap/lastStableBuild/artifact/build-result/maven-repository/</url>
 			<releases>
 				<enabled>false</enabled>
 			</releases>


### PR DESCRIPTION
Build steps defined in Jenkinsfile pass the built-in environment
variable 'JENKINS_URL' to the Gradle/Maven executions. This is evaluated
in the build scripts for upstream repository URLs. On Xtext JIPP this
will use upstream repos from JIPP. In local builds outside of Jenkins
the property defaults to Typefox CI like before.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>