### PR TITLE
[#980] Ensure the AbstractHighlightingTest works properly.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.xtend
@@ -12,10 +12,10 @@ import org.eclipse.core.resources.IFile
 import org.eclipse.swt.custom.StyleRange
 import org.eclipse.swt.custom.StyledText
 import org.eclipse.swt.graphics.Color
+import org.eclipse.swt.widgets.Display
 import org.eclipse.xtext.resource.FileExtensionProvider
 import org.eclipse.xtext.ui.XtextProjectHelper
 import org.eclipse.xtext.ui.editor.utils.TextStyle
-import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
 
 import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.addNature
@@ -27,7 +27,6 @@ import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.ad
  */
 abstract class AbstractHighlightingTest extends AbstractEditorTest {
 
-	@Inject extension SyncUtil
 	@Inject extension FileExtensionProvider
 
 	/**
@@ -109,9 +108,16 @@ abstract class AbstractHighlightingTest extends AbstractEditorTest {
 		 * wait for the Xtext framework HighlightingPresenter.updatePresentation()
 		 * to apply the semantic highlighting executed asynchronously
 		 */
-		editor.waitForReconciler
+		waitForEventProcessing
 	
 		editor.internalSourceViewer.textWidget
+	}
+
+	/**
+	 * @since 2.18
+	 */
+	protected def void waitForEventProcessing() {
+		while(Display.^default.readAndDispatch) {}
 	}
 
 	protected def testHighlighting(StyledText styledText, String text, int fontStyle,
@@ -122,7 +128,7 @@ abstract class AbstractHighlightingTest extends AbstractEditorTest {
 		val expectedBackgroundColor = new Color(null, backgroundR, backgroundG, backgroundB)
 
 		val content = styledText.text
-		val offset = content.indexOf(text)
+		val offset = content.getStartPosition(text)
 		assertNotEquals('''Cannot locate '«text»' in «content»''', -1, offset)
 		
 		for (var i = 0; i < text.length; i++) {
@@ -137,6 +143,13 @@ abstract class AbstractHighlightingTest extends AbstractEditorTest {
 				]
 			}
 		}
+	}
+
+	/**
+	 * @since 2.18
+	 */
+	protected def int getStartPosition(String content, String text) {
+		content.indexOf(text)
 	}
 
 	protected def isRelevant(String character) {

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.java
@@ -15,12 +15,12 @@ import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.utils.TextStyle;
-import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
 import org.eclipse.xtext.ui.testing.AbstractEditorTest;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -36,10 +36,6 @@ import org.junit.Assert;
  */
 @SuppressWarnings("all")
 public abstract class AbstractHighlightingTest extends AbstractEditorTest {
-  @Inject
-  @Extension
-  private SyncUtil _syncUtil;
-  
   @Inject
   @Extension
   private FileExtensionProvider _fileExtensionProvider;
@@ -169,7 +165,7 @@ public abstract class AbstractHighlightingTest extends AbstractEditorTest {
       StyledText _xblockexpression = null;
       {
         final XtextEditor editor = this.openEditor(dslFile);
-        this._syncUtil.waitForReconciler(editor);
+        this.waitForEventProcessing();
         _xblockexpression = editor.getInternalSourceViewer().getTextWidget();
       }
       return _xblockexpression;
@@ -178,11 +174,19 @@ public abstract class AbstractHighlightingTest extends AbstractEditorTest {
     }
   }
   
+  /**
+   * @since 2.18
+   */
+  protected void waitForEventProcessing() {
+    while (Display.getDefault().readAndDispatch()) {
+    }
+  }
+  
   protected void testHighlighting(final StyledText styledText, final String text, final int fontStyle, final int foregroundR, final int foregroundG, final int foregroundB, final int backgroundR, final int backgroundG, final int backgroundB) {
     final Color expectedForegroundColor = new Color(null, foregroundR, foregroundG, foregroundB);
     final Color expectedBackgroundColor = new Color(null, backgroundR, backgroundG, backgroundB);
     final String content = styledText.getText();
-    final int offset = content.indexOf(text);
+    final int offset = this.getStartPosition(content, text);
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("Cannot locate \'");
     _builder.append(text);
@@ -205,6 +209,13 @@ public abstract class AbstractHighlightingTest extends AbstractEditorTest {
         }
       }
     }
+  }
+  
+  /**
+   * @since 2.18
+   */
+  protected int getStartPosition(final String content, final String text) {
+    return content.indexOf(text);
   }
   
   protected boolean isRelevant(final String character) {

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HighlightingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HighlightingTest.xtend
@@ -1,0 +1,227 @@
+package org.eclipse.xtext.example.domainmodel.ui.tests
+
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHighlightingTest
+import org.eclipse.xtext.xbase.ui.highlighting.XbaseHighlightingConfiguration
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(DomainmodelUiInjectorProvider)
+class HighlightingTest extends AbstractHighlightingTest {
+
+	@Inject extension XbaseHighlightingConfiguration
+
+	@Before def void setup() {
+		/*
+		 * Xbase-based languages require java project
+		 */
+		 projectName.createJavaProject
+	}
+
+	@Test def package_keyword() {
+		'''
+			package P {}
+		'''.testHighlighting("package", keywordTextStyle)
+	}
+
+	@Test def entity_keyword() {
+		'''
+			entity E {}
+		'''.testHighlighting("entity", keywordTextStyle)
+	}
+
+	@Test def extends_keyword() {
+		'''
+			entity A {}
+			entity B extends A {}
+		'''.testHighlighting("extends", keywordTextStyle)
+	}
+
+	@Test def op_keyword() {
+		'''
+			entity E {
+				op m() {}
+			}
+		'''.testHighlighting("op", keywordTextStyle)
+	}
+
+	@Test def import_keyword() {
+		'''
+			import java.util.List
+			entity E {
+				adresse : List<String>
+			}
+		'''.testHighlighting("import", keywordTextStyle)
+	}
+
+	@Test def int_keyword() {
+		'''
+			entity E {
+				op m(int b) {}
+			}
+		'''.testHighlighting("int", keywordTextStyle)
+	}
+
+	@Test def boolean_keyword() {
+		'''
+			entity E {
+				op m(boolean b) {}
+			}
+		'''.testHighlighting("boolean", keywordTextStyle)
+	}
+
+	@Test def if_keyword() {
+		'''
+			entity E {
+				op m(boolean b) {
+					if (b) 1 else 2
+				}
+			}
+		'''.testHighlighting("if", keywordTextStyle)
+	}
+
+	@Test def else_keyword() {
+		'''
+			entity E {
+				op m(boolean b) {
+					if (b) 1 else 2
+				}
+			}
+		'''.testHighlighting("else", keywordTextStyle)
+	}
+
+	@Test def return_keyword() {
+		'''
+			entity E {
+				op m(boolean b) {
+					return if (b) 1 else 2
+				}
+			}
+		'''.testHighlighting("return", keywordTextStyle)
+	}
+
+	@Test def instanceof_keyword() {
+		'''
+			entity A {
+				op m(A a) {
+					if (a instanceof B) 1 else 2
+				}
+			}
+			entity B extends A {}
+		'''.testHighlighting("instanceof", keywordTextStyle)
+	}
+
+	@Test def single_line_comment() {
+		'''
+			// A language to model domain-model elements
+			entity E {
+			}
+		'''.testHighlighting("A language to model domain-model elements", commentTextStyle)
+	}
+
+	@Test def multi_line_comment() {
+		'''
+			/*
+			 * A language to model domain-model elements.
+			 * Each entity can have properties, operations
+			 * and relations to each other.
+			 */
+			entity E {
+			}
+		'''.testHighlighting('''
+			/*
+			 * A language to model domain-model elements.
+			 * Each entity can have properties, operations
+			 * and relations to each other.
+			 */
+		''', commentTextStyle)
+	}
+
+	@Test def javadoc_comment() {
+		'''
+			/**
+			 * A language to model domain-model elements.
+			 * Each entity can have properties, operations
+			 * and relations to each other.
+			 */
+			entity E {
+			}
+		'''.testHighlighting('''
+			/**
+			 * A language to model domain-model elements.
+			 * Each entity can have properties, operations
+			 * and relations to each other.
+			 */
+		''', commentTextStyle)
+	}
+
+	@Test def fixme_task_in_comment() {
+		'''
+			/**
+			 * FIXME
+			 */
+			entity E {}
+		'''.testHighlighting("FIXME", taskTextStyle)
+	}
+
+	@Test def todo_task_in_comment() {
+		'''
+			/**
+			 * TODO
+			 */
+			entity E {}
+		'''.testHighlighting("TODO", taskTextStyle)
+	}
+
+	@Test def xxx_task_in_comment() {
+		'''
+			/**
+			 * XXX
+			 */
+			entity E {}
+		'''.testHighlighting("XXX", taskTextStyle)
+	}
+
+	@Test def single_quoted_string() {
+		'''
+			entity E {
+				a : String
+				op m() {
+					a = 'foo'
+				}
+			}
+		'''.testHighlighting("'foo'", stringTextStyle)
+	}
+
+	@Test def double_quoted_string() {
+		'''
+			entity E {
+				a : String
+				op m() {
+					a = "foo"
+				}
+			}
+		'''.testHighlighting('"foo"', stringTextStyle)
+	}
+
+	@Test def number_literal() {
+		'''
+			entity E {
+				a : int
+				op m() {
+					a = 100
+				}
+			}
+		'''.testHighlighting('100', numberTextStyle)
+	}
+
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HighlightingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HighlightingTest.java
@@ -1,0 +1,398 @@
+package org.eclipse.xtext.example.domainmodel.ui.tests;
+
+import com.google.inject.Inject;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.domainmodel.ui.tests.DomainmodelUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHighlightingTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.ui.highlighting.XbaseHighlightingConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(DomainmodelUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class HighlightingTest extends AbstractHighlightingTest {
+  @Inject
+  @Extension
+  private XbaseHighlightingConfiguration _xbaseHighlightingConfiguration;
+  
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void package_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package P {}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "package", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void entity_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "entity", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void extends_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity A {}");
+    _builder.newLine();
+    _builder.append("entity B extends A {}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "extends", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void op_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "op", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void import_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("adresse : List<String>");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "import", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void int_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m(int b) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "int", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void boolean_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m(boolean b) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "boolean", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void if_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m(boolean b) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("if (b) 1 else 2");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "if", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void else_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m(boolean b) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("if (b) 1 else 2");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "else", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void return_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m(boolean b) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("return if (b) 1 else 2");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "return", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void instanceof_keyword() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity A {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m(A a) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("if (a instanceof B) 1 else 2");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("entity B extends A {}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "instanceof", this._xbaseHighlightingConfiguration.keywordTextStyle());
+  }
+  
+  @Test
+  public void single_line_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("// A language to model domain-model elements");
+    _builder.newLine();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "A language to model domain-model elements", this._xbaseHighlightingConfiguration.commentTextStyle());
+  }
+  
+  @Test
+  public void multi_line_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/*");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* A language to model domain-model elements.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* Each entity can have properties, operations");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* and relations to each other.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("/*");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* A language to model domain-model elements.");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* Each entity can have properties, operations");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* and relations to each other.");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    this.testHighlighting(_builder, _builder_1.toString(), this._xbaseHighlightingConfiguration.commentTextStyle());
+  }
+  
+  @Test
+  public void javadoc_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* A language to model domain-model elements.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* Each entity can have properties, operations");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* and relations to each other.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("/**");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* A language to model domain-model elements.");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* Each entity can have properties, operations");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* and relations to each other.");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    this.testHighlighting(_builder, _builder_1.toString(), this._xbaseHighlightingConfiguration.commentTextStyle());
+  }
+  
+  @Test
+  public void fixme_task_in_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* FIXME");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("entity E {}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "FIXME", this._xbaseHighlightingConfiguration.taskTextStyle());
+  }
+  
+  @Test
+  public void todo_task_in_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* TODO");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("entity E {}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "TODO", this._xbaseHighlightingConfiguration.taskTextStyle());
+  }
+  
+  @Test
+  public void xxx_task_in_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* XXX");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("entity E {}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "XXX", this._xbaseHighlightingConfiguration.taskTextStyle());
+  }
+  
+  @Test
+  public void single_quoted_string() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("a : String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("a = \'foo\'");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "\'foo\'", this._xbaseHighlightingConfiguration.stringTextStyle());
+  }
+  
+  @Test
+  public void double_quoted_string() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("a : String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("a = \"foo\"");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "\"foo\"", this._xbaseHighlightingConfiguration.stringTextStyle());
+  }
+  
+  @Test
+  public void number_literal() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("a : int");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op m() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("a = 100");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.testHighlighting(_builder, "100", this._xbaseHighlightingConfiguration.numberTextStyle());
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHighlightingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHighlightingTest.xtend
@@ -182,4 +182,22 @@ class StatemachineHighlightingTest extends AbstractHighlightingTest {
 			 */
 		''', SWT.NORMAL, 63, 127, 95)
 	}
+
+	@Test def fixme_task_in_comment() {
+		'''
+			// FIXME
+		'''.testHighlighting('FIXME', SWT.BOLD, 127, 159, 191)
+	}
+
+	@Test def todo_task_in_comment() {
+		'''
+			// TODO
+		'''.testHighlighting('TODO', SWT.BOLD, 127, 159, 191)
+	}
+
+	@Test def xxx_task_in_comment() {
+		'''
+			// XXX
+		'''.testHighlighting('XXX', SWT.BOLD, 127, 159, 191)
+	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHighlightingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineHighlightingTest.java
@@ -368,4 +368,28 @@ public class StatemachineHighlightingTest extends AbstractHighlightingTest {
     _builder_1.newLine();
     this.testHighlighting(_builder, _builder_1.toString(), SWT.NORMAL, 63, 127, 95);
   }
+  
+  @Test
+  public void fixme_task_in_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("// FIXME");
+    _builder.newLine();
+    this.testHighlighting(_builder, "FIXME", SWT.BOLD, 127, 159, 191);
+  }
+  
+  @Test
+  public void todo_task_in_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("// TODO");
+    _builder.newLine();
+    this.testHighlighting(_builder, "TODO", SWT.BOLD, 127, 159, 191);
+  }
+  
+  @Test
+  public void xxx_task_in_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("// XXX");
+    _builder.newLine();
+    this.testHighlighting(_builder, "XXX", SWT.BOLD, 127, 159, 191);
+  }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHighlightingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHighlightingTest.xtend
@@ -3,10 +3,13 @@ package org.eclipse.xtext.example.homeautomation.ui.tests
 import com.google.inject.Inject
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
-import org.eclipse.xtext.ui.editor.syntaxcoloring.DefaultHighlightingConfiguration
 import org.eclipse.xtext.ui.testing.AbstractHighlightingTest
+import org.eclipse.xtext.xbase.ui.highlighting.XbaseHighlightingConfiguration
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
 
 /**
  * @author miklossy - Initial contribution and API
@@ -15,7 +18,14 @@ import org.junit.runner.RunWith
 @InjectWith(RuleEngineUiInjectorProvider)
 class RuleEngineHighlightingTest extends AbstractHighlightingTest {
 
-	@Inject extension DefaultHighlightingConfiguration
+	@Inject extension XbaseHighlightingConfiguration
+
+	@Before def void setup() {
+		/*
+		 * Xbase-based languages require java project
+		 */
+		projectName.createJavaProject
+	}
 
 	@Test def device_keyword() {
 		'''
@@ -155,6 +165,26 @@ class RuleEngineHighlightingTest extends AbstractHighlightingTest {
 		'''.testHighlighting("rule1", stringTextStyle)
 	}
 
+	@Test def fire_method_invocation() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			Rule "rule1" when Window.open then
+				fire(Heater.off)
+		'''.testHighlighting("fire", staticMethodInvocation)
+	}
+
+	@Test def device_state_access() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			Rule "rule1" when Window.open then
+				fire(Heater.off)
+		'''.testHighlighting("off", staticField)
+	}
+
 	@Test def single_line_comment() {
 		'''
 			// A language for home automation systems.
@@ -184,5 +214,36 @@ class RuleEngineHighlightingTest extends AbstractHighlightingTest {
 			 * similar to Python.
 			 */
 		''', commentTextStyle)
+	}
+
+	@Test def fixme_task_in_comment() {
+		'''
+			/**
+			 * FIXME
+			 */
+			Device Window can be open, closed
+		'''.testHighlighting('FIXME', taskTextStyle)
+	}
+
+	@Test def todo_task_in_comment() {
+		'''
+			/**
+			 * TODO
+			 */
+			Device Window can be open, closed
+		'''.testHighlighting('TODO', taskTextStyle)
+	}
+
+	@Test def xxx_task_in_comment() {
+		'''
+			/**
+			 * XXX
+			 */
+			Device Window can be open, closed
+		'''.testHighlighting('XXX', taskTextStyle)
+	}
+
+	protected override int getStartPosition(String content, String text) {
+		content.lastIndexOf(text)
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHighlightingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineHighlightingTest.java
@@ -5,9 +5,12 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.example.homeautomation.ui.tests.RuleEngineUiInjectorProvider;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
-import org.eclipse.xtext.ui.editor.syntaxcoloring.DefaultHighlightingConfiguration;
 import org.eclipse.xtext.ui.testing.AbstractHighlightingTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.ui.highlighting.XbaseHighlightingConfiguration;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -20,14 +23,23 @@ import org.junit.runner.RunWith;
 public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
   @Inject
   @Extension
-  private DefaultHighlightingConfiguration _defaultHighlightingConfiguration;
+  private XbaseHighlightingConfiguration _xbaseHighlightingConfiguration;
+  
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
   
   @Test
   public void device_keyword() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("Device Window can be open, closed");
     _builder.newLine();
-    this.testHighlighting(_builder, "Device", this._defaultHighlightingConfiguration.keywordTextStyle());
+    this.testHighlighting(_builder, "Device", this._xbaseHighlightingConfiguration.keywordTextStyle());
   }
   
   @Test
@@ -35,7 +47,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("Device Window can be open, closed");
     _builder.newLine();
-    this.testHighlighting(_builder, "can", this._defaultHighlightingConfiguration.keywordTextStyle());
+    this.testHighlighting(_builder, "can", this._xbaseHighlightingConfiguration.keywordTextStyle());
   }
   
   @Test
@@ -43,7 +55,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("Device Window can be open, closed");
     _builder.newLine();
-    this.testHighlighting(_builder, "be", this._defaultHighlightingConfiguration.keywordTextStyle());
+    this.testHighlighting(_builder, "be", this._xbaseHighlightingConfiguration.keywordTextStyle());
   }
   
   @Test
@@ -59,7 +71,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t");
     _builder.append("fire(Heater.off)");
     _builder.newLine();
-    this.testHighlighting(_builder, "Rule", this._defaultHighlightingConfiguration.keywordTextStyle());
+    this.testHighlighting(_builder, "Rule", this._xbaseHighlightingConfiguration.keywordTextStyle());
   }
   
   @Test
@@ -75,7 +87,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t");
     _builder.append("fire(Heater.off)");
     _builder.newLine();
-    this.testHighlighting(_builder, "when", this._defaultHighlightingConfiguration.keywordTextStyle());
+    this.testHighlighting(_builder, "when", this._xbaseHighlightingConfiguration.keywordTextStyle());
   }
   
   @Test
@@ -91,7 +103,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t");
     _builder.append("fire(Heater.off)");
     _builder.newLine();
-    this.testHighlighting(_builder, "then", this._defaultHighlightingConfiguration.keywordTextStyle());
+    this.testHighlighting(_builder, "then", this._xbaseHighlightingConfiguration.keywordTextStyle());
   }
   
   @Test
@@ -122,7 +134,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t\t\t");
     _builder.append("fire(Heater.on)");
     _builder.newLine();
-    this.testHighlighting(_builder, "switch", this._defaultHighlightingConfiguration.keywordTextStyle());
+    this.testHighlighting(_builder, "switch", this._xbaseHighlightingConfiguration.keywordTextStyle());
   }
   
   @Test
@@ -153,7 +165,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t\t\t");
     _builder.append("fire(Heater.on)");
     _builder.newLine();
-    this.testHighlighting(_builder, "case", this._defaultHighlightingConfiguration.keywordTextStyle());
+    this.testHighlighting(_builder, "case", this._xbaseHighlightingConfiguration.keywordTextStyle());
   }
   
   @Test
@@ -184,7 +196,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t\t\t");
     _builder.append("fire(Heater.on)");
     _builder.newLine();
-    this.testHighlighting(_builder, "default", this._defaultHighlightingConfiguration.keywordTextStyle());
+    this.testHighlighting(_builder, "default", this._xbaseHighlightingConfiguration.keywordTextStyle());
   }
   
   @Test
@@ -215,7 +227,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t\t\t");
     _builder.append("fire(Heater.on)");
     _builder.newLine();
-    this.testHighlighting(_builder, "1", this._defaultHighlightingConfiguration.numberTextStyle());
+    this.testHighlighting(_builder, "1", this._xbaseHighlightingConfiguration.numberTextStyle());
   }
   
   @Test
@@ -231,7 +243,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t");
     _builder.append("fire(Heater.off)");
     _builder.newLine();
-    this.testHighlighting(_builder, ".", this._defaultHighlightingConfiguration.punctuationTextStyle());
+    this.testHighlighting(_builder, ".", this._xbaseHighlightingConfiguration.punctuationTextStyle());
   }
   
   @Test
@@ -247,7 +259,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t");
     _builder.append("fire(Heater.off)");
     _builder.newLine();
-    this.testHighlighting(_builder, "rule1", this._defaultHighlightingConfiguration.stringTextStyle());
+    this.testHighlighting(_builder, "rule1", this._xbaseHighlightingConfiguration.stringTextStyle());
   }
   
   @Test
@@ -263,7 +275,39 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t");
     _builder.append("fire(Heater.off)");
     _builder.newLine();
-    this.testHighlighting(_builder, "rule1", this._defaultHighlightingConfiguration.stringTextStyle());
+    this.testHighlighting(_builder, "rule1", this._xbaseHighlightingConfiguration.stringTextStyle());
+  }
+  
+  @Test
+  public void fire_method_invocation() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Rule \"rule1\" when Window.open then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(Heater.off)");
+    _builder.newLine();
+    this.testHighlighting(_builder, "fire", this._xbaseHighlightingConfiguration.staticMethodInvocation());
+  }
+  
+  @Test
+  public void device_state_access() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Rule \"rule1\" when Window.open then");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("fire(Heater.off)");
+    _builder.newLine();
+    this.testHighlighting(_builder, "off", this._xbaseHighlightingConfiguration.staticField());
   }
   
   @Test
@@ -282,7 +326,7 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder.append("\t");
     _builder.append("fire(Heater.off)");
     _builder.newLine();
-    this.testHighlighting(_builder, "A language for home automation systems", this._defaultHighlightingConfiguration.commentTextStyle());
+    this.testHighlighting(_builder, "A language for home automation systems", this._xbaseHighlightingConfiguration.commentTextStyle());
   }
   
   @Test
@@ -322,6 +366,59 @@ public class RuleEngineHighlightingTest extends AbstractHighlightingTest {
     _builder_1.append(" ");
     _builder_1.append("*/");
     _builder_1.newLine();
-    this.testHighlighting(_builder, _builder_1.toString(), this._defaultHighlightingConfiguration.commentTextStyle());
+    this.testHighlighting(_builder, _builder_1.toString(), this._xbaseHighlightingConfiguration.commentTextStyle());
+  }
+  
+  @Test
+  public void fixme_task_in_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* FIXME");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    this.testHighlighting(_builder, "FIXME", this._xbaseHighlightingConfiguration.taskTextStyle());
+  }
+  
+  @Test
+  public void todo_task_in_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* TODO");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    this.testHighlighting(_builder, "TODO", this._xbaseHighlightingConfiguration.taskTextStyle());
+  }
+  
+  @Test
+  public void xxx_task_in_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* XXX");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    this.testHighlighting(_builder, "XXX", this._xbaseHighlightingConfiguration.taskTextStyle());
+  }
+  
+  @Override
+  protected int getStartPosition(final String content, final String text) {
+    return content.lastIndexOf(text);
   }
 }


### PR DESCRIPTION
- Modify the AbstractHighlightingTest to properly wait for the semantic
highlighting to be completed before asserting the result.
- Modify the AbstractHighlightingTest to be more extensible by clients.
- Add corresponding DomainmodelHighlightingTest,
RuleEngineHighlightingTest, StatemachineHighlightingTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>