### PR TITLE
[eclipse/xtext#1182] added support for java 11 as target

### DIFF
--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/JavaVersionExtendedTest.java
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/JavaVersionExtendedTest.java
@@ -41,6 +41,13 @@ public class JavaVersionExtendedTest {
 		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException | SecurityException e) {
 			// ok
 		}
+		try {
+			long value = ClassFileConstants.class.getField("JDK11").getLong(null);
+			assertEquals(value, JavaVersion.JAVA11.toJdtClassFileConstant());
+		} catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException | SecurityException e) {
+			System.err.println("ooops");
+			// ok
+		}
 	}
 
 }


### PR DESCRIPTION
[eclipse/xtext#1182] added support for java 11 as target
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>