### PR TITLE
[#839] Add QuickfixTest to the Xtext Domainmodel/Homeautomation example.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.16.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.domainmodel.ui.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.domainmodel.ui,
+Require-Bundle: org.eclipse.xtext.example.domainmodel,
+ org.eclipse.xtext.example.domainmodel.ui,
  org.eclipse.xtext.testing,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/QuickfixTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/QuickfixTest.xtend
@@ -1,0 +1,63 @@
+package org.eclipse.xtext.example.domainmodel.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractQuickfixTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static org.eclipse.xtext.example.domainmodel.validation.IssueCodes.INVALID_FEATURE_NAME
+import static org.eclipse.xtext.example.domainmodel.validation.IssueCodes.INVALID_TYPE_NAME
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
+
+@RunWith(XtextRunner)
+@InjectWith(DomainmodelUiInjectorProvider)
+class QuickfixTest extends AbstractQuickfixTest {
+
+	@Before def void setup() {
+		/*
+		 * Xbase-based languages require java project
+		 */
+		projectName.createJavaProject
+	}
+
+	@Test def fix_invalid_entity_name() {
+		'''
+			entity blog {
+			}
+		'''.testQuickfixesOn(INVALID_TYPE_NAME, new Quickfix("Capitalize name", "Capitalize name  of 'blog'", '''
+			entity Blog {
+			}
+		'''))
+	}
+
+	@Test def fix_invalid_property_name() {
+		'''
+			entity Blog {
+				Title : String
+			}
+		'''.testQuickfixesOn(INVALID_FEATURE_NAME, new Quickfix("Uncapitalize name", "Uncapitalize name of 'Title'", '''
+			entity Blog {
+				title : String
+			
+			}
+		'''))
+	}
+
+	@Test def fix_invalid_operation_name() {
+		'''
+			entity Blog {
+				title : String
+				op SetTitle(String title) {}
+			}
+		'''.testQuickfixesOn(INVALID_FEATURE_NAME, new Quickfix("Uncapitalize name", "Uncapitalize name of 'SetTitle'", '''
+			entity Blog {
+				title : String
+				op setTitle(String title) {}
+			
+			}
+		'''))
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/QuickfixTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/QuickfixTest.java
@@ -1,0 +1,95 @@
+package org.eclipse.xtext.example.domainmodel.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.domainmodel.ui.tests.DomainmodelUiInjectorProvider;
+import org.eclipse.xtext.example.domainmodel.validation.IssueCodes;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractQuickfixTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(XtextRunner.class)
+@InjectWith(DomainmodelUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class QuickfixTest extends AbstractQuickfixTest {
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void fix_invalid_entity_name() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity blog {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity Blog {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Capitalize name", "Capitalize name  of \'blog\'", _builder_1.toString());
+    this.testQuickfixesOn(_builder, IssueCodes.INVALID_TYPE_NAME, _quickfix);
+  }
+  
+  @Test
+  public void fix_invalid_property_name() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Blog {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("Title : String");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity Blog {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("title : String");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Uncapitalize name", "Uncapitalize name of \'Title\'", _builder_1.toString());
+    this.testQuickfixesOn(_builder, IssueCodes.INVALID_FEATURE_NAME, _quickfix);
+  }
+  
+  @Test
+  public void fix_invalid_operation_name() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Blog {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("title : String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op SetTitle(String title) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity Blog {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("title : String");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("op setTitle(String title) {}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Uncapitalize name", "Uncapitalize name of \'SetTitle\'", _builder_1.toString());
+    this.testQuickfixesOn(_builder, IssueCodes.INVALID_FEATURE_NAME, _quickfix);
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineQuickfixTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineQuickfixTest.xtend
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.homeautomation.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractQuickfixTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static org.eclipse.xtext.diagnostics.Diagnostic.LINKING_DIAGNOSTIC
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
+
+@RunWith(XtextRunner)
+@InjectWith(RuleEngineUiInjectorProvider)
+class RuleEngineQuickfixTest extends AbstractQuickfixTest {
+
+	@Before def void setup() {
+		/*
+		 * Xbase-based languages require java project
+		 */
+		projectName.createJavaProject
+	}
+
+	@Test def fix_invalid_rule_device_state() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			Rule 'rule1' when foo then
+				fire(Heater.off)
+		'''.testQuickfixesOn(LINKING_DIAGNOSTIC,
+			new Quickfix("Change to 'Window.open'", "Change to 'Window.open'", '''
+				Device Window can be open, closed
+				Device Heater can be on, off, error
+				
+				Rule 'rule1' when Window.open then
+					fire(Heater.off)
+			'''),
+			new Quickfix("Change to 'Window.closed'", "Change to 'Window.closed'", '''
+				Device Window can be open, closed
+				Device Heater can be on, off, error
+				
+				Rule 'rule1' when Window.closed then
+					fire(Heater.off)
+			'''),
+			new Quickfix("Change to 'Heater.on'", "Change to 'Heater.on'", '''
+				Device Window can be open, closed
+				Device Heater can be on, off, error
+				
+				Rule 'rule1' when Heater.on then
+					fire(Heater.off)
+			'''),
+			new Quickfix("Change to 'Heater.off'", "Change to 'Heater.off'", '''
+				Device Window can be open, closed
+				Device Heater can be on, off, error
+				
+				Rule 'rule1' when Heater.off then
+					fire(Heater.off)
+			'''),
+			new Quickfix("Change to 'Heater.error'", "Change to 'Heater.error'", '''
+				Device Window can be open, closed
+				Device Heater can be on, off, error
+				
+				Rule 'rule1' when Heater.error then
+					fire(Heater.off)
+			''')
+		)
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineQuickfixTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineQuickfixTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.homeautomation.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.diagnostics.Diagnostic;
+import org.eclipse.xtext.example.homeautomation.ui.tests.RuleEngineUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractQuickfixTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(XtextRunner.class)
+@InjectWith(RuleEngineUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class RuleEngineQuickfixTest extends AbstractQuickfixTest {
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void fix_invalid_rule_device_state() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Rule \'rule1\' when foo then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(Heater.off)");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Device Window can be open, closed");
+    _builder_1.newLine();
+    _builder_1.append("Device Heater can be on, off, error");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("Rule \'rule1\' when Window.open then");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("fire(Heater.off)");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Change to \'Window.open\'", "Change to \'Window.open\'", _builder_1.toString());
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("Device Window can be open, closed");
+    _builder_2.newLine();
+    _builder_2.append("Device Heater can be on, off, error");
+    _builder_2.newLine();
+    _builder_2.newLine();
+    _builder_2.append("Rule \'rule1\' when Window.closed then");
+    _builder_2.newLine();
+    _builder_2.append("\t");
+    _builder_2.append("fire(Heater.off)");
+    _builder_2.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix_1 = new AbstractQuickfixTest.Quickfix("Change to \'Window.closed\'", "Change to \'Window.closed\'", _builder_2.toString());
+    StringConcatenation _builder_3 = new StringConcatenation();
+    _builder_3.append("Device Window can be open, closed");
+    _builder_3.newLine();
+    _builder_3.append("Device Heater can be on, off, error");
+    _builder_3.newLine();
+    _builder_3.newLine();
+    _builder_3.append("Rule \'rule1\' when Heater.on then");
+    _builder_3.newLine();
+    _builder_3.append("\t");
+    _builder_3.append("fire(Heater.off)");
+    _builder_3.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix_2 = new AbstractQuickfixTest.Quickfix("Change to \'Heater.on\'", "Change to \'Heater.on\'", _builder_3.toString());
+    StringConcatenation _builder_4 = new StringConcatenation();
+    _builder_4.append("Device Window can be open, closed");
+    _builder_4.newLine();
+    _builder_4.append("Device Heater can be on, off, error");
+    _builder_4.newLine();
+    _builder_4.newLine();
+    _builder_4.append("Rule \'rule1\' when Heater.off then");
+    _builder_4.newLine();
+    _builder_4.append("\t");
+    _builder_4.append("fire(Heater.off)");
+    _builder_4.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix_3 = new AbstractQuickfixTest.Quickfix("Change to \'Heater.off\'", "Change to \'Heater.off\'", _builder_4.toString());
+    StringConcatenation _builder_5 = new StringConcatenation();
+    _builder_5.append("Device Window can be open, closed");
+    _builder_5.newLine();
+    _builder_5.append("Device Heater can be on, off, error");
+    _builder_5.newLine();
+    _builder_5.newLine();
+    _builder_5.append("Rule \'rule1\' when Heater.error then");
+    _builder_5.newLine();
+    _builder_5.append("\t");
+    _builder_5.append("fire(Heater.off)");
+    _builder_5.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix_4 = new AbstractQuickfixTest.Quickfix("Change to \'Heater.error\'", "Change to \'Heater.error\'", _builder_5.toString());
+    this.testQuickfixesOn(_builder, Diagnostic.LINKING_DIAGNOSTIC, _quickfix, _quickfix_1, _quickfix_2, _quickfix_3, _quickfix_4);
+  }
+}


### PR DESCRIPTION
- The Domainmodel/Homeautomation QuickfixTest demonstrate the usage of
the AbstractQuickfixTest base class in combination with Xbase languages
that require java project.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>