### PR TITLE
[#949] Provide the AbstractHyperlinkingTest abstract base class.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.xtend
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ui.testing
+
+import com.google.inject.Inject
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.jdt.core.IType
+import org.eclipse.jface.text.IRegion
+import org.eclipse.jface.text.Region
+import org.eclipse.jface.text.hyperlink.IHyperlink
+import org.eclipse.xtext.common.types.xtext.ui.JdtHyperlink
+import org.eclipse.xtext.naming.IQualifiedNameProvider
+import org.eclipse.xtext.resource.FileExtensionProvider
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.ui.XtextProjectHelper
+import org.eclipse.xtext.ui.editor.XtextEditor
+import org.eclipse.xtext.ui.editor.XtextEditorInfo
+import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper
+import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink
+import org.eclipse.xtext.ui.editor.model.IXtextDocument
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
+import org.eclipse.xtext.ui.resource.IResourceSetProvider
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
+import org.eclipse.xtext.util.concurrent.IUnitOfWork
+
+import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.addNature
+
+/**
+ * @author miklossy - Initial contribution and API
+ * 
+ * @since 2.17
+ */
+abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
+
+	@Inject protected extension IHyperlinkHelper
+	@Inject protected extension FileExtensionProvider
+	@Inject protected extension IQualifiedNameProvider
+	@Inject protected extension SyncUtil
+
+	@Inject protected XtextEditorInfo editorInfo
+	@Inject protected IResourceSetProvider resourceSetProvider
+
+	protected IProject project
+
+	// position marker
+	protected val c = '''<|>'''
+
+	override protected getEditorId() {
+		editorInfo.getEditorId
+	}
+
+	/**
+	 * Tests that the user can navigate to the target element in a DSL text when activating the hyperlink on a certain region.
+	 * 
+	 * @param it
+	 *            The DSL text. The text must contain the {@link #c} special symbols twice indicating the beginning and the end of the
+	 *            region wehre the hyperlink navigation gets activated.
+	 * @param hyperlinkTarget
+	 *            The fully qualified name of the expected target element.
+	 */
+	def void hasHyperlinkTo(CharSequence it, String hyperlinkTarget) {
+		hasHyperlinkTo(hyperlinkRegion, hyperlinkTarget)
+	}
+
+	/**
+	 * Tests that the user can navigate to the target element in a DSL text when activating the hyperlink on a certain region.
+	 * 
+	 * @param it The initial DSL text.
+	 * @param hyperlinkRegion The region where the hyperlink navigation gets activated.
+	 * @param hyperlinkTarget The fully qualified name of the expected target element.
+	 */
+	def void hasHyperlinkTo(CharSequence it, IRegion hyperlinkRegion, String hyperlinkTarget) {
+		// given
+		dslFile.
+		// when
+		hyperlinkingOn(hyperlinkRegion.offset).
+		// then
+		hyperlinkIsOffered(hyperlinkRegion, hyperlinkTarget)
+	}
+
+	protected def IFile dslFile(CharSequence text) {
+		val content = text.toString.replace(c, "")
+		val file = IResourcesSetupUtil.createFile(projectName, fileName, fileExtension, content.toString)
+
+		/*
+		 * TODO: find a better (with good performance) solution
+		 * to set the Xtext nature on the test project.
+		 */
+		val project = file.project
+		if(!project.hasNature(XtextProjectHelper.NATURE_ID)) {
+			project.addNature(XtextProjectHelper.NATURE_ID)
+		}
+
+		file
+	}
+
+	protected def IHyperlink[] hyperlinkingOn(IFile dslFile, int offset) {
+		val editor = dslFile.openInEditor
+		val document = editor.internalSourceViewer.document as IXtextDocument
+		val resource = document.readOnly(new IUnitOfWork<XtextResource, XtextResource>(){
+
+			override exec(XtextResource state) {
+				state
+			}
+			
+		})
+
+		resource.createHyperlinksByOffset(offset, true)
+	}
+
+	protected def XtextEditor openInEditor(IFile dslFile) {
+		/*
+		 * wait for the cross-reference resolution
+		 */
+		waitForBuild(new NullProgressMonitor)
+		dslFile.openEditor
+	}
+
+	protected def void hyperlinkIsOffered(IHyperlink[] hyperlinks, IRegion expectedRegion, String expectedHyperlinkTarget) {
+		assertNotNull("No hyperlinks found!", hyperlinks)
+		assertEquals(1, hyperlinks.length)
+		val hyperlink = hyperlinks.head
+		
+		expectedRegion.assertEquals(hyperlink.hyperlinkRegion)
+		expectedHyperlinkTarget.assertEquals(hyperlink.target)
+	}
+
+	protected def dispatch String target(JdtHyperlink hyperlink) {
+		val javaElement = hyperlink.javaElement
+		assertTrue(javaElement instanceof IType)
+		(javaElement as IType).fullyQualifiedName
+	}
+
+	protected def dispatch String target(XtextHyperlink hyperlink) {
+		val resourceSet = resourceSetProvider.get(project)
+		val eObject = resourceSet.getEObject(hyperlink.URI, true)
+		eObject.fullyQualifiedName.toString
+	}
+
+	protected def dispatch String target(IHyperlink hyperlink) {
+		fail("Unsupported hyperlink " + hyperlink.class)
+		null
+	}
+
+	protected def String getProjectName() {
+		"HyperlinkingTestProject"
+	}
+
+	protected def String getFileName() {
+		"hyperlinking"
+	}
+
+	protected def String getFileExtension() {
+		primaryFileExtension
+	}
+
+	protected def IRegion hyperlinkRegion(CharSequence input) {
+		val text = input.toString
+		val first = text.indexOf(c)
+		if (first==-1) {
+			fail('''Can't locate the first position symbol '«c»' in the input text''')
+		}
+		val second = text.lastIndexOf(c)
+		if (first==second) {
+			fail('''Can't locate the second position symbol '«c»' in the input text''')
+		}
+		val offset = first
+		val length = second - first - c.length
+		new Region(offset, length)
+	}
+}

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ui.testing;
+
+import com.google.inject.Inject;
+import java.util.Arrays;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.common.types.xtext.ui.JdtHyperlink;
+import org.eclipse.xtext.naming.IQualifiedNameProvider;
+import org.eclipse.xtext.resource.FileExtensionProvider;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.XtextProjectHelper;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.eclipse.xtext.ui.editor.XtextEditorInfo;
+import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
+import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
+import org.eclipse.xtext.ui.resource.IResourceSetProvider;
+import org.eclipse.xtext.ui.testing.AbstractEditorTest;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Functions.Function0;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.junit.Assert;
+
+/**
+ * @author miklossy - Initial contribution and API
+ * 
+ * @since 2.17
+ */
+@SuppressWarnings("all")
+public abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
+  @Inject
+  @Extension
+  protected IHyperlinkHelper _iHyperlinkHelper;
+  
+  @Inject
+  @Extension
+  protected FileExtensionProvider _fileExtensionProvider;
+  
+  @Inject
+  @Extension
+  protected IQualifiedNameProvider _iQualifiedNameProvider;
+  
+  @Inject
+  @Extension
+  protected SyncUtil _syncUtil;
+  
+  @Inject
+  protected XtextEditorInfo editorInfo;
+  
+  @Inject
+  protected IResourceSetProvider resourceSetProvider;
+  
+  protected IProject project;
+  
+  protected final String c = new Function0<String>() {
+    public String apply() {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("<|>");
+      return _builder.toString();
+    }
+  }.apply();
+  
+  @Override
+  protected String getEditorId() {
+    return this.editorInfo.getEditorId();
+  }
+  
+  /**
+   * Tests that the user can navigate to the target element in a DSL text when activating the hyperlink on a certain region.
+   * 
+   * @param it
+   *            The DSL text. The text must contain the {@link #c} special symbols twice indicating the beginning and the end of the
+   *            region wehre the hyperlink navigation gets activated.
+   * @param hyperlinkTarget
+   *            The fully qualified name of the expected target element.
+   */
+  public void hasHyperlinkTo(final CharSequence it, final String hyperlinkTarget) {
+    this.hasHyperlinkTo(it, this.hyperlinkRegion(it), hyperlinkTarget);
+  }
+  
+  /**
+   * Tests that the user can navigate to the target element in a DSL text when activating the hyperlink on a certain region.
+   * 
+   * @param it The initial DSL text.
+   * @param hyperlinkRegion The region where the hyperlink navigation gets activated.
+   * @param hyperlinkTarget The fully qualified name of the expected target element.
+   */
+  public void hasHyperlinkTo(final CharSequence it, final IRegion hyperlinkRegion, final String hyperlinkTarget) {
+    this.hyperlinkIsOffered(this.hyperlinkingOn(this.dslFile(it), hyperlinkRegion.getOffset()), hyperlinkRegion, hyperlinkTarget);
+  }
+  
+  protected IFile dslFile(final CharSequence text) {
+    try {
+      IFile _xblockexpression = null;
+      {
+        final String content = text.toString().replace(this.c, "");
+        final IFile file = IResourcesSetupUtil.createFile(this.getProjectName(), this.getFileName(), this.getFileExtension(), content.toString());
+        final IProject project = file.getProject();
+        boolean _hasNature = project.hasNature(XtextProjectHelper.NATURE_ID);
+        boolean _not = (!_hasNature);
+        if (_not) {
+          IResourcesSetupUtil.addNature(project, XtextProjectHelper.NATURE_ID);
+        }
+        _xblockexpression = file;
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected IHyperlink[] hyperlinkingOn(final IFile dslFile, final int offset) {
+    IHyperlink[] _xblockexpression = null;
+    {
+      final XtextEditor editor = this.openInEditor(dslFile);
+      IDocument _document = editor.getInternalSourceViewer().getDocument();
+      final IXtextDocument document = ((IXtextDocument) _document);
+      final XtextResource resource = document.<XtextResource>readOnly(new IUnitOfWork<XtextResource, XtextResource>() {
+        @Override
+        public XtextResource exec(final XtextResource state) {
+          return state;
+        }
+      });
+      _xblockexpression = this._iHyperlinkHelper.createHyperlinksByOffset(resource, offset, true);
+    }
+    return _xblockexpression;
+  }
+  
+  protected XtextEditor openInEditor(final IFile dslFile) {
+    try {
+      XtextEditor _xblockexpression = null;
+      {
+        NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+        this._syncUtil.waitForBuild(_nullProgressMonitor);
+        _xblockexpression = this.openEditor(dslFile);
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected void hyperlinkIsOffered(final IHyperlink[] hyperlinks, final IRegion expectedRegion, final String expectedHyperlinkTarget) {
+    Assert.assertNotNull("No hyperlinks found!", hyperlinks);
+    Assert.assertEquals(1, hyperlinks.length);
+    final IHyperlink hyperlink = IterableExtensions.<IHyperlink>head(((Iterable<IHyperlink>)Conversions.doWrapArray(hyperlinks)));
+    Assert.assertEquals(expectedRegion, hyperlink.getHyperlinkRegion());
+    Assert.assertEquals(expectedHyperlinkTarget, this.target(hyperlink));
+  }
+  
+  protected String _target(final JdtHyperlink hyperlink) {
+    String _xblockexpression = null;
+    {
+      final IJavaElement javaElement = hyperlink.getJavaElement();
+      Assert.assertTrue((javaElement instanceof IType));
+      _xblockexpression = ((IType) javaElement).getFullyQualifiedName();
+    }
+    return _xblockexpression;
+  }
+  
+  protected String _target(final XtextHyperlink hyperlink) {
+    String _xblockexpression = null;
+    {
+      final ResourceSet resourceSet = this.resourceSetProvider.get(this.project);
+      final EObject eObject = resourceSet.getEObject(hyperlink.getURI(), true);
+      _xblockexpression = this._iQualifiedNameProvider.getFullyQualifiedName(eObject).toString();
+    }
+    return _xblockexpression;
+  }
+  
+  protected String _target(final IHyperlink hyperlink) {
+    Object _xblockexpression = null;
+    {
+      Class<? extends IHyperlink> _class = hyperlink.getClass();
+      String _plus = ("Unsupported hyperlink " + _class);
+      Assert.fail(_plus);
+      _xblockexpression = null;
+    }
+    return ((String)_xblockexpression);
+  }
+  
+  protected String getProjectName() {
+    return "HyperlinkingTestProject";
+  }
+  
+  protected String getFileName() {
+    return "hyperlinking";
+  }
+  
+  protected String getFileExtension() {
+    return this._fileExtensionProvider.getPrimaryFileExtension();
+  }
+  
+  protected IRegion hyperlinkRegion(final CharSequence input) {
+    Region _xblockexpression = null;
+    {
+      final String text = input.toString();
+      final int first = text.indexOf(this.c);
+      if ((first == (-1))) {
+        StringConcatenation _builder = new StringConcatenation();
+        _builder.append("Can\'t locate the first position symbol \'");
+        _builder.append(this.c);
+        _builder.append("\' in the input text");
+        Assert.fail(_builder.toString());
+      }
+      final int second = text.lastIndexOf(this.c);
+      if ((first == second)) {
+        StringConcatenation _builder_1 = new StringConcatenation();
+        _builder_1.append("Can\'t locate the second position symbol \'");
+        _builder_1.append(this.c);
+        _builder_1.append("\' in the input text");
+        Assert.fail(_builder_1.toString());
+      }
+      final int offset = first;
+      int _length = this.c.length();
+      final int length = ((second - first) - _length);
+      _xblockexpression = new Region(offset, length);
+    }
+    return _xblockexpression;
+  }
+  
+  protected String target(final IHyperlink hyperlink) {
+    if (hyperlink instanceof JdtHyperlink) {
+      return _target((JdtHyperlink)hyperlink);
+    } else if (hyperlink instanceof XtextHyperlink) {
+      return _target((XtextHyperlink)hyperlink);
+    } else if (hyperlink != null) {
+      return _target(hyperlink);
+    } else {
+      throw new IllegalArgumentException("Unhandled parameter types: " +
+        Arrays.<Object>asList(hyperlink).toString());
+    }
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/hyperlinking/HyperlinkingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/hyperlinking/HyperlinkingTest.xtend
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.arithmetics.ui.tests.hyperlinking
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest
+import org.junit.runner.RunWith
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider
+import org.junit.Test
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(ArithmeticsUiInjectorProvider)
+class HyperlinkingTest extends AbstractHyperlinkingTest {
+
+	@Test def hyperlink_on_function_call() {
+		'''
+			module arithmetics
+			
+			def pi: 3.14;
+			«c»pi«c» * 4;
+		'''.hasHyperlinkTo("arithmetics.pi")
+	}
+
+	@Test def hyperlink_on_parameter() {
+		'''
+			module m1
+			
+			def multiply(a, b) : a * «c»b«c»;
+			multiply(2,3);
+		'''.hasHyperlinkTo("m1.multiply.b")
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/hyperlinking/HyperlinkingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/hyperlinking/HyperlinkingTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.arithmetics.ui.tests.hyperlinking;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(ArithmeticsUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class HyperlinkingTest extends AbstractHyperlinkingTest {
+  @Test
+  public void hyperlink_on_function_call() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("module arithmetics");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("def pi: 3.14;");
+    _builder.newLine();
+    _builder.append(this.c);
+    _builder.append("pi");
+    _builder.append(this.c);
+    _builder.append(" * 4;");
+    _builder.newLineIfNotEmpty();
+    this.hasHyperlinkTo(_builder, "arithmetics.pi");
+  }
+  
+  @Test
+  public void hyperlink_on_parameter() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("module m1");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("def multiply(a, b) : a * ");
+    _builder.append(this.c);
+    _builder.append("b");
+    _builder.append(this.c);
+    _builder.append(";");
+    _builder.newLineIfNotEmpty();
+    _builder.append("multiply(2,3);");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "m1.multiply.b");
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HyperlinkingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HyperlinkingTest.xtend
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.domainmodel.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(DomainmodelUiInjectorProvider)
+class HyperlinkingTest extends AbstractHyperlinkingTest {
+
+	@Before def void setup() {
+		/*
+		 * Xbase-based languages require java project
+		 */
+		projectName.createJavaProject
+	}
+
+	@Test def hyperlink_on_java_import_statement() {
+		'''
+			import «c»java.util.Date«c»
+			
+			entity Foo {
+				date : Date
+			}
+		'''.hasHyperlinkTo("java.util.Date")
+	}
+
+	@Test def hyperlink_on_java_member_type() {
+		'''
+			import java.util.Date
+			
+			entity Foo {
+				date : «c»Date«c»
+			}
+		'''.hasHyperlinkTo("java.util.Date")
+	}
+
+	@Test def hyperlink_on_entity_import_statement() {
+		'''
+			import «c»foopackage.Foo«c»
+			
+			package foopackage {
+				entity Foo {}
+			}
+			
+			entity Bar {
+				foo : Foo
+			}
+		'''.hasHyperlinkTo("foopackage.Foo")
+	}
+
+	@Test def hyperlink_on_entity_member_type() {
+		'''
+			entity Foo {}
+			
+			entity Bar {
+				foo : «c»Foo«c»
+			}
+		'''.hasHyperlinkTo("Foo")
+	}
+
+	@Test def hyperlink_on_entity_member_type_in_package() {
+		'''
+			import foopackage.Foo
+			
+			package foopackage {
+				entity Foo {}
+			}
+			
+			entity Bar {
+				foo : «c»foopackage.Foo«c»
+			}
+		'''.hasHyperlinkTo("foopackage.Foo")
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HyperlinkingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HyperlinkingTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.domainmodel.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.domainmodel.ui.tests.DomainmodelUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(DomainmodelUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class HyperlinkingTest extends AbstractHyperlinkingTest {
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void hyperlink_on_java_import_statement() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import ");
+    _builder.append(this.c);
+    _builder.append("java.util.Date");
+    _builder.append(this.c);
+    _builder.newLineIfNotEmpty();
+    _builder.newLine();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("date : Date");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "java.util.Date");
+  }
+  
+  @Test
+  public void hyperlink_on_java_member_type() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.Date");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("date : ");
+    _builder.append(this.c, "\t");
+    _builder.append("Date");
+    _builder.append(this.c, "\t");
+    _builder.newLineIfNotEmpty();
+    _builder.append("}");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "java.util.Date");
+  }
+  
+  @Test
+  public void hyperlink_on_entity_import_statement() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import ");
+    _builder.append(this.c);
+    _builder.append("foopackage.Foo");
+    _builder.append(this.c);
+    _builder.newLineIfNotEmpty();
+    _builder.newLine();
+    _builder.append("package foopackage {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("entity Foo {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Bar {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("foo : Foo");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "foopackage.Foo");
+  }
+  
+  @Test
+  public void hyperlink_on_entity_member_type() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {}");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Bar {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("foo : ");
+    _builder.append(this.c, "\t");
+    _builder.append("Foo");
+    _builder.append(this.c, "\t");
+    _builder.newLineIfNotEmpty();
+    _builder.append("}");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "Foo");
+  }
+  
+  @Test
+  public void hyperlink_on_entity_member_type_in_package() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import foopackage.Foo");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("package foopackage {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("entity Foo {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity Bar {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("foo : ");
+    _builder.append(this.c, "\t");
+    _builder.append("foopackage.Foo");
+    _builder.append(this.c, "\t");
+    _builder.newLineIfNotEmpty();
+    _builder.append("}");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "foopackage.Foo");
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHyperlinkingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHyperlinkingTest.xtend
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.fowlerdsl.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(StatemachineUiInjectorProvider)
+class StatemachineHyperlinkingTest extends AbstractHyperlinkingTest {
+
+	@Test def hyperlink_on_event() {
+		'''
+			events
+				doorClosed D1CL
+			end
+			
+			state idle
+				«c»doorClosed«c» => active
+			end
+			
+			state active
+			end
+		'''.hasHyperlinkTo("doorClosed")
+	}
+
+	@Test def hyperlink_on_command() {
+		'''
+			commands
+				unlockDoor D1UL
+			end
+			
+			state idle
+				actions {«c»unlockDoor«c»}
+			end
+		'''.hasHyperlinkTo("unlockDoor")
+	}
+
+	@Test def hyperlink_on_state() {
+		'''
+			events
+				doorClosed D1CL
+			end
+			
+			state idle
+				doorClosed => «c»active«c»
+			end
+			
+			state active
+			end
+		'''.hasHyperlinkTo("active")
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHyperlinkingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHyperlinkingTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.fowlerdsl.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.fowlerdsl.ui.tests.StatemachineUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(StatemachineUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class StatemachineHyperlinkingTest extends AbstractHyperlinkingTest {
+  @Test
+  public void hyperlink_on_event() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed D1CL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state idle");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append(this.c, "\t");
+    _builder.append("doorClosed");
+    _builder.append(this.c, "\t");
+    _builder.append(" => active");
+    _builder.newLineIfNotEmpty();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state active");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "doorClosed");
+  }
+  
+  @Test
+  public void hyperlink_on_command() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("commands");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockDoor D1UL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state idle");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("actions {");
+    _builder.append(this.c, "\t");
+    _builder.append("unlockDoor");
+    _builder.append(this.c, "\t");
+    _builder.append("}");
+    _builder.newLineIfNotEmpty();
+    _builder.append("end");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "unlockDoor");
+  }
+  
+  @Test
+  public void hyperlink_on_state() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed D1CL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state idle");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed => ");
+    _builder.append(this.c, "\t");
+    _builder.append("active");
+    _builder.append(this.c, "\t");
+    _builder.newLineIfNotEmpty();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("state active");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "active");
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHyperlinkingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHyperlinkingTest.xtend
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.homeautomation.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(RuleEngineUiInjectorProvider)
+class RuleEngineHyperlinkingTest extends AbstractHyperlinkingTest {
+
+	@Before def void setup() {
+		/*
+		 * Xbase-based languages require java project
+		 */
+		projectName.createJavaProject
+	}
+
+	@Test def hyperlink_on_rule_when_part() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			Rule 'rule1' when «c»Window.open«c» then
+				fire(Heater.off)
+		'''.hasHyperlinkTo("Window.open")
+	}
+
+	@Test def hyperlink_on_device_name_in_rule_then_part() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			Rule 'rule1' when Window.open then
+				fire(«c»Heater«c».off)
+		'''.hasHyperlinkTo("Heater")
+	}
+
+	@Test def hyperlink_on_device_state_in_rule_then_part() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			Rule 'rule1' when Window.open then
+				fire(Heater.«c»off«c»)
+		'''.hasHyperlinkTo("Heater.off")
+	}
+
+	@Test def hyperlink_on_link_in_javadoc1() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			/**
+			 * If the {@link «c»Window«c»} is open, the {@link Heater} should be turned off.
+			 */
+			Rule 'rule1' when Window.open then
+				fire(Heater.off)
+		'''.hasHyperlinkTo("Window")
+	}
+
+	@Test def hyperlink_on_link_in_javadoc2() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			/**
+			 * If the {@link Window} is open, the {@link «c»Heater«c»} should be turned off.
+			 */
+			Rule 'rule1' when Window.open then
+				fire(Heater.off)
+		'''.hasHyperlinkTo("Heater")
+	}
+
+	@Test def hyperlink_on_link_in_javadoc3() {
+		'''
+			/**
+			 * {@link «c»java.util.List«c»}
+			 */
+			Device Window can be open, closed
+		'''.hasHyperlinkTo("java.util.List")
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHyperlinkingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHyperlinkingTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.homeautomation.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.homeautomation.ui.tests.RuleEngineUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(RuleEngineUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class RuleEngineHyperlinkingTest extends AbstractHyperlinkingTest {
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void hyperlink_on_rule_when_part() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Rule \'rule1\' when ");
+    _builder.append(this.c);
+    _builder.append("Window.open");
+    _builder.append(this.c);
+    _builder.append(" then");
+    _builder.newLineIfNotEmpty();
+    _builder.append("\t");
+    _builder.append("fire(Heater.off)");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "Window.open");
+  }
+  
+  @Test
+  public void hyperlink_on_device_name_in_rule_then_part() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Rule \'rule1\' when Window.open then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(");
+    _builder.append(this.c, "\t");
+    _builder.append("Heater");
+    _builder.append(this.c, "\t");
+    _builder.append(".off)");
+    _builder.newLineIfNotEmpty();
+    this.hasHyperlinkTo(_builder, "Heater");
+  }
+  
+  @Test
+  public void hyperlink_on_device_state_in_rule_then_part() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Rule \'rule1\' when Window.open then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(Heater.");
+    _builder.append(this.c, "\t");
+    _builder.append("off");
+    _builder.append(this.c, "\t");
+    _builder.append(")");
+    _builder.newLineIfNotEmpty();
+    this.hasHyperlinkTo(_builder, "Heater.off");
+  }
+  
+  @Test
+  public void hyperlink_on_link_in_javadoc1() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* If the {@link ");
+    _builder.append(this.c, " ");
+    _builder.append("Window");
+    _builder.append(this.c, " ");
+    _builder.append("} is open, the {@link Heater} should be turned off.");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("Rule \'rule1\' when Window.open then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(Heater.off)");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "Window");
+  }
+  
+  @Test
+  public void hyperlink_on_link_in_javadoc2() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* If the {@link Window} is open, the {@link ");
+    _builder.append(this.c, " ");
+    _builder.append("Heater");
+    _builder.append(this.c, " ");
+    _builder.append("} should be turned off.");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("Rule \'rule1\' when Window.open then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(Heater.off)");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "Heater");
+  }
+  
+  @Test
+  public void hyperlink_on_link_in_javadoc3() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* {@link ");
+    _builder.append(this.c, " ");
+    _builder.append("java.util.List");
+    _builder.append(this.c, " ");
+    _builder.append("}");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "java.util.List");
+  }
+}


### PR DESCRIPTION
- Extend the 'Xtext UI Testing' test infrastructure by the
AbstractHyperlinkingTest abstract class to provide a base infrastructure
for testing hyperlink navigations.
- Extend the Xtext Examples the HyperlinkingTest test cases to
demonstrate the usage of the AbstractHyperlinkingTest class.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>