### PR TITLE
[#836] Provide better fix for CodeMining functionality bug on Photon.

### DIFF
--- a/org.eclipse.xtext.ui.codemining/src/org/eclipse/xtext/ui/codemining/AbstractXtextCodeMiningProvider.java
+++ b/org.eclipse.xtext.ui.codemining/src/org/eclipse/xtext/ui/codemining/AbstractXtextCodeMiningProvider.java
@@ -141,7 +141,7 @@ public abstract class AbstractXtextCodeMiningProvider extends AbstractCodeMining
 	 */
 	protected LineContentCodeMining createNewLineContentCodeMining(int beforeCharacter, String contentText,
 			Consumer<MouseEvent> action) {
-		return new LineContentCodeMining(new Position(beforeCharacter, contentText.length()), this, action) {
+		return new LineContentCodeMining(new Position(beforeCharacter, 1), this, action) {
 			@Override
 			protected CompletableFuture<Void> doResolve(ITextViewer viewer, IProgressMonitor monitor) {
 				return CompletableFuture.runAsync(() -> {


### PR DESCRIPTION
- Set the lenght of a Position object to '1' instead of the lenght of
the content text.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>