### PR TITLE
Prevent NPE when RefactoringDocument is null

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/IRefactoringUpdateAcceptor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/IRefactoringUpdateAcceptor.java
@@ -32,6 +32,11 @@ public interface IRefactoringUpdateAcceptor {
 
 	StatusWrapper getRefactoringStatus();
 	
+	/**
+	 * Returns the document related to the refactoring.
+	 * 
+	 * @return The refactoring document or null if it can not be found or is not editable
+	 */
 	IRefactoringDocument getDocument(URI resourceURI);
 	
 	/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/EmfResourceChangeUtil.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/EmfResourceChangeUtil.java
@@ -30,6 +30,8 @@ public class EmfResourceChangeUtil {
 
 	public void addSaveAsUpdate(Resource resource, IRefactoringUpdateAcceptor updateAcceptor) throws IOException {
 		IRefactoringDocument document = updateAcceptor.getDocument(resource.getURI());
+		if (document == null) return;
+
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		resource.save(outputStream, null);
 		String newContent = new String(outputStream.toByteArray(), encodingProvider.getEncoding(resource.getURI()));

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/RefactoringUpdateAcceptor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/RefactoringUpdateAcceptor.java
@@ -50,13 +50,17 @@ public class RefactoringUpdateAcceptor implements IRefactoringUpdateAcceptor, IC
 	@Override
 	public void accept(URI resourceURI, TextEdit textEdit) {
 		IRefactoringDocument document = getDocument(resourceURI);
-		document2textEdits.put(document, textEdit);
+		if (document != null) {
+			document2textEdits.put(document, textEdit);
+		}
 	}
 
 	@Override
 	public void accept(URI resourceURI, Change change) {
 		IRefactoringDocument document = getDocument(resourceURI);
-		document2change.put(document, change);
+		if (document != null) {
+			document2change.put(document, change);
+		}
 	}
 	
 	@Override
@@ -64,9 +68,13 @@ public class RefactoringUpdateAcceptor implements IRefactoringUpdateAcceptor, IC
 		IRefactoringDocument document = uri2document.get(resourceURI);
 		if(document != null) 
 			return document;
-		IRefactoringDocument newDocument = refactoringDocumentProvider.get(resourceURI, status); 
-		uri2document.put(resourceURI, newDocument);
-		return newDocument;
+		IRefactoringDocument newDocument = refactoringDocumentProvider.get(resourceURI, status);
+		if (newDocument != null) {
+			uri2document.put(resourceURI, newDocument);
+			return newDocument;
+		}
+
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/imports/MultiImportOrganizer.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/imports/MultiImportOrganizer.java
@@ -75,13 +75,15 @@ public class MultiImportOrganizer {
 					}
 					TextEdit textEdit = replaceConverter.convertToTextEdit(replace);
 					IRefactoringDocument iRefactoringDocument = provider.get(uri, status);
-					Change change = iRefactoringDocument.createChange(Messages.OrganizeImports, textEdit);
-					if (change instanceof EditorDocumentChange) {
-						if (((EditorDocument) iRefactoringDocument).getEditor().isDirty()) {
-							((EditorDocumentChange) change).setDoSave(false);
+					if (iRefactoringDocument != null) {
+						Change change = iRefactoringDocument.createChange(Messages.OrganizeImports, textEdit);
+						if (change instanceof EditorDocumentChange) {
+							if (((EditorDocument) iRefactoringDocument).getEditor().isDirty()) {
+								((EditorDocumentChange) change).setDoSave(false);
+							}
 						}
+						result.add(change);
 					}
-					result.add(change);
 				}
 				mon.worked(1);
 				if (mon.isCanceled()) {


### PR DESCRIPTION
`IRefactoringDocument.Provider.get()` can produce null values but none of the callers do any null checks