### PR TITLE
Added comment about possible null return

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/DirtyStateEditorSupport.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/DirtyStateEditorSupport.java
@@ -245,6 +245,9 @@ public class DirtyStateEditorSupport implements IResourceDescription.Event.Liste
 	 */
 	public interface IDirtyStateEditorSupportClient {
 
+		/**
+		 * May return <code>null</code> before EditorPart creation or after its disposal.
+		 */
 		IXtextDocument getDocument();
 
 		boolean isDirty();


### PR DESCRIPTION
Comment is based on org.eclipse.ui.texteditor.AbstractTextEditor.getSourceViewer().
Is it to specific on that interface? If so, what would be better? It can definitely be null