### PR TITLE
[#991] removed duplicate entry in maven clean plugin config

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/pom.xml
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/pom.xml
@@ -142,10 +142,6 @@
 								<includes>
 									<include>**/*</include>
 								</includes>
-								<directory>${basedir}/xtend-gen</directory>
-								<includes>
-									<include>**/*</include>
-								</includes>
 							</fileset>
 						</filesets>
 					</configuration>


### PR DESCRIPTION
[#991] removed duplicate entry in maven clean plugin config
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>