### PR TITLE
Run IXtextModelListeners on the UI thread

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/IXtextModelListener.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/IXtextModelListener.java
@@ -15,6 +15,11 @@ import org.eclipse.xtext.resource.XtextResource;
  */
 public interface IXtextModelListener {
 	
+	/**
+	 * Run when the {@link XtextResource} is modified. This code will be executed on the UI thread to guarantee that the corresponding
+	 * IDocument is not being changed during the run. It's therefore important to keep the code executed light weight and offload any heavy
+	 * computation to a background job.
+	 */
 	void modelChanged(XtextResource resource);
 
 }


### PR DESCRIPTION
Some of the IXtextModelListeners silently assume that the IDocument that
is associated with the XtextResource is not being changed during the
listener's run.  This patch achieves this by running the
IXtextModelListeners on the UI thread.

eclipse/xtext-eclipse#816