### PR TITLE
[#951] Extend the Domainmodel Example by hyperlinking in javadoc.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HyperlinkingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HyperlinkingTest.xtend
@@ -64,6 +64,19 @@ class HyperlinkingTest extends AbstractHyperlinkingTest {
 		'''.hasHyperlinkTo("foopackage.Foo")
 	}
 
+	@Test def hyperlink_javadoc_link_to_java_type() {
+		'''
+			import java.util.Date
+			
+			/**
+			 * {@link «c»Date«c»}
+			 */
+			entity Foo {
+				date : Date
+			}
+		'''.hasHyperlinkTo("java.util.Date")
+	}
+
 	@Test def hyperlink_on_entity_member_type() {
 		'''
 			entity Foo {}
@@ -86,5 +99,18 @@ class HyperlinkingTest extends AbstractHyperlinkingTest {
 				foo : «c»foopackage.Foo«c»
 			}
 		'''.hasHyperlinkTo("foopackage.Foo")
+	}
+
+	@Test def hyperlink_javadoc_link_to_entity_type() {
+		'''
+			import java.util.Date
+			
+			/**
+			 * {@link «c»Foo«c»}
+			 */
+			entity Foo {
+				date : Date
+			}
+		'''.hasHyperlinkTo("Foo")
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HyperlinkingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HyperlinkingTest.java
@@ -100,6 +100,34 @@ public class HyperlinkingTest extends AbstractHyperlinkingTest {
   }
   
   @Test
+  public void hyperlink_javadoc_link_to_java_type() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.Date");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* {@link ");
+    _builder.append(this.c, " ");
+    _builder.append("Date");
+    _builder.append(this.c, " ");
+    _builder.append("}");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("date : Date");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "java.util.Date");
+  }
+  
+  @Test
   public void hyperlink_on_entity_member_type() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("entity Foo {}");
@@ -143,5 +171,33 @@ public class HyperlinkingTest extends AbstractHyperlinkingTest {
     _builder.append("}");
     _builder.newLine();
     this.hasHyperlinkTo(_builder, "foopackage.Foo");
+  }
+  
+  @Test
+  public void hyperlink_javadoc_link_to_entity_type() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.Date");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* {@link ");
+    _builder.append(this.c, " ");
+    _builder.append("Foo");
+    _builder.append(this.c, " ");
+    _builder.append("}");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("date : Date");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.hasHyperlinkTo(_builder, "Foo");
   }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/navigation/DomainmodelHyperlinkHelper.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/navigation/DomainmodelHyperlinkHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,6 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.text.Region;
 import org.eclipse.xtext.common.types.xtext.ui.JdtHyperlink;
-import org.eclipse.xtext.common.types.xtext.ui.TypeAwareHyperlinkHelper;
 import org.eclipse.xtext.example.domainmodel.domainmodel.DomainmodelPackage;
 import org.eclipse.xtext.example.domainmodel.domainmodel.Entity;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
@@ -27,6 +26,7 @@ import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkAcceptor;
+import org.eclipse.xtext.xbase.ui.navigation.XbaseHyperLinkHelper;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -35,7 +35,7 @@ import com.google.inject.Provider;
  * @author Sebastian Zarnekow - Initial contribution and API
  * @author Jan Koehnlein - introduced QualifiedName
  */
-public class DomainmodelHyperlinkHelper extends TypeAwareHyperlinkHelper {
+public class DomainmodelHyperlinkHelper extends XbaseHyperLinkHelper {
 
 	private static final Logger logger = Logger.getLogger(DomainmodelHyperlinkHelper.class);
 


### PR DESCRIPTION
- Modify the DomainmodelHyperlinkHelper to recognize hyperlinks in
javadocs.
- Implement corresponding HyperlinkingTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>