### PR TITLE
Improve ResourceSetBasedAllContainersStateProvider.getResourc…

### DIFF
--- a/org.eclipse.xtext.builder/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.builder/META-INF/MANIFEST.MF
@@ -43,7 +43,7 @@ Export-Package: org.eclipse.xtext.builder,
  org.eclipse.xtext.builder.trace;x-friends:="org.eclipse.xtext.xbase.ui,org.eclipse.xtend.ide",
  org.eclipse.xtext.builder.trace.impl;x-internal:=true,
  org.eclipse.xtext.builder.trace.util;x-internal:=true
-Require-Bundle: org.eclipse.xtext,
+Require-Bundle: org.eclipse.xtext;bundle-version="2.17.0",
  org.eclipse.xtext.util,
  org.eclipse.emf.ecore;bundle-version="2.10.2";visibility:=reexport,
  com.google.guava;bundle-version="[14.0.0,22.0.0)",

--- a/org.eclipse.xtext.builder/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.builder/META-INF/MANIFEST.MF
@@ -43,7 +43,7 @@ Export-Package: org.eclipse.xtext.builder,
  org.eclipse.xtext.builder.trace;x-friends:="org.eclipse.xtext.xbase.ui,org.eclipse.xtend.ide",
  org.eclipse.xtext.builder.trace.impl;x-internal:=true,
  org.eclipse.xtext.builder.trace.util;x-internal:=true
-Require-Bundle: org.eclipse.xtext;bundle-version="2.17.0",
+Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.util,
  org.eclipse.emf.ecore;bundle-version="2.10.2";visibility:=reexport,
  com.google.guava;bundle-version="[14.0.0,22.0.0)",

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/clustering/CurrentDescriptions.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/clustering/CurrentDescriptions.java
@@ -22,6 +22,8 @@ import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
  * @author Thomas Wolf <thomas.wolf@paranor.ch> - Performance optimization and JavaDoc
@@ -34,8 +36,6 @@ public class CurrentDescriptions extends AdapterImpl implements IResourceDescrip
 	private final ResourceDescriptionsData newData;
 	
 	private BuildData buildData;
-
-	private ResourceSet resourceSet;
 	
 	/**
 	 * @since 2.4
@@ -54,7 +54,6 @@ public class CurrentDescriptions extends AdapterImpl implements IResourceDescrip
 	 */
 	public CurrentDescriptions(ResourceSet resourceSet, ResourceDescriptionsData newData) {
 		this.newData = newData;
-		this.resourceSet = resourceSet;
 		resourceSet.eAdapters().add(this);
 	}
 	
@@ -146,6 +145,8 @@ public class CurrentDescriptions extends AdapterImpl implements IResourceDescrip
 	 */
 	@Override
 	public ResourceSet getResourceSet() {
+		Object target = getTarget();
+		ResourceSet resourceSet = (ResourceSet) checkNotNull(target);
 		return resourceSet;
 	}
 

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/clustering/CurrentDescriptions.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/clustering/CurrentDescriptions.java
@@ -26,7 +26,7 @@ import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
  * @author Sebastian Zarnekow - Initial contribution and API
  * @author Thomas Wolf <thomas.wolf@paranor.ch> - Performance optimization and JavaDoc
  */
-public class CurrentDescriptions extends AdapterImpl implements IResourceDescriptions {
+public class CurrentDescriptions extends AdapterImpl implements IResourceDescriptions.IResourceSetAware {
 
 	/**
 	 * New index.
@@ -34,6 +34,8 @@ public class CurrentDescriptions extends AdapterImpl implements IResourceDescrip
 	private final ResourceDescriptionsData newData;
 	
 	private BuildData buildData;
+
+	private ResourceSet resourceSet;
 	
 	/**
 	 * @since 2.4
@@ -52,6 +54,7 @@ public class CurrentDescriptions extends AdapterImpl implements IResourceDescrip
 	 */
 	public CurrentDescriptions(ResourceSet resourceSet, ResourceDescriptionsData newData) {
 		this.newData = newData;
+		this.resourceSet = resourceSet;
 		resourceSet.eAdapters().add(this);
 	}
 	
@@ -136,6 +139,14 @@ public class CurrentDescriptions extends AdapterImpl implements IResourceDescrip
 	@Override
 	public boolean isAdapterForType(Object type) {
 		return CurrentDescriptions.class.equals(type);
+	}
+
+	/**
+	 * @since 2.17
+	 */
+	@Override
+	public ResourceSet getResourceSet() {
+		return resourceSet;
 	}
 
 	/**

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/clustering/CurrentDescriptions.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/clustering/CurrentDescriptions.java
@@ -153,7 +153,7 @@ public class CurrentDescriptions extends AdapterImpl implements IResourceDescrip
 	/**
 	 * Context-aware instance of our index.
 	 */
-	public static class ResourceSetAware implements IResourceDescriptions.IContextAware {
+	public static class ResourceSetAware implements IResourceDescriptions.IContextAware, IResourceDescriptions.IResourceSetAware {
 
 		/** Base index. */
 		private IResourceDescriptions delegate;
@@ -221,5 +221,15 @@ public class CurrentDescriptions extends AdapterImpl implements IResourceDescrip
 			return delegate.getExportedObjectsByObject(object);
 		}
 
+		/**
+		 * @since 2.17
+		 */
+		@Override
+		public ResourceSet getResourceSet() {
+			checkNotNull(delegate);
+			IResourceSetAware resourceSetAware = (IResourceSetAware) delegate;
+			ResourceSet resourceSet = resourceSetAware.getResourceSet();
+			return resourceSet;
+		}
 	}
 }


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=427770

Short:
    Implement solution mentioned in above BUG report.

Longer:
    Bug (?) can be triggered by e.g.:

    IResourceServiceProvider sp = IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(fileUri);
    IResourceSetProvider provider = sp.get(IResourceSetProvider.class);
    IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
    // ... file etc
    IProject project = file.getProject();
    // Use the provider to get the resource set for the given project
    // FIXME how to get the existing XtextResourceSet? Below just creates a new rs. :-(
    ResourceSet rs = provider.get(project);
    // ... run build to generate index used by namespace etc
    BuildRequest request = new BuildRequest();
    request.setResourceSet(rs);
    request.setBaseDir(UriUtil.createFolderURI(new File(baseDir)));
    request.setDirtyFiles(allFiles);
    // ... copy paste code ...
    indexState = incrementalBuilder.build(request, languages).getIndexState();

    Hints for doing this correctly/cleaner is highly appreciated!

    After the code above has been triggered doing a Project Clean will
    trigger method from title to be called with a CurrentDescriptions.

Note that this commit goes together with a commit in xtext-core (see
https://github.com/eclipse/xtext-core/pull/1002).

Signed-off-by: Anders Dahlberg <anders.xb.dahlberg@ericsson.com>