### PR TITLE
[#917] do not punish perfectly matching content assist proposals

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/ContentProposalPriorities.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/ContentProposalPriorities.java
@@ -16,7 +16,8 @@ public class ContentProposalPriorities implements IContentProposalPriorities {
 	protected int keywordPriority = 300;
 	protected int defaultPriority = 400;
 	protected int proposalWithPrefixMultiplier = 2;
-	protected double sameTextMultiplier = 0.75;
+	// do not treat perfect matches differently, by default, but allow subclasses to change this:
+	protected double sameTextMultiplier = proposalWithPrefixMultiplier;
 	
 	protected void adjustPriority(ICompletionProposal proposal, String prefix, int priority) {
 		if (proposal == null || !(proposal instanceof ConfigurableCompletionProposal))


### PR DESCRIPTION
Just a quick proposal for adjusting the behavior described in #917.

Please feel free to close without merge if you feel this doesn't make sense!