### PR TITLE
[eclipse/xtext#1321] bootstrap against 2.16.0.M1

### DIFF
--- a/releng/org.eclipse.xtext.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtext.tycho.parent/pom.xml
@@ -9,7 +9,7 @@
 
 	<properties>
 		<tycho-version>1.2.0</tycho-version>
-		<xtend-maven-plugin-version>2.15.0</xtend-maven-plugin-version>
+		<xtend-maven-plugin-version>2.16.0.M1</xtend-maven-plugin-version>
 
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>


### PR DESCRIPTION
[eclipse/xtext#1321] bootstrap against 2.16.0.M1
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>