### PR TITLE
[#902] Avoid NPE on accessing 'folders' field

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JavaProjectFactory.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/JavaProjectFactory.java
@@ -67,7 +67,7 @@ public class JavaProjectFactory extends ProjectFactory {
 							.getFullPath());
 					classpathEntries.add(referencedProjectClasspathEntry);
 				}
-				for (final String folderName : folders) {
+				for (final String folderName : getFolders()) {
 					final IFolder sourceFolder = project.getFolder(folderName);
 					String outputFolderName = sourceFolderOutputs.get(folderName);
 					final IClasspathEntry srcClasspathEntry = JavaCore.newSourceEntry(sourceFolder.getFullPath(),

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/PluginProjectFactory.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/util/PluginProjectFactory.java
@@ -108,7 +108,7 @@ public class PluginProjectFactory extends JavaProjectFactory {
 
 	protected void createBuildProperties(IProject project, IProgressMonitor progressMonitor) {
 		final StringBuilder content = new StringBuilder();
-		Iterable<String> foldersTrailingSlash = Iterables.transform(folders, new Function<String, String>() {
+		Iterable<String> foldersTrailingSlash = Iterables.transform(getFolders(), new Function<String, String>() {
 			@Override
 			public String apply(String input) {
 				return input.replaceFirst("\\./", "") + "/";


### PR DESCRIPTION
To avoid an NPE clients should use the getter getFolders().

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>