### PR TITLE
Prevent glitchy outline select

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
@@ -27,7 +27,6 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextInputListener;
 import org.eclipse.jface.text.source.ISourceViewer;
-import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeNode;
 import org.eclipse.jface.viewers.TreeNodeContentProvider;
@@ -313,8 +312,6 @@ public class OutlinePage extends ContentOutlinePage implements ISourceViewerAwar
 						treeViewer.setExpandedElements(Iterables.toArray(nodesToBeExpanded, IOutlineNode.class));
 						treeViewer.setSelection(new StructuredSelection(Iterables.toArray(selectedNodes,
 								IOutlineNode.class)));
-						ISelectionProvider selectionProvider = sourceViewer.getSelectionProvider();
-						selectionProvider.setSelection(selectionProvider.getSelection());
 						treeUpdated();
 					}
 				} catch (Throwable t) {


### PR DESCRIPTION
1. Open an Xtend editor
2. Open the outline view
3. Type something in the Xtend editor such that the outline refreshes
4. After typing quickly press (and hold) shift and tap the left arrow button to start selecting text
5. Note how the selection jumps around resulting in the last few characters not being selected

I don't really see why the outline would like to change the `SourceViewer`'s selection when it refreshes but feel free to let me know if I'm missing something