### PR TITLE
Refactoring the DomainmodelHyperlinkHelper in the Domain-Model Example.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/navigation/DomainmodelHyperlinkHelper.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/navigation/DomainmodelHyperlinkHelper.java
@@ -22,7 +22,6 @@ import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
-import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkAcceptor;
@@ -48,13 +47,10 @@ public class DomainmodelHyperlinkHelper extends XbaseHyperLinkHelper {
 	@Inject
 	private Provider<JdtHyperlink> jdtHyperlinkProvider;
 
-	@Inject
-	private EObjectAtOffsetHelper eObjectAtOffsetHelper;
-
 	@Override
 	public void createHyperlinksByOffset(XtextResource resource, int offset, IHyperlinkAcceptor acceptor) {
 		super.createHyperlinksByOffset(resource, offset, acceptor);
-		EObject eObject = eObjectAtOffsetHelper.resolveElementAt(resource, offset);
+		EObject eObject = getEObjectAtOffsetHelper().resolveElementAt(resource, offset);
 		if (eObject instanceof Entity) {
 			List<INode> nodes = NodeModelUtils.findNodesForFeature(eObject, DomainmodelPackage.Literals.ABSTRACT_ELEMENT__NAME);
 			if (!nodes.isEmpty()) {


### PR DESCRIPTION
- Use the inherited EObjectAtOffsetHelper instance instead of injecting
an own one.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>