### PR TITLE
[#836] Ensure the CodeMining works on 2018-09.

### DIFF
--- a/org.eclipse.xtext.ui.codemining/src/org/eclipse/xtext/ui/codemining/AbstractXtextCodeMiningProvider.java
+++ b/org.eclipse.xtext.ui.codemining/src/org/eclipse/xtext/ui/codemining/AbstractXtextCodeMiningProvider.java
@@ -141,7 +141,7 @@ public abstract class AbstractXtextCodeMiningProvider extends AbstractCodeMining
 	 */
 	protected LineContentCodeMining createNewLineContentCodeMining(int beforeCharacter, String contentText,
 			Consumer<MouseEvent> action) {
-		return new LineContentCodeMining(new Position(beforeCharacter), this, action) {
+		return new LineContentCodeMining(new Position(beforeCharacter, contentText.length()), this, action) {
 			@Override
 			protected CompletableFuture<Void> doResolve(ITextViewer viewer, IProgressMonitor monitor) {
 				return CompletableFuture.runAsync(() -> {


### PR DESCRIPTION
- Modify the AbstractXtextCodeMiningProvider to set not only the offset,
but also the length of the Position object.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>