### PR TITLE
Refactoring the test case accesses the workspace root.

### DIFF
--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/builderState/EclipseResourceFileSystemAccessTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/builderState/EclipseResourceFileSystemAccessTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,11 +14,11 @@ import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.xtext.builder.EclipseResourceFileSystemAccess;
 import org.eclipse.xtext.builder.tests.BuilderTestLanguageInjectorProvider;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.TestedWorkspaceWithJDT;
 import org.eclipse.xtext.util.IAcceptor;
 import org.junit.Assert;
@@ -43,7 +43,7 @@ public class EclipseResourceFileSystemAccessTest extends Assert {
 	@Test public void testDirsAreCreated() throws Exception {
 		IProject project = workspace.createProject("test");
 		EclipseResourceFileSystemAccess fileSystemAccess = new EclipseResourceFileSystemAccess();
-		fileSystemAccess.setRoot(ResourcesPlugin.getWorkspace().getRoot());
+		fileSystemAccess.setRoot(IResourcesSetupUtil.root());
 		fileSystemAccess.setOutputPath("test");
 		final List<String> newFiles = newArrayList();
 		fileSystemAccess.setNewFileAcceptor(new IAcceptor<String>() {

--- a/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/access/jdt/MockJavaProjectProvider.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/access/jdt/MockJavaProjectProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,6 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
@@ -138,8 +137,7 @@ public class MockJavaProjectProvider implements IJavaProjectProvider {
 		IProject project = null;
 		IJavaProject javaProject = null;
 		try {
-			IWorkspace workspace = ResourcesPlugin.getWorkspace();
-			project = workspace.getRoot().getProject(projectName);
+			project = IResourcesSetupUtil.root().getProject(projectName);
 			deleteProject(project);
 
 			javaProject = JavaCore.create(project);
@@ -207,7 +205,7 @@ public class MockJavaProjectProvider implements IJavaProjectProvider {
 	 * Returns the Java Model this test suite is running on.
 	 */
 	public static IJavaModel getJavaModel() {
-		return JavaCore.create(ResourcesPlugin.getWorkspace().getRoot());
+		return JavaCore.create(IResourcesSetupUtil.root());
 	}
 	
 	public static void refresh(final IJavaProject javaProject) throws CoreException {

--- a/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/ui/refactoring/participant/TextChangeCombinerTest.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/ui/refactoring/participant/TextChangeCombinerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ import static org.junit.Assert.*;
 import java.io.InputStream;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.ltk.core.refactoring.Change;
@@ -61,7 +60,7 @@ public class TextChangeCombinerTest {
 	
 	@AfterClass
 	public static void tearDown() throws Exception {
-		ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT).delete(true, new NullProgressMonitor());
+		IResourcesSetupUtil.root().getProject(PROJECT).delete(true, new NullProgressMonitor());
 	}
 
 	@Test

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -67,7 +67,7 @@ public class IResourcesSetupUtil {
 	}
 	
 	public static void assertNoErrorsInWorkspace() throws CoreException {
-		IMarker[] findMarkers = ResourcesPlugin.getWorkspace().getRoot().findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+		IMarker[] findMarkers = root().findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
 		String msg = "";
 		for (IMarker iMarker : findMarkers) {
 			if (MarkerUtilities.getSeverity(iMarker) == IMarker.SEVERITY_ERROR)

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,7 +26,6 @@ import java.util.jar.JarOutputStream;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -129,16 +128,14 @@ public class JavaProjectSetupUtil {
 	}
 	
 	public static IJavaProject findJavaProject(String projectName) {
-		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		IProject project = root.getProject(projectName);
+		IProject project = root().getProject(projectName);
 		if (project != null)
 			return JavaCore.create(project);
 		return null;
 	}
 
 	public static IProject createSimpleProject(String projectName) throws CoreException {
-		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		IProject project = root.getProject(projectName);
+		IProject project = root().getProject(projectName);
 		deleteProject(project);
 		project.create(null);
 		project.open(null);

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/autoedit/AutoEditTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/autoedit/AutoEditTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,13 +10,13 @@ package org.eclipse.xtext.ui.tests.editor.autoedit;
 import java.util.Collections;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swt.SWT;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.testing.AbstractCStyleLanguageAutoEditTest;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.util.JREContainerProvider;
 import org.eclipse.xtext.ui.util.PluginProjectFactory;
@@ -73,7 +73,7 @@ public class AutoEditTest extends AbstractCStyleLanguageAutoEditTest {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		autoEditTestProject = ResourcesPlugin.getWorkspace().getRoot().getProject(TESTPROJECT_NAME);
+		autoEditTestProject = IResourcesSetupUtil.root().getProject(TESTPROJECT_NAME);
 		if (!autoEditTestProject.exists())
 			createPluginProject(TESTPROJECT_NAME);
 	}

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/autoedit/Bug330096Test.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/autoedit/Bug330096Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@ package org.eclipse.xtext.ui.tests.editor.autoedit;
 import java.util.Collections;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.JavaCore;
@@ -18,6 +17,7 @@ import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.testing.AbstractCStyleLanguageAutoEditTest;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.util.JREContainerProvider;
 import org.eclipse.xtext.ui.util.PluginProjectFactory;
@@ -52,7 +52,7 @@ public class Bug330096Test extends AbstractCStyleLanguageAutoEditTest {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(TESTPROJECT_NAME);
+		IProject project = IResourcesSetupUtil.root().getProject(TESTPROJECT_NAME);
 		if (!project.exists()) {
 			createPluginProject(TESTPROJECT_NAME);
 		}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/encoding/EncodingTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/encoding/EncodingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,6 @@ package org.eclipse.xtext.ui.tests.editor.encoding;
 import static org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.*;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.xtext.resource.XtextResource;
@@ -38,7 +37,7 @@ public class EncodingTest extends AbstractEditorTest {
 
 	@Test public void testFileEncodingIsUsedInEMFResource() throws Exception {
 		IFile file = createFile("foo/x_default.encodinguitestlanguage", "");
-		openEditorAndCheckEncoding(file, ResourcesPlugin.getWorkspace().getRoot().getDefaultCharset());
+		openEditorAndCheckEncoding(file, root().getDefaultCharset());
 		file = createFile("foo/x_utf.encodinguitestlanguage", "");
 		file.setCharset("UTF-8", null);
 		openEditorAndCheckEncoding(file, "UTF-8");

--- a/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/editor/autoedit/XtextAutoEditStrategyTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/editor/autoedit/XtextAutoEditStrategyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ import java.util.Collections;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swt.SWT;
@@ -306,7 +305,7 @@ public class XtextAutoEditStrategyTest extends AbstractCStyleLanguageAutoEditTes
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		autoEditTestProject = ResourcesPlugin.getWorkspace().getRoot().getProject(TESTPROJECT_NAME);
+		autoEditTestProject = root().getProject(TESTPROJECT_NAME);
 		if (!autoEditTestProject.exists())
 			createPluginProject(TESTPROJECT_NAME);
 	}

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProviderTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 Michael Clay and others.
+ * Copyright (c) 2010, 2019 Michael Clay and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -70,7 +69,7 @@ public class XtextGrammarQuickfixProviderTest extends AbstractQuickfixTest {
 	
 	@Before
 	public void assertEmptyWorkspace() {
-		IProject[] allProjects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
+		IProject[] allProjects = IResourcesSetupUtil.root().getProjects();
 		Assert.assertEquals(0, allProjects.length);
 	}
 	


### PR DESCRIPTION
- Eliminate duplicated code by reusing the
org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.root() helper
method whenever the test cases need access to the workspace root.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>