### PR TITLE
[refactoring] fixed progress reporting of rename+move refactorings in 'ResourceRelocationProcessor'

### DIFF
--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/AbstractResourceRelocationTest.xtend
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/AbstractResourceRelocationTest.xtend
@@ -12,6 +12,7 @@ import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IResource
 import org.eclipse.core.resources.IncrementalProjectBuilder
+import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.ltk.core.refactoring.RefactoringDescriptor
 import org.eclipse.ltk.core.refactoring.RefactoringStatus
@@ -73,14 +74,18 @@ abstract class AbstractResourceRelocationTest {
 	}
 	
 	protected def performRefactoring(RefactoringDescriptor descriptor) {
+		performRefactoring(descriptor, new NullProgressMonitor)
+	}
+	
+	protected def performRefactoring(RefactoringDescriptor descriptor, IProgressMonitor monitor) {
 		project.refreshLocal(IResource.DEPTH_INFINITE, null)
 		project.build(IncrementalProjectBuilder.FULL_BUILD, null)
 		val status = new RefactoringStatus
 		val refactoring = descriptor.createRefactoring(status)
-		refactoring.checkAllConditions(new NullProgressMonitor)
+		refactoring.checkAllConditions(monitor)
 		assertTrue(status.OK)
-		val change = refactoring.createChange(new NullProgressMonitor)
-		change.perform(new NullProgressMonitor)
+		val change = refactoring.createChange(monitor)
+		change.perform(monitor)
 		project.refreshLocal(IResource.DEPTH_INFINITE, null)
 		project.build(IncrementalProjectBuilder.FULL_BUILD, null)
 	}

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/ProgressReportingTest.xtend
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/ProgressReportingTest.xtend
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2019 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ui.tests.refactoring
+
+import org.eclipse.core.resources.IResource
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.ltk.core.refactoring.resource.RenameResourceDescriptor
+import org.junit.ComparisonFailure
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+/**
+ * @author Christian Schneider - Initial contribution and API
+ */
+class ProgressReportingTest extends AbstractResourceRelocationTest {
+	@Test 
+	def void testProgressReportOfRenameCommonDir() {
+		val x = file('foo/X.fileawaretestlanguage', '''
+			package foo.bar
+			element X {
+				ref X
+			}
+		''')	
+		val y = file('foo/Y.fileawaretestlanguage', '''
+			package foo
+			element Y {
+				ref bar.X
+			}
+		''')
+		
+		val monitor = new TestProgressMonitor()
+		performRename(x.parent, 'baz', monitor)
+		assertFalse(x.exists)
+		assertFalse(y.exists)
+		monitor.assertLogged('''
+			BeginTask (44)
+			SetTaskName Checking preconditions...
+			InternalWorked 4.0 (4.0)
+			SetTaskName Checking preconditions...
+			InternalWorked 22.22222222222222 (26.22222222222222)
+			SetTaskName Preparing the refactoring...
+			InternalWorked 1.777777777777778 (28.0)«               /* 1/5 of the work logged in 'ResourceRelocationProcessor, remaining: 7.111111 (4/5)*/»
+			SetTaskName Preparing and applying file changes...«    /* 8/17 of 7.111111 == 3,3464... */»
+			InternalWorked 0.8355555555555556 (28.835555555555555)«/* 2/17 on preparing first resource */»
+			InternalWorked 0.8355555555555556 (29.67111111111111)« /* 2/17 on preparing second resource */»
+			InternalWorked 0.4177777777777778 (30.08888888888889)« /* 1/17 on first modification */»
+			InternalWorked 0.4177777777777778 (30.506666666666668)«/* 1/17 on second modification */»
+			InternalWorked 0.4177777777777778 (30.924444444444447)«/* 1/17 on third modification */»
+			InternalWorked 0.4177777777777778 (31.342222222222226)«/* 1/17 on fourth modification */»
+			SetTaskName Creating text changes...«                  /* 9/17 of 7.111111 == 3,7647... */»
+			InternalWorked 2.088888888888889 (33.431111111111115)« /* 5/17 on determining related resources (fixed enumerator) */
+			                                                       /* setWorkRemaining(2), was 4, causes some initial fraction in 'usedForChildren' (0.00...) */»
+			InternalWorked 0.8444444444444444 (34.275555555555556)«/* ca. 2/17 on creating changes for first resource */»
+			InternalWorked 0.8355555555555556 (35.111111111111114)«/* ca. 2/17 on creating changes for first resource, differs due to rounding differences and the fraction from above */»
+			InternalWorked 2.2222222222222223 (37.333333333333336)«/* final condition validations in ProcessorBasedRefactoring#checkFinalConditions(IPM) */»
+			InternalWorked 6.666666666666664 (44.0)«               /* finalization of primary monitor in ProcessorBasedRefactoring#checkFinalConditions(IPM) */»
+			Done
+		''')
+	}
+	
+	protected def performRename(IResource theResource, String theNewName, IProgressMonitor monitor) {
+		performRefactoring(new RenameResourceDescriptor() => [
+			resourcePath = theResource.fullPath
+			newName = theNewName
+			project = project.name
+		], monitor)
+	}
+	
+	static class TestProgressMonitor extends NullProgressMonitor {
+		
+		val events = <String>newArrayList()
+		var double accumulatedWork = 0.0d
+		
+		override worked(int work) {
+			accumulatedWork += work
+			events += 'Worked ' + work + ' (' + accumulatedWork + ')'
+		}
+		
+		override internalWorked(double work) {
+			accumulatedWork += work
+			events += 'InternalWorked ' + work + ' (' + accumulatedWork + ')'
+		}
+		
+		override beginTask(String name, int totalWork) {
+			events += 'BeginTask ' + name + (if (name.nullOrEmpty) '(' else ' (') + totalWork + ')'
+		}
+		
+		override subTask(String name) {
+			events += 'SubTask ' + name
+		}
+		
+		override setTaskName(String name) {
+			events += 'SetTaskName ' + name
+		}
+		
+		override done() {
+			events += 'Done'
+		}
+		
+		override setCanceled(boolean value) {
+			super.setCanceled(value)
+			events += 'Canceled'
+		}
+		
+		def assertLogged(String expectation) {
+			val eventsDump = events.join('\n')
+			if (!eventsDump.startsWith(expectation))
+				throw new ComparisonFailure('', expectation, eventsDump)
+		}
+	}
+}

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/refactoring/AbstractResourceRelocationTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/refactoring/AbstractResourceRelocationTest.java
@@ -14,6 +14,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.Refactoring;
@@ -107,18 +108,20 @@ public abstract class AbstractResourceRelocationTest {
   }
   
   protected void performRefactoring(final RefactoringDescriptor descriptor) {
+    NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+    this.performRefactoring(descriptor, _nullProgressMonitor);
+  }
+  
+  protected void performRefactoring(final RefactoringDescriptor descriptor, final IProgressMonitor monitor) {
     try {
       this.project.refreshLocal(IResource.DEPTH_INFINITE, null);
       this.project.build(IncrementalProjectBuilder.FULL_BUILD, null);
       final RefactoringStatus status = new RefactoringStatus();
       final Refactoring refactoring = descriptor.createRefactoring(status);
-      NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
-      refactoring.checkAllConditions(_nullProgressMonitor);
+      refactoring.checkAllConditions(monitor);
       Assert.assertTrue(status.isOK());
-      NullProgressMonitor _nullProgressMonitor_1 = new NullProgressMonitor();
-      final Change change = refactoring.createChange(_nullProgressMonitor_1);
-      NullProgressMonitor _nullProgressMonitor_2 = new NullProgressMonitor();
-      change.perform(_nullProgressMonitor_2);
+      final Change change = refactoring.createChange(monitor);
+      change.perform(monitor);
       this.project.refreshLocal(IResource.DEPTH_INFINITE, null);
       this.project.build(IncrementalProjectBuilder.FULL_BUILD, null);
     } catch (Throwable _e) {

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/refactoring/ProgressReportingTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/refactoring/ProgressReportingTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2019 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ui.tests.refactoring;
+
+import java.util.ArrayList;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.ltk.core.refactoring.resource.RenameResourceDescriptor;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.ui.tests.refactoring.AbstractResourceRelocationTest;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.eclipse.xtext.xbase.lib.StringExtensions;
+import org.junit.Assert;
+import org.junit.ComparisonFailure;
+import org.junit.Test;
+
+/**
+ * @author Christian Schneider - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class ProgressReportingTest extends AbstractResourceRelocationTest {
+  public static class TestProgressMonitor extends NullProgressMonitor {
+    private final ArrayList<String> events = CollectionLiterals.<String>newArrayList();
+    
+    private double accumulatedWork = 0.0d;
+    
+    @Override
+    public void worked(final int work) {
+      double _accumulatedWork = this.accumulatedWork;
+      this.accumulatedWork = (_accumulatedWork + work);
+      this.events.add((((("Worked " + Integer.valueOf(work)) + " (") + Double.valueOf(this.accumulatedWork)) + ")"));
+    }
+    
+    @Override
+    public void internalWorked(final double work) {
+      double _accumulatedWork = this.accumulatedWork;
+      this.accumulatedWork = (_accumulatedWork + work);
+      this.events.add((((("InternalWorked " + Double.valueOf(work)) + " (") + Double.valueOf(this.accumulatedWork)) + ")"));
+    }
+    
+    @Override
+    public void beginTask(final String name, final int totalWork) {
+      String _xifexpression = null;
+      boolean _isNullOrEmpty = StringExtensions.isNullOrEmpty(name);
+      if (_isNullOrEmpty) {
+        _xifexpression = "(";
+      } else {
+        _xifexpression = " (";
+      }
+      String _plus = (("BeginTask " + name) + _xifexpression);
+      String _plus_1 = (_plus + Integer.valueOf(totalWork));
+      String _plus_2 = (_plus_1 + ")");
+      this.events.add(_plus_2);
+    }
+    
+    @Override
+    public void subTask(final String name) {
+      this.events.add(("SubTask " + name));
+    }
+    
+    @Override
+    public void setTaskName(final String name) {
+      this.events.add(("SetTaskName " + name));
+    }
+    
+    @Override
+    public void done() {
+      this.events.add("Done");
+    }
+    
+    @Override
+    public void setCanceled(final boolean value) {
+      super.setCanceled(value);
+      this.events.add("Canceled");
+    }
+    
+    public void assertLogged(final String expectation) {
+      final String eventsDump = IterableExtensions.join(this.events, "\n");
+      boolean _startsWith = eventsDump.startsWith(expectation);
+      boolean _not = (!_startsWith);
+      if (_not) {
+        throw new ComparisonFailure("", expectation, eventsDump);
+      }
+    }
+  }
+  
+  @Test
+  public void testProgressReportOfRenameCommonDir() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo.bar");
+    _builder.newLine();
+    _builder.append("element X {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("ref X");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    final IFile x = this.file("foo/X.fileawaretestlanguage", _builder);
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo");
+    _builder_1.newLine();
+    _builder_1.append("element Y {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("ref bar.X");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    final IFile y = this.file("foo/Y.fileawaretestlanguage", _builder_1);
+    final ProgressReportingTest.TestProgressMonitor monitor = new ProgressReportingTest.TestProgressMonitor();
+    this.performRename(x.getParent(), "baz", monitor);
+    Assert.assertFalse(x.exists());
+    Assert.assertFalse(y.exists());
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("BeginTask (44)");
+    _builder_2.newLine();
+    _builder_2.append("SetTaskName Checking preconditions...");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 4.0 (4.0)");
+    _builder_2.newLine();
+    _builder_2.append("SetTaskName Checking preconditions...");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 22.22222222222222 (26.22222222222222)");
+    _builder_2.newLine();
+    _builder_2.append("SetTaskName Preparing the refactoring...");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 1.777777777777778 (28.0)");
+    _builder_2.newLine();
+    _builder_2.append("SetTaskName Preparing and applying file changes...");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 0.8355555555555556 (28.835555555555555)");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 0.8355555555555556 (29.67111111111111)");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 0.4177777777777778 (30.08888888888889)");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 0.4177777777777778 (30.506666666666668)");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 0.4177777777777778 (30.924444444444447)");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 0.4177777777777778 (31.342222222222226)");
+    _builder_2.newLine();
+    _builder_2.append("SetTaskName Creating text changes...");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 2.088888888888889 (33.431111111111115)");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 0.8444444444444444 (34.275555555555556)");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 0.8355555555555556 (35.111111111111114)");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 2.2222222222222223 (37.333333333333336)");
+    _builder_2.newLine();
+    _builder_2.append("InternalWorked 6.666666666666664 (44.0)");
+    _builder_2.newLine();
+    _builder_2.append("Done");
+    _builder_2.newLine();
+    monitor.assertLogged(_builder_2.toString());
+  }
+  
+  protected void performRename(final IResource theResource, final String theNewName, final IProgressMonitor monitor) {
+    RenameResourceDescriptor _renameResourceDescriptor = new RenameResourceDescriptor();
+    final Procedure1<RenameResourceDescriptor> _function = (RenameResourceDescriptor it) -> {
+      it.setResourcePath(theResource.getFullPath());
+      it.setNewName(theNewName);
+      it.setProject(this.project.getName());
+    };
+    RenameResourceDescriptor _doubleArrow = ObjectExtensions.<RenameResourceDescriptor>operator_doubleArrow(_renameResourceDescriptor, _function);
+    this.performRefactoring(_doubleArrow, monitor);
+  }
+}


### PR DESCRIPTION
… as demanded in #1053;

added corresponding test (`ProgressReportingTest`).