### PR TITLE
[eclipse/xtext#1272] Xtext bootstrap 2.15

### DIFF
--- a/releng/org.eclipse.xtext.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtext.tycho.parent/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<tycho-version>1.2.0</tycho-version>
-		<xtend-maven-plugin-version>2.14.0</xtend-maven-plugin-version>
+		<xtend-maven-plugin-version>2.15.0</xtend-maven-plugin-version>
 
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
@@ -162,23 +162,6 @@
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 				<version>${xtend-maven-plugin-version}</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.eclipse.jdt</groupId>
-						<artifactId>org.eclipse.jdt.core</artifactId>
-						<version>3.13.102</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.jdt</groupId>
-						<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
-						<version>1.3.110</version>
-					</dependency>
-					<dependency>
-						<groupId>org.eclipse.jdt</groupId>
-						<artifactId>org.eclipse.jdt.compiler.tool</artifactId>
-						<version>1.2.101</version>
-					</dependency>
-				</dependencies>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
- use xtend-maven-plugin 2.15
- remove signature workaround

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>