### PR TITLE
#796 Make AbstractParticipatingBuilderTest thread safe

### DIFF
--- a/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/ResourceDescriptionUpdaterTest.java
+++ b/org.eclipse.xtext.builder.tests/src-longrunning/org/eclipse/xtext/builder/impl/ResourceDescriptionUpdaterTest.java
@@ -63,7 +63,7 @@ public class ResourceDescriptionUpdaterTest extends AbstractParticipatingBuilder
 		assertFalse(REFERENCING_FILE_NAME, affectedResourcesContain(PROJECT2, REFERENCING_FILE_NAME));
 	}
 
-	private boolean affectedResourcesContain(final String projectName, final String fileName) {
+	private synchronized boolean affectedResourcesContain(final String projectName, final String fileName) {
 		try {
 			final URI expected = URI.createPlatformResourceURI(projectName + "/" + SRC_FOLDER + "/" + fileName + F_EXT, true);
 			Iterables.find(getContext().getDeltas(), new Predicate<IResourceDescription.Delta>() {

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractParticipatingBuilderTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/AbstractParticipatingBuilderTest.java
@@ -44,35 +44,35 @@ public abstract class AbstractParticipatingBuilderTest extends AbstractBuilderTe
 	}
 	
 	@Override
-	public void build(IBuildContext context, IProgressMonitor monitor) throws CoreException {
+	public synchronized void build(IBuildContext context, IProgressMonitor monitor) throws CoreException {
 		if (logging) {
 			invocationCount++;
 			this.context = context;
 		}
 	}
 	
-	public int getInvocationCount() {
+	public synchronized int getInvocationCount() {
 		return invocationCount;
 	}
 	
-	public IBuildContext getContext() {
+	public synchronized IBuildContext getContext() {
 		return context;
 	}
 	
-	public void startLogging() {
+	public synchronized void startLogging() {
 		logging = true;
 	}
 	
-	public void stopLogging() {
+	public synchronized void stopLogging() {
 		reset();
 		logging = false;
 	}
 	
-	public boolean isLogging() {
+	public synchronized boolean isLogging() {
 		return logging;
 	}
 	
-	public void reset() {
+	public synchronized void reset() {
 		invocationCount = 0;
 		context = null;
 	}

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug355821Test.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/Bug355821Test.java
@@ -52,7 +52,7 @@ public class Bug355821Test extends AbstractParticipatingBuilderTest {
 	}
 	
 	@Override
-	public void build(IBuildContext context, IProgressMonitor monitor) throws CoreException {
+	public synchronized void build(IBuildContext context, IProgressMonitor monitor) throws CoreException {
 		if (context.getBuildType() == BuildType.FULL)
 			invocationCount++;
 	}


### PR DESCRIPTION
Because multiple threads (main + build thread) may access state
concurrently.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>