### PR TITLE
Refactoring the Xtext UI Test Infrastructure.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractEditorDoubleClickTextSelectionTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractEditorDoubleClickTextSelectionTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,14 +15,14 @@ import org.eclipse.ui.texteditor.AbstractTextEditor
 import org.eclipse.xtext.resource.FileExtensionProvider
 import org.eclipse.xtext.ui.editor.XtextEditor
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
-import org.eclipse.xtext.ui.editor.XtextEditorInfo
 
 /**
+ * @author miklossy - Initial contribution and API
+ * 
  * @since 2.14
  */
 abstract class AbstractEditorDoubleClickTextSelectionTest extends AbstractEditorTest {
 
-	@Inject XtextEditorInfo xtextEditorInfo
 	@Inject extension FileExtensionProvider
 
 	/**
@@ -95,9 +95,4 @@ abstract class AbstractEditorDoubleClickTextSelectionTest extends AbstractEditor
 		val actualSelectedText = (textEditor.selectionProvider.selection as ITextSelection).text
 		expectedSelectedText.assertEquals(actualSelectedText)
 	}
-
-	override protected getEditorId() {
-		xtextEditorInfo.editorId
-	}
-
 }

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractEditorTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractEditorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,10 @@ import org.eclipse.ui.ide.FileStoreEditorInput;
 import org.eclipse.ui.internal.ErrorEditorPart;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.eclipse.xtext.ui.editor.XtextEditorInfo;
 import org.eclipse.xtext.ui.editor.utils.EditorUtils;
+
+import com.google.inject.Inject;
 
 /**
  * @author Peter Friese - Initial contribution and API
@@ -35,7 +38,11 @@ public abstract class AbstractEditorTest extends AbstractWorkbenchTest {
 
 	static final long STEP_DELAY = 0;
 
-	protected abstract String getEditorId();
+	@Inject protected XtextEditorInfo editorInfo;
+
+	protected String getEditorId() {
+		return editorInfo.getEditorId();
+	}
 
 	protected XtextEditor openEditor(IFile file) throws Exception {
 		return getXtextEditor(

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ import org.eclipse.swt.custom.StyledText
 import org.eclipse.swt.graphics.Color
 import org.eclipse.xtext.resource.FileExtensionProvider
 import org.eclipse.xtext.ui.XtextProjectHelper
-import org.eclipse.xtext.ui.editor.XtextEditorInfo
 import org.eclipse.xtext.ui.editor.utils.TextStyle
 import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
@@ -22,18 +21,14 @@ import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
 import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.addNature
 
 /**
+ * @author miklossy - Initial contribution and API
+ * 
  * @since 2.15
  */
 abstract class AbstractHighlightingTest extends AbstractEditorTest {
 
-	@Inject XtextEditorInfo editorInfo
-
 	@Inject extension SyncUtil
 	@Inject extension FileExtensionProvider
-
-	override protected getEditorId() {
-		editorInfo.getEditorId
-	}
 
 	/**
 	 * @param it The editor's input text. The input text must contain the given <code>text</code>.

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHoverTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHoverTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,6 @@ import org.eclipse.jface.text.Region
 import org.eclipse.xtext.resource.FileExtensionProvider
 import org.eclipse.xtext.ui.XtextProjectHelper
 import org.eclipse.xtext.ui.editor.XtextEditor
-import org.eclipse.xtext.ui.editor.XtextEditorInfo
 import org.eclipse.xtext.ui.editor.hover.IEObjectHover
 import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
@@ -32,14 +31,9 @@ import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.ad
 abstract class AbstractHoverTest extends AbstractEditorTest {
 
 	@Inject protected IEObjectHover eObjectHover
-	@Inject protected XtextEditorInfo editorInfo
 
 	@Inject protected extension SyncUtil
 	@Inject protected extension FileExtensionProvider
-
-	override protected getEditorId() {
-		editorInfo.getEditorId
-	}
 
 	/**
 	 * Test that the expected text appears in a popup window while hovering over a certain text in a given DSL text.

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.xtend
@@ -21,7 +21,6 @@ import org.eclipse.xtext.resource.FileExtensionProvider
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.ui.XtextProjectHelper
 import org.eclipse.xtext.ui.editor.XtextEditor
-import org.eclipse.xtext.ui.editor.XtextEditorInfo
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper
 import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink
 import org.eclipse.xtext.ui.editor.model.IXtextDocument
@@ -44,17 +43,12 @@ abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
 	@Inject protected extension IQualifiedNameProvider
 	@Inject protected extension SyncUtil
 
-	@Inject protected XtextEditorInfo editorInfo
 	@Inject protected IResourceSetProvider resourceSetProvider
 
 	protected IProject project
 
 	// position marker
 	protected val c = '''<|>'''
-
-	override protected getEditorId() {
-		editorInfo.getEditorId
-	}
 
 	/**
 	 * Tests that the user can navigate to the target element in a DSL text when activating the hyperlink on a certain region.

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,6 @@ import org.eclipse.xtext.resource.IResourceFactory
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.ui.XtextProjectHelper
 import org.eclipse.xtext.ui.editor.XtextEditor
-import org.eclipse.xtext.ui.editor.XtextEditorInfo
 import org.eclipse.xtext.ui.editor.model.IXtextDocument
 import org.eclipse.xtext.ui.editor.model.XtextDocument
 import org.eclipse.xtext.ui.editor.model.edit.IModificationContext
@@ -46,7 +45,6 @@ import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.ad
 abstract class AbstractQuickfixTest extends AbstractEditorTest {
 
 	@Inject protected Injector injector
-	@Inject protected XtextEditorInfo editorInfo
 	@Inject protected IResourceSetProvider resourceSetProvider
 
 	@Inject protected extension SyncUtil
@@ -55,10 +53,6 @@ abstract class AbstractQuickfixTest extends AbstractEditorTest {
 	@Inject protected extension IssueResolutionProvider
 	
 	protected IProject project
-
-	override protected getEditorId() {
-		editorInfo.getEditorId
-	}
 
 	/**
 	 * Test that the expected quickfixes are offered on a given validation issue in a given DSL text.

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractEditorDoubleClickTextSelectionTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractEditorDoubleClickTextSelectionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.ui.editor.XtextEditor;
-import org.eclipse.xtext.ui.editor.XtextEditorInfo;
 import org.eclipse.xtext.ui.testing.AbstractEditorTest;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -29,13 +28,12 @@ import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 
 /**
+ * @author miklossy - Initial contribution and API
+ * 
  * @since 2.14
  */
 @SuppressWarnings("all")
 public abstract class AbstractEditorDoubleClickTextSelectionTest extends AbstractEditorTest {
-  @Inject
-  private XtextEditorInfo xtextEditorInfo;
-  
   @Inject
   @Extension
   private FileExtensionProvider _fileExtensionProvider;
@@ -136,10 +134,5 @@ public abstract class AbstractEditorDoubleClickTextSelectionTest extends Abstrac
     ISelection _selection = textEditor.getSelectionProvider().getSelection();
     final String actualSelectedText = ((ITextSelection) _selection).getText();
     Assert.assertEquals(expectedSelectedText, actualSelectedText);
-  }
-  
-  @Override
-  protected String getEditorId() {
-    return this.xtextEditorInfo.getEditorId();
   }
 }

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
-import org.eclipse.xtext.ui.editor.XtextEditorInfo;
 import org.eclipse.xtext.ui.editor.utils.TextStyle;
 import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
 import org.eclipse.xtext.ui.testing.AbstractEditorTest;
@@ -31,13 +30,12 @@ import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.junit.Assert;
 
 /**
+ * @author miklossy - Initial contribution and API
+ * 
  * @since 2.15
  */
 @SuppressWarnings("all")
 public abstract class AbstractHighlightingTest extends AbstractEditorTest {
-  @Inject
-  private XtextEditorInfo editorInfo;
-  
   @Inject
   @Extension
   private SyncUtil _syncUtil;
@@ -45,11 +43,6 @@ public abstract class AbstractHighlightingTest extends AbstractEditorTest {
   @Inject
   @Extension
   private FileExtensionProvider _fileExtensionProvider;
-  
-  @Override
-  protected String getEditorId() {
-    return this.editorInfo.getEditorId();
-  }
   
   /**
    * @param it The editor's input text. The input text must contain the given <code>text</code>.

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHoverTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
-import org.eclipse.xtext.ui.editor.XtextEditorInfo;
 import org.eclipse.xtext.ui.editor.hover.IEObjectHover;
 import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
 import org.eclipse.xtext.ui.testing.AbstractEditorTest;
@@ -39,20 +38,12 @@ public abstract class AbstractHoverTest extends AbstractEditorTest {
   protected IEObjectHover eObjectHover;
   
   @Inject
-  protected XtextEditorInfo editorInfo;
-  
-  @Inject
   @Extension
   protected SyncUtil _syncUtil;
   
   @Inject
   @Extension
   protected FileExtensionProvider _fileExtensionProvider;
-  
-  @Override
-  protected String getEditorId() {
-    return this.editorInfo.getEditorId();
-  }
   
   /**
    * Test that the expected text appears in a popup window while hovering over a certain text in a given DSL text.

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.java
@@ -27,7 +27,6 @@ import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
-import org.eclipse.xtext.ui.editor.XtextEditorInfo;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
 import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
@@ -67,9 +66,6 @@ public abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
   protected SyncUtil _syncUtil;
   
   @Inject
-  protected XtextEditorInfo editorInfo;
-  
-  @Inject
   protected IResourceSetProvider resourceSetProvider;
   
   protected IProject project;
@@ -81,11 +77,6 @@ public abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
       return _builder.toString();
     }
   }.apply();
-  
-  @Override
-  protected String getEditorId() {
-    return this.editorInfo.getEditorId();
-  }
   
   /**
    * Tests that the user can navigate to the target element in a DSL text when activating the hyperlink on a certain region.

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,6 @@ import org.eclipse.xtext.resource.IResourceFactory;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
-import org.eclipse.xtext.ui.editor.XtextEditorInfo;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.XtextDocument;
 import org.eclipse.xtext.ui.editor.model.edit.IModification;
@@ -161,9 +160,6 @@ public abstract class AbstractQuickfixTest extends AbstractEditorTest {
   protected Injector injector;
   
   @Inject
-  protected XtextEditorInfo editorInfo;
-  
-  @Inject
   protected IResourceSetProvider resourceSetProvider;
   
   @Inject
@@ -183,11 +179,6 @@ public abstract class AbstractQuickfixTest extends AbstractEditorTest {
   protected IssueResolutionProvider _issueResolutionProvider;
   
   protected IProject project;
-  
-  @Override
-  protected String getEditorId() {
-    return this.editorInfo.getEditorId();
-  }
   
   /**
    * Test that the expected quickfixes are offered on a given validation issue in a given DSL text.

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/occurrences/MarkOccurrencesTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/occurrences/MarkOccurrencesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,6 @@ import org.eclipse.xtext.ui.testing.AbstractEditorTest;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.tests.editor.outline.ui.tests.OutlineTestLanguageUiInjectorProvider;
-import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.eclipse.xtext.util.Triple;
 import org.eclipse.xtext.util.Tuples;
 import org.junit.Assert;
@@ -66,11 +65,6 @@ public class MarkOccurrencesTest extends AbstractEditorTest {
 
 	@Inject
 	private IOccurrenceComputer occurrenceComputer;
-
-	@Override
-	protected String getEditorId() {
-		return TestsActivator.ORG_ECLIPSE_XTEXT_UI_TESTS_EDITOR_OUTLINE_OUTLINETESTLANGUAGE;
-	}
 
 	@Override
 	public void setUp() throws Exception {

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.ui.tests.bug462047
 
-import com.google.inject.Inject
 import org.apache.log4j.Level
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.util.EcoreUtil
@@ -15,7 +14,6 @@ import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.testing.logging.LoggingTester
-import org.eclipse.xtext.ui.editor.XtextEditorInfo
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
 import org.eclipse.xtext.ui.testing.AbstractEditorTest
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
@@ -41,8 +39,6 @@ class Bug462047Test extends AbstractEditorTest {
 		TargetPlatformUtil.setTargetPlatform(Bug462047Test);
 	}
 	
-	@Inject XtextEditorInfo editorInfo
-	
 	@Before
 	def void createProjects() {
 		AbstractXbaseUITestCase.createPluginProject('bug462047')
@@ -51,10 +47,6 @@ class Bug462047Test extends AbstractEditorTest {
 	@After
 	def deleteProjects() {
 		IResourcesSetupUtil.cleanWorkspace();
-	}
-	
-	override protected getEditorId() {
-		editorInfo.editorId
 	}
 	
 	@Test

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtext.xbase.ui.tests.bug462047;
 
-import com.google.inject.Inject;
 import org.apache.log4j.Level;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.emf.common.util.URI;
@@ -18,7 +17,6 @@ import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.testing.logging.LoggingTester;
 import org.eclipse.xtext.ui.editor.XtextEditor;
-import org.eclipse.xtext.ui.editor.XtextEditorInfo;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.ui.testing.AbstractEditorTest;
@@ -52,9 +50,6 @@ public class Bug462047Test extends AbstractEditorTest {
     }
   }
   
-  @Inject
-  private XtextEditorInfo editorInfo;
-  
   @Before
   public void createProjects() {
     try {
@@ -71,11 +66,6 @@ public class Bug462047Test extends AbstractEditorTest {
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
-  }
-  
-  @Override
-  protected String getEditorId() {
-    return this.editorInfo.getEditorId();
   }
   
   @Test

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/OutlineTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/OutlineTest.xtend
@@ -1,6 +1,5 @@
 package org.eclipse.xtext.example.domainmodel.ui.tests
 
-import org.eclipse.xtext.example.domainmodel.ui.internal.DomainmodelActivator
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.ui.testing.AbstractOutlineTest
@@ -13,10 +12,6 @@ import org.junit.runner.RunWith
 @RunWith(XtextRunner)
 @InjectWith(DomainmodelUiInjectorProvider)
 class OutlineTest extends AbstractOutlineTest {
-
-	override protected getEditorId() {
-		DomainmodelActivator.ORG_ECLIPSE_XTEXT_EXAMPLE_DOMAINMODEL_DOMAINMODEL
-	}
 
 	@Test def void testOutline() {
 		'''

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/OutlineTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/OutlineTest.java
@@ -1,7 +1,6 @@
 package org.eclipse.xtext.example.domainmodel.ui.tests;
 
 import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.example.domainmodel.ui.internal.DomainmodelActivator;
 import org.eclipse.xtext.example.domainmodel.ui.tests.DomainmodelUiInjectorProvider;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
@@ -17,11 +16,6 @@ import org.junit.runner.RunWith;
 @InjectWith(DomainmodelUiInjectorProvider.class)
 @SuppressWarnings("all")
 public class OutlineTest extends AbstractOutlineTest {
-  @Override
-  protected String getEditorId() {
-    return DomainmodelActivator.ORG_ECLIPSE_XTEXT_EXAMPLE_DOMAINMODEL_DOMAINMODEL;
-  }
-  
   @Test
   public void testOutline() {
     try {


### PR DESCRIPTION
- Modify the AbstractEditorTest class to provide a default
implementation of the getEditorId() method instead of being an abstract
method.
- Eliminate the getEditorId() method from the derived classes that
provide the same implementation of the getEditorId() method as the
inherited one.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>