### PR TITLE
[#913] Ensure that the Domainmodel outline view displays custom images.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/LabelProviderTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/LabelProviderTest.xtend
@@ -1,0 +1,49 @@
+package org.eclipse.xtext.example.domainmodel.ui.tests
+
+import com.google.inject.Inject
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.jface.viewers.ILabelProvider
+import org.eclipse.xtext.example.domainmodel.domainmodel.DomainmodelFactory
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.IImageHelper
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.junit.Assert.assertEquals
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(DomainmodelUiInjectorProvider)
+class LabelProviderTest {
+
+	@Inject ILabelProvider labelProvider
+	@Inject IImageHelper imageHelper
+
+	val extension DomainmodelFactory = DomainmodelFactory.eINSTANCE
+
+	@Test def package_image() {
+		createPackageDeclaration.hasImage("PackageDeclaration.gif")
+	}
+
+	@Test def entity_image() {
+		createEntity.hasImage("Entity.gif")
+	}
+
+	@Test def property_image() {
+		createProperty.hasImage("Property.gif")
+	}
+
+	@Test def operation_image() {
+		createOperation.hasImage("Operation.gif")
+	}
+
+	private def hasImage(EObject eObject, String image) {
+		val actual = labelProvider.getImage(eObject)
+		val expected = imageHelper.getImage(image) 
+		expected.assertEquals(actual)
+	}
+
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/LabelProviderTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/LabelProviderTest.java
@@ -1,0 +1,58 @@
+package org.eclipse.xtext.example.domainmodel.ui.tests;
+
+import com.google.inject.Inject;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.xtext.example.domainmodel.domainmodel.DomainmodelFactory;
+import org.eclipse.xtext.example.domainmodel.ui.tests.DomainmodelUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.IImageHelper;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(DomainmodelUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class LabelProviderTest {
+  @Inject
+  private ILabelProvider labelProvider;
+  
+  @Inject
+  private IImageHelper imageHelper;
+  
+  @Extension
+  private final DomainmodelFactory _domainmodelFactory = DomainmodelFactory.eINSTANCE;
+  
+  @Test
+  public void package_image() {
+    this.hasImage(this._domainmodelFactory.createPackageDeclaration(), "PackageDeclaration.gif");
+  }
+  
+  @Test
+  public void entity_image() {
+    this.hasImage(this._domainmodelFactory.createEntity(), "Entity.gif");
+  }
+  
+  @Test
+  public void property_image() {
+    this.hasImage(this._domainmodelFactory.createProperty(), "Property.gif");
+  }
+  
+  @Test
+  public void operation_image() {
+    this.hasImage(this._domainmodelFactory.createOperation(), "Operation.gif");
+  }
+  
+  private void hasImage(final EObject eObject, final String image) {
+    final Image actual = this.labelProvider.getImage(eObject);
+    final Image expected = this.imageHelper.getImage(image);
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.xtend
@@ -34,7 +34,7 @@ class DomainmodelLabelProvider extends XbaseLabelProvider {
 
 	override protected Object doGetImage(Object element) {
 		if (element instanceof EObject && !(element instanceof JvmIdentifiableElement)) {
-			return '''«((element as EObject)).eClass().getName()».gif'''
+			return '''«((element as EObject)).eClass().getName()».gif'''.toString
 		}
 		return super.doGetImage(element)
 	}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.java
@@ -42,7 +42,7 @@ public class DomainmodelLabelProvider extends XbaseLabelProvider {
       String _name = ((EObject) element).eClass().getName();
       _builder.append(_name);
       _builder.append(".gif");
-      return _builder;
+      return _builder.toString();
     }
     return super.doGetImage(element);
   }


### PR DESCRIPTION
- Fix broken DomainmodelLabelProvider implementation.
- Implement corresponding LabelProviderTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>