### PR TITLE
[#1096] Provide the AbstractFoldingTest abstract base class.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractFoldingTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractFoldingTest.xtend
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ui.testing
+
+import com.google.common.annotations.Beta
+import com.google.inject.Inject
+import org.eclipse.core.resources.IFile
+import org.eclipse.xtext.resource.FileExtensionProvider
+import org.eclipse.xtext.ui.XtextProjectHelper
+import org.eclipse.xtext.ui.editor.folding.IFoldingRegionProvider
+import org.eclipse.xtext.ui.editor.model.IXtextDocument
+import org.eclipse.xtext.ui.testing.AbstractEditorTest
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
+
+import static extension java.util.regex.Pattern.quote
+import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.addNature
+
+/**
+ * @author miklossy - Initial contribution and API
+ * @since 2.19
+ */
+@Beta
+abstract class AbstractFoldingTest extends AbstractEditorTest {
+
+	@Inject protected extension FileExtensionProvider
+	@Inject protected extension IFoldingRegionProvider
+
+	/**
+	 * Special symbol indicating the beginning of a folding region.
+	 */
+	def String b() '''[>'''
+
+	/**
+	 * Special symbol indicating the end of a folding region.
+	 */
+	def String e() '''<]'''
+
+	/**
+	 * Test that the expected folding regions are present on a given DSL text.
+	 *
+	 * @param it The DSL text where the expected folding regions are enclosed by the {@link #b() b} and {@link #e() e} symbols.
+	 */
+	def void testFoldingRegions(CharSequence it) {
+		// given
+		dslFile.
+		// when
+		openInEditor.
+		// then
+		foldingRegionsArePresent(it)
+	}
+
+	protected def IFile dslFile(CharSequence text) {
+		val file = IResourcesSetupUtil.createFile(projectName, fileName, fileExtension, text.content)
+
+		/*
+		 * TODO: find a better (with good performance) solution
+		 * to set the Xtext nature on the test project.
+		 */
+		val project = file.project
+		if(!project.hasNature(XtextProjectHelper.NATURE_ID)) {
+			project.addNature(XtextProjectHelper.NATURE_ID)
+		}
+
+		file
+	}
+
+	protected def String getProjectName() {
+		"FoldingTestProject"
+	}
+
+	protected def String getFileName() {
+		"folding"
+	}
+
+	protected def String getFileExtension() {
+		primaryFileExtension
+	}
+
+	protected def String getContent(CharSequence text) {
+		text.toString.replaceAll(b.quote, "").replaceAll(e.quote, "")
+	}
+
+	protected def IXtextDocument openInEditor(IFile dslFile) {
+		val document = dslFile.openEditor.document
+		document.assertNotNull
+		document
+	}
+
+	protected def foldingRegionsArePresent(IXtextDocument document, CharSequence expected) {
+		val actual = document.insertFoldingRegionMarkers
+		expected.toString.trim.assertEquals(actual)
+	}
+
+	protected def insertFoldingRegionMarkers(IXtextDocument document) {
+		val lineSeparator = System.lineSeparator
+		val lines = document.get.split(lineSeparator).toList
+
+		for (foldingRegion : document.foldingRegions) {
+			// insert the beginning folding region marker at the beginning of the corresponding line
+			val startLine = document.getLineOfOffset(foldingRegion.offset)
+			lines.set(startLine, b + lines.get(startLine))
+
+			// insert the end folding region marker at the end of the corresponding line
+			val endLine = document.getLineOfOffset(foldingRegion.offset + foldingRegion.length) - 1
+			lines.set(endLine, lines.get(endLine) + e)
+		}
+
+		lines.join(lineSeparator)
+	}
+}

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractFoldingTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractFoldingTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.ui.testing;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.resource.FileExtensionProvider;
+import org.eclipse.xtext.ui.XtextProjectHelper;
+import org.eclipse.xtext.ui.editor.folding.FoldedPosition;
+import org.eclipse.xtext.ui.editor.folding.IFoldingRegionProvider;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.testing.AbstractEditorTest;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.junit.Assert;
+
+/**
+ * @author miklossy - Initial contribution and API
+ * @since 2.19
+ */
+@Beta
+@SuppressWarnings("all")
+public abstract class AbstractFoldingTest extends AbstractEditorTest {
+  @Inject
+  @Extension
+  protected FileExtensionProvider _fileExtensionProvider;
+  
+  @Inject
+  @Extension
+  protected IFoldingRegionProvider _iFoldingRegionProvider;
+  
+  /**
+   * Special symbol indicating the beginning of a folding region.
+   */
+  public String b() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>");
+    return _builder.toString();
+  }
+  
+  /**
+   * Special symbol indicating the end of a folding region.
+   */
+  public String e() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("<]");
+    return _builder.toString();
+  }
+  
+  /**
+   * Test that the expected folding regions are present on a given DSL text.
+   * 
+   * @param it The DSL text where the expected folding regions are enclosed by the {@link #b() b} and {@link #e() e} symbols.
+   */
+  public void testFoldingRegions(final CharSequence it) {
+    this.foldingRegionsArePresent(this.openInEditor(this.dslFile(it)), it);
+  }
+  
+  protected IFile dslFile(final CharSequence text) {
+    try {
+      IFile _xblockexpression = null;
+      {
+        final IFile file = IResourcesSetupUtil.createFile(this.getProjectName(), this.getFileName(), this.getFileExtension(), this.getContent(text));
+        final IProject project = file.getProject();
+        boolean _hasNature = project.hasNature(XtextProjectHelper.NATURE_ID);
+        boolean _not = (!_hasNature);
+        if (_not) {
+          IResourcesSetupUtil.addNature(project, XtextProjectHelper.NATURE_ID);
+        }
+        _xblockexpression = file;
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected String getProjectName() {
+    return "FoldingTestProject";
+  }
+  
+  protected String getFileName() {
+    return "folding";
+  }
+  
+  protected String getFileExtension() {
+    return this._fileExtensionProvider.getPrimaryFileExtension();
+  }
+  
+  protected String getContent(final CharSequence text) {
+    return text.toString().replaceAll(Pattern.quote(this.b()), "").replaceAll(Pattern.quote(this.e()), "");
+  }
+  
+  protected IXtextDocument openInEditor(final IFile dslFile) {
+    try {
+      IXtextDocument _xblockexpression = null;
+      {
+        final IXtextDocument document = this.openEditor(dslFile).getDocument();
+        Assert.assertNotNull(document);
+        _xblockexpression = document;
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected void foldingRegionsArePresent(final IXtextDocument document, final CharSequence expected) {
+    final String actual = this.insertFoldingRegionMarkers(document);
+    Assert.assertEquals(expected.toString().trim(), actual);
+  }
+  
+  protected String insertFoldingRegionMarkers(final IXtextDocument document) {
+    try {
+      String _xblockexpression = null;
+      {
+        final String lineSeparator = System.lineSeparator();
+        final List<String> lines = IterableExtensions.<String>toList(((Iterable<String>)Conversions.doWrapArray(document.get().split(lineSeparator))));
+        Collection<FoldedPosition> _foldingRegions = this._iFoldingRegionProvider.getFoldingRegions(document);
+        for (final FoldedPosition foldingRegion : _foldingRegions) {
+          {
+            final int startLine = document.getLineOfOffset(foldingRegion.offset);
+            String _b = this.b();
+            String _get = lines.get(startLine);
+            String _plus = (_b + _get);
+            lines.set(startLine, _plus);
+            int _lineOfOffset = document.getLineOfOffset((foldingRegion.offset + foldingRegion.length));
+            final int endLine = (_lineOfOffset - 1);
+            String _get_1 = lines.get(endLine);
+            String _e = this.e();
+            String _plus_1 = (_get_1 + _e);
+            lines.set(endLine, _plus_1);
+          }
+        }
+        _xblockexpression = IterableExtensions.join(lines, lineSeparator);
+      }
+      return _xblockexpression;
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/folding/FoldingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/folding/FoldingTest.xtend
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.arithmetics.ui.tests.folding
+
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractFoldingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(ArithmeticsUiInjectorProvider)
+class FoldingTest extends AbstractFoldingTest {
+
+	@Test def function001() {
+		'''
+			module arithmetics
+			
+			def add(a, b) :	a + b;
+		'''.testFoldingRegions
+	}
+
+	@Test def function002() {
+		'''
+			module arithmetics
+			
+			[>def add(a, b) :
+				a + b;<]
+		'''.testFoldingRegions
+	}
+
+	@Test def function003() {
+		'''
+			module arithmetics
+			
+			[>def add(a, b) :
+				a + b;<]
+			
+			[>def multiply(a, b) :
+				a * b;<]
+		'''.testFoldingRegions
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/folding/FoldingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/folding/FoldingTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.arithmetics.ui.tests.folding;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractFoldingTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(ArithmeticsUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class FoldingTest extends AbstractFoldingTest {
+  @Test
+  public void function001() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("module arithmetics");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("def add(a, b) :\ta + b;");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void function002() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("module arithmetics");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>def add(a, b) :");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("a + b;<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void function003() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("module arithmetics");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>def add(a, b) :");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("a + b;<]");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>def multiply(a, b) :");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("a * b;<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/FoldingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/FoldingTest.xtend
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.domainmodel.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractFoldingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(DomainmodelUiInjectorProvider)
+class FoldingTest extends AbstractFoldingTest {
+
+	@Test def imports() {
+		'''
+			[>import java.util.List
+			import java.util.Date<]
+		'''.testFoldingRegions
+	}
+
+	@Test def package_declaration() {
+		'''
+			[>package p1 {
+				
+			}<]
+		'''.testFoldingRegions
+	}
+
+	@Test def package_declarations() {
+		'''
+			[>package p1 {
+				
+			}<]
+			
+			[>package p2 {
+				
+			}<]
+		'''.testFoldingRegions
+	}
+
+	@Test def entitiy() {
+		'''
+			[>entity HasAuthor {
+				
+			}<]
+		'''.testFoldingRegions
+	}
+
+	@Test def operation1() {
+		'''
+			[>entity HasAuthor {
+				author: String
+				
+			[>[>op getAuthor() {
+					author
+				}<]<]
+			}<]
+		'''.testFoldingRegions
+	}
+
+	@Test def operation2() {
+		'''
+			[>entity HasAuthor {
+				author: String
+				
+			[>	op getAuthor()
+			[>	{
+					author
+				}<]<]
+			}<]
+		'''.testFoldingRegions
+	}
+
+	@Test def complex() {
+		'''
+			import java.util.List
+			
+			[>entity Blog {
+				title: String
+				posts: List<Post>
+				
+				op addPost(Post post) : void {}
+				op getPosts() : List<Post> {}
+			}<]
+			
+			[>entity HasAuthor {
+				author: String
+				
+				op getAuthor() { author }
+				op setAuthor() : void {}
+			}<]
+			
+			[>entity Post extends HasAuthor {
+				title: String
+				content: String
+				comments: List<Comment>
+			}<]
+			
+			[>entity Comment extends HasAuthor {
+				content: String
+			}<]
+		'''.testFoldingRegions
+	}
+	
+	@Test def multi_line_comment() {
+		'''
+		[>/*
+		   * Description of the entity E.
+		   */<]
+		entity E {}
+		'''.testFoldingRegions
+	}
+	
+	@Test def java_doc() {
+		'''
+		[>/**
+		   * Documentation of the entity E.
+		   */<]
+		entity E {}
+		'''.testFoldingRegions
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/FoldingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/FoldingTest.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.domainmodel.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.domainmodel.ui.tests.DomainmodelUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractFoldingTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(DomainmodelUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class FoldingTest extends AbstractFoldingTest {
+  @Test
+  public void imports() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>import java.util.List");
+    _builder.newLine();
+    _builder.append("import java.util.Date<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void package_declaration() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>package p1 {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void package_declarations() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>package p1 {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>package p2 {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void entitiy() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>entity HasAuthor {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void operation1() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>entity HasAuthor {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("author: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("[>[>op getAuthor() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("author");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}<]<]");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void operation2() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>entity HasAuthor {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("author: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("[>\top getAuthor()");
+    _builder.newLine();
+    _builder.append("[>\t{");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("author");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}<]<]");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void complex() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>entity Blog {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("title: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("posts: List<Post>");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op addPost(Post post) : void {}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op getPosts() : List<Post> {}");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>entity HasAuthor {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("author: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op getAuthor() { author }");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op setAuthor() : void {}");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>entity Post extends HasAuthor {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("title: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("content: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("comments: List<Comment>");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>entity Comment extends HasAuthor {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("content: String");
+    _builder.newLine();
+    _builder.append("}<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void multi_line_comment() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>/*");
+    _builder.newLine();
+    _builder.append("   ");
+    _builder.append("* Description of the entity E.");
+    _builder.newLine();
+    _builder.append("   ");
+    _builder.append("*/<]");
+    _builder.newLine();
+    _builder.append("entity E {}");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void java_doc() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>/**");
+    _builder.newLine();
+    _builder.append("   ");
+    _builder.append("* Documentation of the entity E.");
+    _builder.newLine();
+    _builder.append("   ");
+    _builder.append("*/<]");
+    _builder.newLine();
+    _builder.append("entity E {}");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineFoldingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineFoldingTest.xtend
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.fowlerdsl.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractFoldingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(StatemachineUiInjectorProvider)
+class StatemachineFoldingTest extends AbstractFoldingTest {
+
+	@Test def state001() {
+		'''
+			[>state idle
+			end<]
+		'''.testFoldingRegions
+	}
+
+	@Test def state002() {
+		'''
+			[>state idle
+				
+				
+				
+			end<]
+		'''.testFoldingRegions
+	}
+
+	@Test def complex() {
+		'''
+			events
+				doorClosed   D1CL
+				drawerOpened D2OP
+				lightOn      L1ON
+				doorOpened   D1OP
+				panelClosed  PNCL
+			end
+			
+			resetEvents
+				doorOpened
+				doorClosed
+			end
+			
+			commands
+				unlockPanel PNUL
+				lockPanel   NLK
+				lockDoor    D1LK
+				unlockDoor  D1UL
+			end
+			
+			[>state idle
+				actions {unlockDoor lockPanel}
+				doorClosed => active
+			end<]
+			
+			[>state active
+				drawerOpened => waitingForLight
+				lightOn      => waitingForDrawer
+			end<]
+			
+			[>state waitingForLight
+				lightOn => unlockedPanel
+			end<]
+			
+			[>state waitingForDrawer
+				drawerOpened => unlockedPanel
+			end<]
+			
+			[>state unlockedPanel
+				actions {unlockPanel lockDoor}
+				panelClosed => idle
+			end<]
+		'''.testFoldingRegions
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineFoldingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineFoldingTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.fowlerdsl.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.fowlerdsl.ui.tests.StatemachineUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractFoldingTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(StatemachineUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class StatemachineFoldingTest extends AbstractFoldingTest {
+  @Test
+  public void state001() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>state idle");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void state002() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>state idle");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void complex() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed   D1CL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened D2OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      L1ON");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened   D1OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed  PNCL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("resetEvents");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("commands");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockPanel PNUL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockPanel   NLK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockDoor    D1LK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockDoor  D1UL");
+    _builder.newLine();
+    _builder.append("end");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>state idle");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("actions {unlockDoor lockPanel}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed => active");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>state active");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened => waitingForLight");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      => waitingForDrawer");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>state waitingForLight");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn => unlockedPanel");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>state waitingForDrawer");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened => unlockedPanel");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>state unlockedPanel");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("actions {unlockPanel lockDoor}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed => idle");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineFoldingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/src/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineFoldingTest.xtend
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.homeautomation.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.eclipse.xtext.ui.testing.AbstractFoldingTest
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(RuleEngineUiInjectorProvider)
+class RuleEngineFoldingTest extends AbstractFoldingTest {
+
+	@Test def rule() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			[>Rule 'rule1' when Window.open then
+			[>	fire(Heater.off)<]<]
+		'''.testFoldingRegions
+	}
+
+	@Test def rules() {
+		'''
+			Device Window can be open, closed
+			Device Heater can be on, off, error
+			
+			[>Rule 'rule1' when Window.open then
+			[>	fire(Heater.off)
+				<]<]
+			[>Rule 'rule2' when Heater.on then
+			[>	fire(Window.closed)
+				<]<]
+			[>Rule 'rule3' when Window.closed then
+			[>	fire(Heater.on)
+				<]<]
+			[>Rule 'rule4' when Window.closed then
+			[>	fire(Window.closed)<]<]
+		'''.testFoldingRegions
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineFoldingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/xtend-gen/org/eclipse/xtext/example/homeautomation/ui/tests/RuleEngineFoldingTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.homeautomation.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.homeautomation.ui.tests.RuleEngineUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractFoldingTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(RuleEngineUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class RuleEngineFoldingTest extends AbstractFoldingTest {
+  @Test
+  public void rule() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>Rule \'rule1\' when Window.open then");
+    _builder.newLine();
+    _builder.append("[>\tfire(Heater.off)<]<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void rules() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("Device Window can be open, closed");
+    _builder.newLine();
+    _builder.append("Device Heater can be on, off, error");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("[>Rule \'rule1\' when Window.open then");
+    _builder.newLine();
+    _builder.append("[>\tfire(Heater.off)");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("<]<]");
+    _builder.newLine();
+    _builder.append("[>Rule \'rule2\' when Heater.on then");
+    _builder.newLine();
+    _builder.append("[>\tfire(Window.closed)");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("<]<]");
+    _builder.newLine();
+    _builder.append("[>Rule \'rule3\' when Window.closed then");
+    _builder.newLine();
+    _builder.append("[>\tfire(Heater.on)");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("<]<]");
+    _builder.newLine();
+    _builder.append("[>Rule \'rule4\' when Window.closed then");
+    _builder.newLine();
+    _builder.append("[>\tfire(Window.closed)<]<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+}


### PR DESCRIPTION
- Extend the 'Xtext UI Testing' test infrastructure by the
AbstractFoldingTest abstract class to provide a base infrastructure
for testing the folding capabilities.
- Extend the Xtext Examples the FoldingTest test cases to
demonstrate the usage of the AbstractFoldingTest class.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>