### PR TITLE
[#897] Provide AbstractHoverTest abstract base class.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHoverTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHoverTest.xtend
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ui.testing
+
+import com.google.inject.Inject
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.jface.internal.text.html.BrowserInformationControlInput
+import org.eclipse.jface.text.IRegion
+import org.eclipse.jface.text.ITextHoverExtension2
+import org.eclipse.jface.text.Region
+import org.eclipse.xtext.resource.FileExtensionProvider
+import org.eclipse.xtext.ui.XtextProjectHelper
+import org.eclipse.xtext.ui.editor.XtextEditor
+import org.eclipse.xtext.ui.editor.XtextEditorInfo
+import org.eclipse.xtext.ui.editor.hover.IEObjectHover
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
+
+import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.addNature
+
+/**
+ * @author miklossy - Initial contribution and API
+ * 
+ * @since 2.16
+ */
+abstract class AbstractHoverTest extends AbstractEditorTest {
+
+	@Inject protected IEObjectHover eObjectHover
+	@Inject protected XtextEditorInfo editorInfo
+
+	@Inject protected extension SyncUtil
+	@Inject protected extension FileExtensionProvider
+
+	override protected getEditorId() {
+		editorInfo.getEditorId
+	}
+
+	/**
+	 * Test that the expected text appears in a popup window while hovering over a certain text in a given DSL text.
+	 * 
+	 * @param it the initial DSL text.
+	 * @param hoverText the text you are hovering over.
+	 * @param hoverContent the text that is expected to be part of the hover popup.
+	 */
+	def void hasHoverOver(CharSequence it, String hoverText, String hoverContent) {
+		hasHoverOver(new Region(toString.indexOf(hoverText), hoverText.length), hoverContent)
+	}
+
+	/**
+	 * Test that the expected text appears in a popup window while hovering over a certain region in a given DSL text.
+	 * 
+	 * @param it the initial DSL text.
+	 * @param hoverRegion the region you are hovering over.
+	 * @param hoverContent the text that is expected to be part of the hover popup.
+	 */
+	def void hasHoverOver(CharSequence it, IRegion hoverRegion, String hoverContent) {
+		// given
+		dslFile.
+		// when
+		hoveringOver(hoverRegion).
+		// then
+		hoverPopupHasContent(hoverContent)
+	}
+
+	protected def IFile dslFile(CharSequence content) {
+		val file = IResourcesSetupUtil.createFile(projectName, fileName, fileExtension, content.toString)
+
+		/*
+		 * TODO: find a better (with good performance) solution
+		 * to set the Xtext nature on the test project.
+		 */
+		val project = file.project
+		if(!project.hasNature(XtextProjectHelper.NATURE_ID)) {
+			project.addNature(XtextProjectHelper.NATURE_ID)
+		}
+
+		file
+	}
+
+	protected def String getProjectName() {
+		"HoverTestProject"
+	}
+
+	protected def String getFileName() {
+		"hover"
+	}
+
+	protected def String getFileExtension() {
+		primaryFileExtension
+	}
+
+	protected def XtextEditor openInEditor(IFile dslFile) {
+		/*
+		 * wait for the cross-reference resolution
+		 */
+		waitForBuild(new NullProgressMonitor)
+		dslFile.openEditor
+	}
+
+	protected def BrowserInformationControlInput hoveringOver(IFile dslFile, IRegion hoverRegion) {
+		val editor = dslFile.openInEditor
+		val textHover = eObjectHover as ITextHoverExtension2
+		textHover.getHoverInfo2(editor.internalSourceViewer, hoverRegion) as BrowserInformationControlInput
+	}
+
+	protected def void hoverPopupHasContent(BrowserInformationControlInput info, String expectedHoverContent) {
+		assertNotNull("No hover found!", info)
+		val actualHoverContent = info.html
+		assertTrue('''
+			Could not find the text '«expectedHoverContent»' in the hover popup:
+				«actualHoverContent»
+		''', actualHoverContent.contains(expectedHoverContent))
+	}
+}

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHoverTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHoverTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ui.testing;
+
+import com.google.inject.Inject;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.internal.text.html.BrowserInformationControlInput;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextHoverExtension2;
+import org.eclipse.jface.text.Region;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.resource.FileExtensionProvider;
+import org.eclipse.xtext.ui.XtextProjectHelper;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.eclipse.xtext.ui.editor.XtextEditorInfo;
+import org.eclipse.xtext.ui.editor.hover.IEObjectHover;
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
+import org.eclipse.xtext.ui.testing.AbstractEditorTest;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.junit.Assert;
+
+/**
+ * @author miklossy - Initial contribution and API
+ * 
+ * @since 2.16
+ */
+@SuppressWarnings("all")
+public abstract class AbstractHoverTest extends AbstractEditorTest {
+  @Inject
+  protected IEObjectHover eObjectHover;
+  
+  @Inject
+  protected XtextEditorInfo editorInfo;
+  
+  @Inject
+  @Extension
+  protected SyncUtil _syncUtil;
+  
+  @Inject
+  @Extension
+  protected FileExtensionProvider _fileExtensionProvider;
+  
+  @Override
+  protected String getEditorId() {
+    return this.editorInfo.getEditorId();
+  }
+  
+  /**
+   * Test that the expected text appears in a popup window while hovering over a certain text in a given DSL text.
+   * 
+   * @param it the initial DSL text.
+   * @param hoverText the text you are hovering over.
+   * @param hoverContent the text that is expected to be part of the hover popup.
+   */
+  public void hasHoverOver(final CharSequence it, final String hoverText, final String hoverContent) {
+    int _indexOf = it.toString().indexOf(hoverText);
+    int _length = hoverText.length();
+    Region _region = new Region(_indexOf, _length);
+    this.hasHoverOver(it, _region, hoverContent);
+  }
+  
+  /**
+   * Test that the expected text appears in a popup window while hovering over a certain region in a given DSL text.
+   * 
+   * @param it the initial DSL text.
+   * @param hoverRegion the region you are hovering over.
+   * @param hoverContent the text that is expected to be part of the hover popup.
+   */
+  public void hasHoverOver(final CharSequence it, final IRegion hoverRegion, final String hoverContent) {
+    this.hoverPopupHasContent(this.hoveringOver(this.dslFile(it), hoverRegion), hoverContent);
+  }
+  
+  protected IFile dslFile(final CharSequence content) {
+    try {
+      IFile _xblockexpression = null;
+      {
+        final IFile file = IResourcesSetupUtil.createFile(this.getProjectName(), this.getFileName(), this.getFileExtension(), content.toString());
+        final IProject project = file.getProject();
+        boolean _hasNature = project.hasNature(XtextProjectHelper.NATURE_ID);
+        boolean _not = (!_hasNature);
+        if (_not) {
+          IResourcesSetupUtil.addNature(project, XtextProjectHelper.NATURE_ID);
+        }
+        _xblockexpression = file;
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected String getProjectName() {
+    return "HoverTestProject";
+  }
+  
+  protected String getFileName() {
+    return "hover";
+  }
+  
+  protected String getFileExtension() {
+    return this._fileExtensionProvider.getPrimaryFileExtension();
+  }
+  
+  protected XtextEditor openInEditor(final IFile dslFile) {
+    try {
+      XtextEditor _xblockexpression = null;
+      {
+        NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+        this._syncUtil.waitForBuild(_nullProgressMonitor);
+        _xblockexpression = this.openEditor(dslFile);
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected BrowserInformationControlInput hoveringOver(final IFile dslFile, final IRegion hoverRegion) {
+    BrowserInformationControlInput _xblockexpression = null;
+    {
+      final XtextEditor editor = this.openInEditor(dslFile);
+      final ITextHoverExtension2 textHover = ((ITextHoverExtension2) this.eObjectHover);
+      Object _hoverInfo2 = textHover.getHoverInfo2(editor.getInternalSourceViewer(), hoverRegion);
+      _xblockexpression = ((BrowserInformationControlInput) _hoverInfo2);
+    }
+    return _xblockexpression;
+  }
+  
+  protected void hoverPopupHasContent(final BrowserInformationControlInput info, final String expectedHoverContent) {
+    Assert.assertNotNull("No hover found!", info);
+    final String actualHoverContent = info.getHtml();
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Could not find the text \'");
+    _builder.append(expectedHoverContent);
+    _builder.append("\' in the hover popup:");
+    _builder.newLineIfNotEmpty();
+    _builder.append("\t");
+    _builder.append(actualHoverContent, "\t");
+    _builder.newLineIfNotEmpty();
+    Assert.assertTrue(_builder.toString(), actualHoverContent.contains(expectedHoverContent));
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/hover/HoverTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/hover/HoverTest.xtend
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.arithmetics.ui.tests.hover
+
+import org.eclipse.jface.text.Region
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHoverTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(ArithmeticsUiInjectorProvider)
+class HoverTest extends AbstractHoverTest {
+
+	@Test def hover_over_function_call() {
+		val text = '''
+			module arithmetics
+			
+			/*
+			 * A mathematical constant.
+			 * It is approximately equal to 3.14.
+			 */
+			def pi: 3.14
+			
+			pi * 4;
+		'''
+		
+		val hoverText = "pi"
+		val hoverRegion = new Region(text.lastIndexOf(hoverText), hoverText.length)
+		text.hasHoverOver(hoverRegion, '''
+			A mathematical constant.
+			It is approximately equal to 3.14.'''
+		)
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/hover/HoverTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/hover/HoverTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.arithmetics.ui.tests.hover;
+
+import org.eclipse.jface.text.Region;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHoverTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(ArithmeticsUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class HoverTest extends AbstractHoverTest {
+  @Test
+  public void hover_over_function_call() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("module arithmetics");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("/*");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* A mathematical constant.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* It is approximately equal to 3.14.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("def pi: 3.14");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("pi * 4;");
+    _builder.newLine();
+    final String text = _builder.toString();
+    final String hoverText = "pi";
+    int _lastIndexOf = text.lastIndexOf(hoverText);
+    int _length = hoverText.length();
+    final Region hoverRegion = new Region(_lastIndexOf, _length);
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("A mathematical constant.");
+    _builder_1.newLine();
+    _builder_1.append("It is approximately equal to 3.14.");
+    this.hasHoverOver(text, hoverRegion, _builder_1.toString());
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HoverTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HoverTest.xtend
@@ -1,0 +1,94 @@
+package org.eclipse.xtext.example.domainmodel.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHoverTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(DomainmodelUiInjectorProvider)
+class HoverTest extends AbstractHoverTest {
+
+	@Before def void setup() {
+		/*
+		 * Xbase-based languages require java project
+		 */
+		 projectName.createJavaProject
+	}
+
+	@Test def hover_over_import_statement() {
+		'''
+			import java.util.List
+			
+			entity Foo {
+				bar : List<String>
+			}
+		'''.hasHoverOver("java.util.List", '''An ordered collection (also known as a <i>sequence</i>''')
+	}
+
+	@Test def hover_over_link_in_javadoc() {
+		'''
+			/**
+			 * {@link java.util.List}
+			 */
+			 entity Foo {}
+		'''.hasHoverOver("java.util.List", '''An ordered collection (also known as a <i>sequence</i>''')
+	}
+
+	@Test def hover_over_java_typed_property() {
+		'''
+			entity Foo {
+				name : Object
+			}
+		'''.hasHoverOver("name", '''Property name : Object''')
+	}
+
+	@Test def hover_over_java_type() {
+		'''
+			entity Foo {
+				name : Object
+			}
+		'''.hasHoverOver("Object", '''Class <code>Object</code> is the root of the class hierarchy.''')
+	}
+
+	@Test def hover_over_entity_typed_property() {
+		'''
+			entity Foo {
+				b : Bar
+			}
+			
+			entity Bar {}
+		'''.hasHoverOver("b", '''Property b : Bar''')
+	}
+
+	@Test def hover_over_entity_type() {
+		'''
+			entity Foo {
+				b : Bar
+			}
+			
+			/**
+			 * Documentation of the entity Bar.
+			 */
+			entity Bar {}
+		'''.hasHoverOver("Bar", '''Documentation of the entity Bar.''')
+	}
+
+	@Test def hover_over_operation() {
+		'''
+			entity Foo {
+				b : String
+				op : getB() {
+					b
+				}
+			}
+		'''.hasHoverOver("getB", '''getB() : String''')
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HoverTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HoverTest.java
@@ -1,0 +1,164 @@
+package org.eclipse.xtext.example.domainmodel.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.domainmodel.ui.tests.DomainmodelUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHoverTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(DomainmodelUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class HoverTest extends AbstractHoverTest {
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void hover_over_import_statement() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("bar : List<String>");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("An ordered collection (also known as a <i>sequence</i>");
+    this.hasHoverOver(_builder, "java.util.List", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_link_in_javadoc() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* {@link java.util.List}");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("entity Foo {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("An ordered collection (also known as a <i>sequence</i>");
+    this.hasHoverOver(_builder, "java.util.List", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_java_typed_property() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("name : Object");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Property name : Object");
+    this.hasHoverOver(_builder, "name", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_java_type() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("name : Object");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Class <code>Object</code> is the root of the class hierarchy.");
+    this.hasHoverOver(_builder, "Object", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_entity_typed_property() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("b : Bar");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Bar {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Property b : Bar");
+    this.hasHoverOver(_builder, "b", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_entity_type() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("b : Bar");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* Documentation of the entity Bar.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("entity Bar {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Documentation of the entity Bar.");
+    this.hasHoverOver(_builder, "Bar", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_operation() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("b : String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op : getB() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("b");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("getB() : String");
+    this.hasHoverOver(_builder, "getB", _builder_1.toString());
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHoverTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHoverTest.xtend
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.fowlerdsl.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHoverTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(StatemachineUiInjectorProvider)
+class StatemachineHoverTest extends AbstractHoverTest {
+
+	@Test def hover_over_event() {
+		'''
+			events
+				doorClosed   D1CL
+				drawerOpened D2OP
+				lightOn      L1ON
+				doorOpened   D1OP
+				panelClosed  PNCL
+			end
+		'''.hasHoverOver("doorClosed", '''Event <b>doorClosed</b>''')
+	}
+
+	@Test def hover_over_command() {
+		'''
+			commands
+				unlockPanel PNUL
+				lockPanel   NLK
+				lockDoor    D1LK
+				unlockDoor  D1UL
+			end
+		'''.hasHoverOver("unlockPanel", '''Command <b>unlockPanel</b>''')
+	}
+
+	@Test def hover_over_state() {
+		'''
+			state idle {}
+		'''.hasHoverOver("idle", '''State <b>state idle</b>''')
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHoverTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHoverTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.fowlerdsl.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.fowlerdsl.ui.tests.StatemachineUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHoverTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(StatemachineUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class StatemachineHoverTest extends AbstractHoverTest {
+  @Test
+  public void hover_over_event() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed   D1CL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened D2OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      L1ON");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened   D1OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed  PNCL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Event <b>doorClosed</b>");
+    this.hasHoverOver(_builder, "doorClosed", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_command() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("commands");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockPanel PNUL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockPanel   NLK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockDoor    D1LK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockDoor  D1UL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Command <b>unlockPanel</b>");
+    this.hasHoverOver(_builder, "unlockPanel", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_state() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("state idle {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("State <b>state idle</b>");
+    this.hasHoverOver(_builder, "idle", _builder_1.toString());
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHoverTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHoverTest.xtend
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.homeautomation.ui.tests
+
+import org.eclipse.jface.text.Region
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHoverTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(RuleEngineUiInjectorProvider)
+class RuleEngineHoverTest extends AbstractHoverTest {
+
+	@Before def void setup() {
+		/*
+		 * Xbase-based languages require java project
+		 */
+		projectName.createJavaProject
+	}
+
+	@Test def hover_over_device_name() {
+		'''
+			Device Window can be open, closed
+		'''.hasHoverOver("Window", '''Device Window''')
+	}
+
+	@Test def hover_over_device_state() {
+		'''
+			Device Window can be open, closed
+		'''.hasHoverOver("open", '''State open''')
+	}
+
+	@Test def hover_over_fire_expression() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			Rule 'rule1' when Window.open then
+				fire(Heater.off)
+		'''.hasHoverOver("fire", '''void Hover.fire(Object event)''')
+	}
+
+	@Test def hover_over_link_in_javadoc1() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			/*
+			 * If the {@link Window} is open, the {@link Heater} should be turned off.
+			 */
+			Rule 'rule1' when Window.open then
+				fire(Heater.off)
+		'''.hasHoverInJavadoc("Window", '''Device Window''')
+	}
+
+	@Test def hover_over_link_in_javadoc2() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			/*
+			 * If the {@link Window} is open, the {@link Heater} should be turned off.
+			 */
+			Rule 'rule1' when Window.open then
+				fire(Heater.off)
+		'''.hasHoverInJavadoc("Heater", '''Device Heater''')
+	}
+
+	@Test def hover_over_link_in_javadoc3() {
+		'''
+			/*
+			 * {@link java.util.List}
+			 */
+			Device Window can be open, closed
+		'''.hasHoverInJavadoc("java.util.List", '''An ordered collection (also known as a <i>sequence</i>''')
+	}
+
+	private def hasHoverInJavadoc(CharSequence it, String hoverText, String hoverContent){
+		val startOfJavadoc = toString.indexOf("/**")
+		val hoverRegion = new Region(toString.indexOf(hoverText, startOfJavadoc), hoverText.length)
+		hasHoverOver(hoverRegion, hoverContent)
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHoverTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHoverTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.homeautomation.ui.tests;
+
+import org.eclipse.jface.text.Region;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.homeautomation.ui.tests.RuleEngineUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHoverTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(RuleEngineUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class RuleEngineHoverTest extends AbstractHoverTest {
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void hover_over_device_name() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Device Window");
+    this.hasHoverOver(_builder, "Window", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_device_state() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("State open");
+    this.hasHoverOver(_builder, "open", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_fire_expression() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Rule \'rule1\' when Window.open then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(Heater.off)");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("void Hover.fire(Object event)");
+    this.hasHoverOver(_builder, "fire", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_link_in_javadoc1() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("/*");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* If the {@link Window} is open, the {@link Heater} should be turned off.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("Rule \'rule1\' when Window.open then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(Heater.off)");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Device Window");
+    this.hasHoverInJavadoc(_builder, "Window", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_link_in_javadoc2() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("/*");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* If the {@link Window} is open, the {@link Heater} should be turned off.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("Rule \'rule1\' when Window.open then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(Heater.off)");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("Device Heater");
+    this.hasHoverInJavadoc(_builder, "Heater", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_link_in_javadoc3() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/*");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* {@link java.util.List}");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("An ordered collection (also known as a <i>sequence</i>");
+    this.hasHoverInJavadoc(_builder, "java.util.List", _builder_1.toString());
+  }
+  
+  private void hasHoverInJavadoc(final CharSequence it, final String hoverText, final String hoverContent) {
+    final int startOfJavadoc = it.toString().indexOf("/**");
+    int _indexOf = it.toString().indexOf(hoverText, startOfJavadoc);
+    int _length = hoverText.length();
+    final Region hoverRegion = new Region(_indexOf, _length);
+    this.hasHoverOver(it, hoverRegion, hoverContent);
+  }
+}


### PR DESCRIPTION
- Extend the 'Xtext UI Testing' test infrastructure by the
AbstractHoverTest abstract class to provide a base infrastructure for
testing hovers.
- Extend the Xtext Examples the HoverTest test cases to
demonstrate the usage of the AbstractHoverTest class.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>