### PR TITLE
[#839] Ensure the Xbase organize import quickfix can be properly tested.

### DIFF
--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.java
@@ -17,13 +17,13 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtend.lib.annotations.Data;
 import org.eclipse.xtext.linking.lazy.LazyLinkingResource;
 import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.resource.IResourceFactory;
 import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.XtextEditorInfo;
@@ -34,6 +34,7 @@ import org.eclipse.xtext.ui.editor.model.edit.IModificationContext;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolution;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionProvider;
 import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
+import org.eclipse.xtext.ui.resource.IResourceSetProvider;
 import org.eclipse.xtext.ui.testing.AbstractEditorTest;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.util.CancelIndicator;
@@ -163,6 +164,9 @@ public abstract class AbstractQuickfixTest extends AbstractEditorTest {
   protected XtextEditorInfo editorInfo;
   
   @Inject
+  protected IResourceSetProvider resourceSetProvider;
+  
+  @Inject
   @Extension
   protected SyncUtil _syncUtil;
   
@@ -177,6 +181,8 @@ public abstract class AbstractQuickfixTest extends AbstractEditorTest {
   @Inject
   @Extension
   protected IssueResolutionProvider _issueResolutionProvider;
+  
+  protected IProject project;
   
   @Override
   protected String getEditorId() {
@@ -205,11 +211,11 @@ public abstract class AbstractQuickfixTest extends AbstractEditorTest {
       IFile _xblockexpression = null;
       {
         final IFile file = IResourcesSetupUtil.createFile(this.getProjectName(), this.getFileName(), this.getFileExtension(), content.toString());
-        final IProject project = file.getProject();
-        boolean _hasNature = project.hasNature(XtextProjectHelper.NATURE_ID);
+        this.project = file.getProject();
+        boolean _hasNature = this.project.hasNature(XtextProjectHelper.NATURE_ID);
         boolean _not = (!_hasNature);
         if (_not) {
-          IResourcesSetupUtil.addNature(project, XtextProjectHelper.NATURE_ID);
+          IResourcesSetupUtil.addNature(this.project, XtextProjectHelper.NATURE_ID);
         }
         _xblockexpression = file;
       }
@@ -318,8 +324,7 @@ public abstract class AbstractQuickfixTest extends AbstractEditorTest {
         String _emptyIfNull = Strings.emptyIfNull(model);
         final StringInputStream in = new StringInputStream(_emptyIfNull);
         final URI uri = URI.createURI("");
-        final XtextResourceSet rs = this.injector.<XtextResourceSet>getInstance(XtextResourceSet.class);
-        rs.setClasspathURIContext(AbstractQuickfixTest.class);
+        final ResourceSet rs = this.resourceSetProvider.get(this.project);
         final Resource resource = this.injector.<IResourceFactory>getInstance(IResourceFactory.class).createResource(uri);
         EList<Resource> _resources = rs.getResources();
         _resources.add(resource);

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/QuickfixTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/QuickfixTest.xtend
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith
 
 import static org.eclipse.xtext.example.domainmodel.validation.IssueCodes.INVALID_FEATURE_NAME
 import static org.eclipse.xtext.example.domainmodel.validation.IssueCodes.INVALID_TYPE_NAME
+import static org.eclipse.xtext.xbase.validation.IssueCodes.IMPORT_UNUSED
+import static org.eclipse.xtext.xbase.validation.IssueCodes.IMPORT_WILDCARD_DEPRECATED
 
 import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
 
@@ -59,5 +61,74 @@ class QuickfixTest extends AbstractQuickfixTest {
 			
 			}
 		'''))
+	}
+
+	@Test def fix_unused_imports1() {
+		'''
+			import java.util.Date
+			
+			entity Blog {}
+		'''.testQuickfixesOn(IMPORT_UNUSED,
+			new Quickfix(
+				"Organize imports",
+				"Organizes the whole import section. Removes wildcard imports as well as duplicates and unused ones.",
+				'''
+					entity Blog {}
+				'''
+			)
+		)
+	}
+
+	@Test def fix_unused_imports2() {
+		'''
+			import java.util.Date
+			import java.util.List
+			
+			entity Blog {
+				posts : List<Post>
+			}
+			
+			entity Post {}
+		'''.testQuickfixesOn(IMPORT_UNUSED,
+			new Quickfix(
+				"Organize imports",
+				"Organizes the whole import section. Removes wildcard imports as well as duplicates and unused ones.",
+				'''
+					import java.util.List
+					
+					entity Blog {
+						posts : List<Post>
+					}
+					
+					entity Post {}
+				'''
+			)
+		)
+	}
+
+	@Test def fix_wildcard_imports() {
+		'''
+			import java.util.*
+			
+			entity Blog {
+				posts : List<Post>
+			}
+			
+			entity Post {}
+		'''.testQuickfixesOn(IMPORT_WILDCARD_DEPRECATED,
+			new Quickfix(
+				"Organize imports",
+				"Organizes the whole import section. Removes wildcard imports as well as duplicates and unused ones.",
+				'''
+					import java.util.List
+					
+					entity Blog {
+						posts : List<Post>
+					}
+					
+					entity Post {}
+				'''
+			)
+		)
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/QuickfixTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/QuickfixTest.java
@@ -92,4 +92,95 @@ public class QuickfixTest extends AbstractQuickfixTest {
     AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Uncapitalize name", "Uncapitalize name of \'SetTitle\'", _builder_1.toString());
     this.testQuickfixesOn(_builder, IssueCodes.INVALID_FEATURE_NAME, _quickfix);
   }
+  
+  @Test
+  public void fix_unused_imports1() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.Date");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Blog {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity Blog {}");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix(
+      "Organize imports", 
+      "Organizes the whole import section. Removes wildcard imports as well as duplicates and unused ones.", _builder_1.toString());
+    this.testQuickfixesOn(_builder, org.eclipse.xtext.xbase.validation.IssueCodes.IMPORT_UNUSED, _quickfix);
+  }
+  
+  @Test
+  public void fix_unused_imports2() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.Date");
+    _builder.newLine();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Blog {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("posts : List<Post>");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Post {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import java.util.List");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("entity Blog {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("posts : List<Post>");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("entity Post {}");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix(
+      "Organize imports", 
+      "Organizes the whole import section. Removes wildcard imports as well as duplicates and unused ones.", _builder_1.toString());
+    this.testQuickfixesOn(_builder, org.eclipse.xtext.xbase.validation.IssueCodes.IMPORT_UNUSED, _quickfix);
+  }
+  
+  @Test
+  public void fix_wildcard_imports() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.*");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Blog {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("posts : List<Post>");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Post {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import java.util.List");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("entity Blog {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("posts : List<Post>");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("entity Post {}");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix(
+      "Organize imports", 
+      "Organizes the whole import section. Removes wildcard imports as well as duplicates and unused ones.", _builder_1.toString());
+    this.testQuickfixesOn(_builder, org.eclipse.xtext.xbase.validation.IssueCodes.IMPORT_WILDCARD_DEPRECATED, _quickfix);
+  }
 }


### PR DESCRIPTION
- Modify the AbstractQuickfixTest to use the IResourceSetProvider to
obtain a new resource while testing the IssueModification effect.
- Implement corresponding QuickfixTest DomainModel Example test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>