### PR TITLE
[#1006] isReadOnly should consider XtextReadonlyEditorInput inputs

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
@@ -51,6 +51,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.editors.text.FileDocumentProvider;
 import org.eclipse.xtext.parser.IEncodingProvider;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.XtextReadonlyEditorInput;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionProvider;
 import org.eclipse.xtext.ui.editor.quickfix.XtextResourceMarkerAnnotationModel;
 import org.eclipse.xtext.ui.editor.validation.AnnotationIssueProcessor;
@@ -449,6 +450,9 @@ public class XtextDocumentProvider extends FileDocumentProvider {
 	
 	@Override
 	public boolean isReadOnly(Object element) {
+		if (element instanceof XtextReadonlyEditorInput) {
+			return true;
+		}
 		if (isWorkspaceExternalEditorInput(element)) {
 			URIInfo info= (URIInfo) getElementInfo(element);
 			if (info != null) {


### PR DESCRIPTION
When element is an instance of XtextReadonlyEditorInput isReadOnly() can
directly return true

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>