### PR TITLE
[#410479] Refactoring the XtextGrammarQuickfixTest test cases.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.xtend
@@ -24,24 +24,41 @@ import static org.eclipse.xtext.xtext.XtextConfigurableIssueCodes.SPACES_IN_KEYW
 @InjectWith(XtextGrammarQuickfixTest.InjectorProvider)
 class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
 
-	@Test
-	def testFixKeywordWithSpaces() {
-		grammarWithRules('''Model: ' a b c d ' a=ID;''').testQuickfixesOn(SPACES_IN_KEYWORD,
-			new Quickfix("Fix keyword with spaces", "Fix keyword with spaces",
-				grammarWithRules('''Model: 'a' 'b' 'c' 'd' a=ID;''')))
+	@Test def fix_keyword_with_spaces() {
+		'''
+			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+			generate myDsl "http://www.xtext.org/mydsl/MyDsl"
+
+			Model: ' a b c d ' a=ID;
+		'''.applyKeywordWithSpacesQuickfix('''
+			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+			generate myDsl "http://www.xtext.org/mydsl/MyDsl"
+			
+			Model: 'a' 'b' 'c' 'd' a=ID;
+		''')
 	}
 
-	@Test
-	def testFixEmptyKeywordWithSpaces() {
-		grammarWithRules('''Model: '    ' a=ID;''').testQuickfixesOn(SPACES_IN_KEYWORD,
-			new Quickfix("Fix keyword with spaces", "Fix keyword with spaces", grammarWithRules('''Model: '' a=ID;''')))
+	@Test def fix_empty_keyword_with_spaces() {
+		'''
+			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+			generate myDsl "http://www.xtext.org/mydsl/MyDsl"
+			
+			Model: '    ' a=ID;
+		'''.applyKeywordWithSpacesQuickfix('''
+			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+			generate myDsl "http://www.xtext.org/mydsl/MyDsl"
+			
+			Model: '' a=ID;
+		''')
 	}
 
-	def private String grammarWithRules(CharSequence... rules) '''
-		grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
-		generate myDsl "http://www.xtext.org/mydsl/MyDsl"
-		«rules.join('\n')»
-	'''
+	private def applyKeywordWithSpacesQuickfix(CharSequence input, String result) {
+		val issueCode = SPACES_IN_KEYWORD
+		val label = "Fix keyword with spaces"
+		val description = "Fix keyword with spaces"
+
+		input.testQuickfixesOn(issueCode, new Quickfix(label, description, result))
+	}
 
 	static class InjectorProvider implements IInjectorProvider {
 		override getInjector() {

--- a/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.java
@@ -13,8 +13,6 @@ import org.eclipse.xtext.testing.IInjectorProvider;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.testing.AbstractQuickfixTest;
-import org.eclipse.xtext.xbase.lib.Conversions;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xtext.XtextConfigurableIssueCodes;
 import org.eclipse.xtext.xtext.ui.Activator;
 import org.junit.Test;
@@ -35,38 +33,52 @@ public class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
   }
   
   @Test
-  public void testFixKeywordWithSpaces() {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("Model: \' a b c d \' a=ID;");
-    String _grammarWithRules = this.grammarWithRules(_builder);
-    StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("Model: \'a\' \'b\' \'c\' \'d\' a=ID;");
-    String _grammarWithRules_1 = this.grammarWithRules(_builder_1);
-    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Fix keyword with spaces", "Fix keyword with spaces", _grammarWithRules_1);
-    this.testQuickfixesOn(_grammarWithRules, XtextConfigurableIssueCodes.SPACES_IN_KEYWORD, _quickfix);
-  }
-  
-  @Test
-  public void testFixEmptyKeywordWithSpaces() {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("Model: \'    \' a=ID;");
-    String _grammarWithRules = this.grammarWithRules(_builder);
-    StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("Model: \'\' a=ID;");
-    String _grammarWithRules_1 = this.grammarWithRules(_builder_1);
-    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Fix keyword with spaces", "Fix keyword with spaces", _grammarWithRules_1);
-    this.testQuickfixesOn(_grammarWithRules, XtextConfigurableIssueCodes.SPACES_IN_KEYWORD, _quickfix);
-  }
-  
-  private String grammarWithRules(final CharSequence... rules) {
+  public void fix_keyword_with_spaces() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
     _builder.newLine();
     _builder.append("generate myDsl \"http://www.xtext.org/mydsl/MyDsl\"");
     _builder.newLine();
-    String _join = IterableExtensions.join(((Iterable<?>)Conversions.doWrapArray(rules)), "\n");
-    _builder.append(_join);
-    _builder.newLineIfNotEmpty();
-    return _builder.toString();
+    _builder.newLine();
+    _builder.append("Model: \' a b c d \' a=ID;");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_1.newLine();
+    _builder_1.append("generate myDsl \"http://www.xtext.org/mydsl/MyDsl\"");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("Model: \'a\' \'b\' \'c\' \'d\' a=ID;");
+    _builder_1.newLine();
+    this.applyKeywordWithSpacesQuickfix(_builder, _builder_1.toString());
+  }
+  
+  @Test
+  public void fix_empty_keyword_with_spaces() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder.newLine();
+    _builder.append("generate myDsl \"http://www.xtext.org/mydsl/MyDsl\"");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Model: \'    \' a=ID;");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_1.newLine();
+    _builder_1.append("generate myDsl \"http://www.xtext.org/mydsl/MyDsl\"");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("Model: \'\' a=ID;");
+    _builder_1.newLine();
+    this.applyKeywordWithSpacesQuickfix(_builder, _builder_1.toString());
+  }
+  
+  private void applyKeywordWithSpacesQuickfix(final CharSequence input, final String result) {
+    final String issueCode = XtextConfigurableIssueCodes.SPACES_IN_KEYWORD;
+    final String label = "Fix keyword with spaces";
+    final String description = "Fix keyword with spaces";
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix(label, description, result);
+    this.testQuickfixesOn(input, issueCode, _quickfix);
   }
 }


### PR DESCRIPTION
- Use the same layout in the XtextGrammarQuickfixTest as in the
ValidationIssue719QuickFixTest to improve consistency and readability.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=410479

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>