### PR TITLE
[eclipse/xtext-eclipse#1022] sort quickfixes by label to have a stabl…

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.xtend
@@ -112,15 +112,16 @@ abstract class AbstractQuickfixTest extends AbstractEditorTest {
 	}
 
 	protected def void quickfixesAreOffered(XtextEditor editor, String issueCode, Quickfix... expected) {
+		val expectedSorted = expected.sortBy[label]
 		val document = editor.document
 		val originalText = document.get
 		val issue = document.getValidationIssue(issueCode)
 
-		val actualIssueResolutions = issue.getResolutions
-		assertEquals("The number of quickfixes does not match!", expected.size, actualIssueResolutions.size)
+		val actualIssueResolutions = issue.getResolutions.sortBy[label]
+		assertEquals("The number of quickfixes does not match!", expectedSorted.size, actualIssueResolutions.size)
 		for (i : 0..< actualIssueResolutions.size) {
 			val actualIssueResolution = actualIssueResolutions.get(i)
-			val expectedIssueResolution = expected.get(i)
+			val expectedIssueResolution = expectedSorted.get(i)
 			expectedIssueResolution.label.assertEquals(actualIssueResolution.label)
 			expectedIssueResolution.description.assertEquals(actualIssueResolution.description)
 			expectedIssueResolution.result.assertIssueResolutionResult(actualIssueResolution, originalText)

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.java
@@ -242,17 +242,24 @@ public abstract class AbstractQuickfixTest extends AbstractEditorTest {
   }
   
   protected void quickfixesAreOffered(final XtextEditor editor, final String issueCode, final AbstractQuickfixTest.Quickfix... expected) {
+    final Function1<AbstractQuickfixTest.Quickfix, String> _function = (AbstractQuickfixTest.Quickfix it) -> {
+      return it.label;
+    };
+    final List<AbstractQuickfixTest.Quickfix> expectedSorted = IterableExtensions.<AbstractQuickfixTest.Quickfix, String>sortBy(((Iterable<AbstractQuickfixTest.Quickfix>)Conversions.doWrapArray(expected)), _function);
     final IXtextDocument document = editor.getDocument();
     final String originalText = document.get();
     final Issue issue = this.getValidationIssue(document, issueCode);
-    final List<IssueResolution> actualIssueResolutions = this._issueResolutionProvider.getResolutions(issue);
-    Assert.assertEquals("The number of quickfixes does not match!", ((List<AbstractQuickfixTest.Quickfix>)Conversions.doWrapArray(expected)).size(), actualIssueResolutions.size());
+    final Function1<IssueResolution, String> _function_1 = (IssueResolution it) -> {
+      return it.getLabel();
+    };
+    final List<IssueResolution> actualIssueResolutions = IterableExtensions.<IssueResolution, String>sortBy(this._issueResolutionProvider.getResolutions(issue), _function_1);
+    Assert.assertEquals("The number of quickfixes does not match!", expectedSorted.size(), actualIssueResolutions.size());
     int _size = actualIssueResolutions.size();
     ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, _size, true);
     for (final Integer i : _doubleDotLessThan) {
       {
         final IssueResolution actualIssueResolution = actualIssueResolutions.get((i).intValue());
-        final AbstractQuickfixTest.Quickfix expectedIssueResolution = expected[(i).intValue()];
+        final AbstractQuickfixTest.Quickfix expectedIssueResolution = expectedSorted.get((i).intValue());
         Assert.assertEquals(expectedIssueResolution.label, actualIssueResolution.getLabel());
         Assert.assertEquals(expectedIssueResolution.description, actualIssueResolution.getDescription());
         this.assertIssueResolutionResult(expectedIssueResolution.result, actualIssueResolution, originalText);


### PR DESCRIPTION
…e order if multiple quickfixes are available

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>