### PR TITLE
Speed up the Xtext UI Test cases.

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/JavaClassPathResourceForIEditorInputFactoryTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/JavaClassPathResourceForIEditorInputFactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,11 +29,8 @@ import org.eclipse.jdt.internal.core.NonJavaResource;
 import org.eclipse.xtext.ui.editor.XtextReadonlyEditorInput;
 import org.eclipse.xtext.ui.editor.model.IResourceForEditorInputFactory;
 import org.eclipse.xtext.ui.testing.AbstractWorkbenchTest;
-import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.TextFile;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.google.inject.Injector;
@@ -53,12 +50,6 @@ public class JavaClassPathResourceForIEditorInputFactoryTest extends AbstractWor
 	
 	protected Injector getInjector() {
 		return TestsActivator.getInstance().getInjector(TestsActivator.ORG_ECLIPSE_XTEXT_UI_TESTS_TESTLANGUAGE);
-	}
-	
-	@Before
-	@After
-	public void cleanWorkspace() throws Exception {
-		IResourcesSetupUtil.cleanWorkspace();
 	}
 	
 	@Test public void testBug463258_01() throws Exception {

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.xtend
@@ -21,7 +21,6 @@ import org.eclipse.xtext.ui.testing.util.TargetPlatformUtil
 import org.eclipse.xtext.xbase.resource.BatchLinkableResource
 import org.eclipse.xtext.xbase.testlanguages.bug462047.ui.tests.Bug462047LangUiInjectorProvider
 import org.eclipse.xtext.xbase.ui.tests.AbstractXbaseUITestCase
-import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -42,11 +41,6 @@ class Bug462047Test extends AbstractEditorTest {
 	@Before
 	def void createProjects() {
 		AbstractXbaseUITestCase.createPluginProject('bug462047')
-	}
-	 
-	@After
-	def deleteProjects() {
-		IResourcesSetupUtil.cleanWorkspace();
 	}
 	
 	@Test

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.java
@@ -27,7 +27,6 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.resource.BatchLinkableResource;
 import org.eclipse.xtext.xbase.testlanguages.bug462047.ui.tests.Bug462047LangUiInjectorProvider;
 import org.eclipse.xtext.xbase.ui.tests.AbstractXbaseUITestCase;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -54,15 +53,6 @@ public class Bug462047Test extends AbstractEditorTest {
   public void createProjects() {
     try {
       AbstractXbaseUITestCase.createPluginProject("bug462047");
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
-  }
-  
-  @After
-  public void deleteProjects() {
-    try {
-      IResourcesSetupUtil.cleanWorkspace();
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }


### PR DESCRIPTION
- Ensure that the IResourcesSetupUtil.cleanWorkspace() method is called
only once after each test execution. The call is already triggered by
the inherited AbstractWorkbenchTest.tearDown() method, so there is no
need to trigger it once again from the concrete test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>