### PR TITLE
[#1103] Extend the Statemachine Xtext Editor folding capabilities.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineFoldingTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/src/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineFoldingTest.xtend
@@ -20,6 +20,38 @@ import org.junit.runner.RunWith
 @InjectWith(StatemachineUiInjectorProvider)
 class StatemachineFoldingTest extends AbstractFoldingTest {
 
+	@Test def events() {
+		'''
+			[>events
+				doorClosed   D1CL
+				drawerOpened D2OP
+				lightOn      L1ON
+				doorOpened   D1OP
+				panelClosed  PNCL
+			end<]
+		'''.testFoldingRegions
+	}
+
+	@Test def resetEvents() {
+		'''
+			[>resetEvents
+				doorOpened
+				doorClosed
+			end<]
+		'''.testFoldingRegions
+	}
+
+	@Test def commands() {
+		'''
+			[>commands
+				unlockPanel PNUL
+				lockPanel   NLK
+				lockDoor    D1LK
+				unlockDoor  D1UL
+			end<]
+		'''.testFoldingRegions
+	}
+
 	@Test def state001() {
 		'''
 			[>state idle
@@ -39,25 +71,25 @@ class StatemachineFoldingTest extends AbstractFoldingTest {
 
 	@Test def complex() {
 		'''
-			events
+			[>events
 				doorClosed   D1CL
 				drawerOpened D2OP
 				lightOn      L1ON
 				doorOpened   D1OP
 				panelClosed  PNCL
-			end
+			end<]
 			
-			resetEvents
+			[>resetEvents
 				doorOpened
 				doorClosed
-			end
+			end<]
 			
-			commands
+			[>commands
 				unlockPanel PNUL
 				lockPanel   NLK
 				lockDoor    D1LK
 				unlockDoor  D1UL
-			end
+			end<]
 			
 			[>state idle
 				actions {unlockDoor lockPanel}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineFoldingTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/tests/StatemachineFoldingTest.java
@@ -23,6 +23,69 @@ import org.junit.runner.RunWith;
 @SuppressWarnings("all")
 public class StatemachineFoldingTest extends AbstractFoldingTest {
   @Test
+  public void events() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>events");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed   D1CL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("drawerOpened D2OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lightOn      L1ON");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened   D1OP");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("panelClosed  PNCL");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void resetEvents() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>resetEvents");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorOpened");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("doorClosed");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
+  public void commands() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("[>commands");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockPanel PNUL");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockPanel   NLK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("lockDoor    D1LK");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("unlockDoor  D1UL");
+    _builder.newLine();
+    _builder.append("end<]");
+    _builder.newLine();
+    this.testFoldingRegions(_builder);
+  }
+  
+  @Test
   public void state001() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("[>state idle");
@@ -51,7 +114,7 @@ public class StatemachineFoldingTest extends AbstractFoldingTest {
   @Test
   public void complex() {
     StringConcatenation _builder = new StringConcatenation();
-    _builder.append("events");
+    _builder.append("[>events");
     _builder.newLine();
     _builder.append("\t");
     _builder.append("doorClosed   D1CL");
@@ -68,10 +131,10 @@ public class StatemachineFoldingTest extends AbstractFoldingTest {
     _builder.append("\t");
     _builder.append("panelClosed  PNCL");
     _builder.newLine();
-    _builder.append("end");
+    _builder.append("end<]");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("resetEvents");
+    _builder.append("[>resetEvents");
     _builder.newLine();
     _builder.append("\t");
     _builder.append("doorOpened");
@@ -79,10 +142,10 @@ public class StatemachineFoldingTest extends AbstractFoldingTest {
     _builder.append("\t");
     _builder.append("doorClosed");
     _builder.newLine();
-    _builder.append("end");
+    _builder.append("end<]");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("commands");
+    _builder.append("[>commands");
     _builder.newLine();
     _builder.append("\t");
     _builder.append("unlockPanel PNUL");
@@ -96,7 +159,7 @@ public class StatemachineFoldingTest extends AbstractFoldingTest {
     _builder.append("\t");
     _builder.append("unlockDoor  D1UL");
     _builder.newLine();
-    _builder.append("end");
+    _builder.append("end<]");
     _builder.newLine();
     _builder.newLine();
     _builder.append("[>state idle");

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/StatemachineUiModule.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/StatemachineUiModule.xtend
@@ -4,12 +4,18 @@
 package org.eclipse.xtext.example.fowlerdsl.ui
 
 import org.eclipse.ui.plugin.AbstractUIPlugin
+import org.eclipse.xtext.example.fowlerdsl.ui.folding.StatemachineFoldingRegionProvider
+import org.eclipse.xtext.ui.editor.folding.IFoldingRegionProvider
 
 /**
  * Use this class to register components to be used within the IDE.
  */
-class StatemachineUiModule extends org.eclipse.xtext.example.fowlerdsl.ui.AbstractStatemachineUiModule {
+class StatemachineUiModule extends AbstractStatemachineUiModule {
 	new(AbstractUIPlugin plugin) {
 		super(plugin)
+	}
+
+	def Class<? extends IFoldingRegionProvider> bindIFoldingRegionProvider() {
+		StatemachineFoldingRegionProvider
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/folding/StatemachineFoldingRegionProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/folding/StatemachineFoldingRegionProvider.xtend
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.example.fowlerdsl.ui.folding
+
+import com.google.inject.Inject
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.Keyword
+import org.eclipse.xtext.example.fowlerdsl.services.StatemachineGrammarAccess
+import org.eclipse.xtext.example.fowlerdsl.statemachine.Statemachine
+import org.eclipse.xtext.nodemodel.INode
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.ui.editor.folding.DefaultFoldingRegionProvider
+import org.eclipse.xtext.ui.editor.folding.IFoldingRegionAcceptor
+import org.eclipse.xtext.util.ITextRegion
+import org.eclipse.xtext.util.TextRegion
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+class StatemachineFoldingRegionProvider extends DefaultFoldingRegionProvider {
+
+	@Inject extension StatemachineGrammarAccess
+
+	override protected computeObjectFolding(EObject eObject, IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+		if (eObject instanceof Statemachine) {
+			val it = eObject.eResource as XtextResource
+			computeEventsFolding(foldingRegionAcceptor)
+			computeResetEventsFolding(foldingRegionAcceptor)
+			computeCommandsFolding(foldingRegionAcceptor)
+		} else {
+			super.computeObjectFolding(eObject, foldingRegionAcceptor)
+		}
+	}
+
+	override protected isHandled(EObject eObject) {
+		super.isHandled(eObject) || eObject instanceof Statemachine
+	}
+
+	private def computeEventsFolding(XtextResource it, IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+		computeFoldingRegionBetweenKeywords(statemachineAccess.eventsKeyword_1_0, statemachineAccess.endKeyword_1_2, foldingRegionAcceptor)
+	}
+
+	private def computeResetEventsFolding(XtextResource it, IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+		computeFoldingRegionBetweenKeywords(statemachineAccess.resetEventsKeyword_2_0, statemachineAccess.endKeyword_2_2, foldingRegionAcceptor)
+	}
+
+	private def computeCommandsFolding(XtextResource it, IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+		computeFoldingRegionBetweenKeywords(statemachineAccess.commandsKeyword_3_0, statemachineAccess.endKeyword_3_2, foldingRegionAcceptor)
+	}
+
+	private def computeFoldingRegionBetweenKeywords(XtextResource it, Keyword startKeyword, Keyword endKeyword, IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+		val region = textRegionBetween(startKeyword, endKeyword)
+		if (region !== null) {
+			foldingRegionAcceptor.accept(region.offset, region.length)
+		}
+	}
+
+	/**
+	 * Determine the text region between the start keyword and the end keyword.
+	 */
+	private def ITextRegion textRegionBetween(XtextResource it, Keyword startKeyword, Keyword endKeyword) {
+		var INode startNode
+		for (INode node : parseResult.rootNode.asTreeIterable) {
+			val grammarElement = node.grammarElement
+			if (grammarElement == startKeyword) {
+				startNode = node
+			}
+			if (grammarElement == endKeyword && startNode !==null) {
+				return textRegionBetween(startNode, node)
+			}
+		}
+	}
+
+	/**
+	 * Determine the text region between the start node and the end node.
+	 */
+	private def ITextRegion textRegionBetween(XtextResource it, INode startNode, INode endNode) {
+		val offset = startNode.offset
+		val length = endNode.endOffset - offset
+		new TextRegion(offset, length)
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/StatemachineUiModule.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/StatemachineUiModule.java
@@ -5,6 +5,8 @@ package org.eclipse.xtext.example.fowlerdsl.ui;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.xtext.example.fowlerdsl.ui.AbstractStatemachineUiModule;
+import org.eclipse.xtext.example.fowlerdsl.ui.folding.StatemachineFoldingRegionProvider;
+import org.eclipse.xtext.ui.editor.folding.IFoldingRegionProvider;
 
 /**
  * Use this class to register components to be used within the IDE.
@@ -13,5 +15,9 @@ import org.eclipse.xtext.example.fowlerdsl.ui.AbstractStatemachineUiModule;
 public class StatemachineUiModule extends AbstractStatemachineUiModule {
   public StatemachineUiModule(final AbstractUIPlugin plugin) {
     super(plugin);
+  }
+  
+  public Class<? extends IFoldingRegionProvider> bindIFoldingRegionProvider() {
+    return StatemachineFoldingRegionProvider.class;
   }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/folding/StatemachineFoldingRegionProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/folding/StatemachineFoldingRegionProvider.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtext.example.fowlerdsl.ui.folding;
+
+import com.google.common.base.Objects;
+import com.google.inject.Inject;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.Keyword;
+import org.eclipse.xtext.example.fowlerdsl.services.StatemachineGrammarAccess;
+import org.eclipse.xtext.example.fowlerdsl.statemachine.Statemachine;
+import org.eclipse.xtext.nodemodel.BidiTreeIterable;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.folding.DefaultFoldingRegionProvider;
+import org.eclipse.xtext.ui.editor.folding.IFoldingRegionAcceptor;
+import org.eclipse.xtext.util.ITextRegion;
+import org.eclipse.xtext.util.TextRegion;
+import org.eclipse.xtext.xbase.lib.Extension;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class StatemachineFoldingRegionProvider extends DefaultFoldingRegionProvider {
+  @Inject
+  @Extension
+  private StatemachineGrammarAccess _statemachineGrammarAccess;
+  
+  @Override
+  protected void computeObjectFolding(final EObject eObject, final IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+    if ((eObject instanceof Statemachine)) {
+      Resource _eResource = ((Statemachine)eObject).eResource();
+      final XtextResource it = ((XtextResource) _eResource);
+      this.computeEventsFolding(it, foldingRegionAcceptor);
+      this.computeResetEventsFolding(it, foldingRegionAcceptor);
+      this.computeCommandsFolding(it, foldingRegionAcceptor);
+    } else {
+      super.computeObjectFolding(eObject, foldingRegionAcceptor);
+    }
+  }
+  
+  @Override
+  protected boolean isHandled(final EObject eObject) {
+    return (super.isHandled(eObject) || (eObject instanceof Statemachine));
+  }
+  
+  private void computeEventsFolding(final XtextResource it, final IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+    this.computeFoldingRegionBetweenKeywords(it, this._statemachineGrammarAccess.getStatemachineAccess().getEventsKeyword_1_0(), this._statemachineGrammarAccess.getStatemachineAccess().getEndKeyword_1_2(), foldingRegionAcceptor);
+  }
+  
+  private void computeResetEventsFolding(final XtextResource it, final IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+    this.computeFoldingRegionBetweenKeywords(it, this._statemachineGrammarAccess.getStatemachineAccess().getResetEventsKeyword_2_0(), this._statemachineGrammarAccess.getStatemachineAccess().getEndKeyword_2_2(), foldingRegionAcceptor);
+  }
+  
+  private void computeCommandsFolding(final XtextResource it, final IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+    this.computeFoldingRegionBetweenKeywords(it, this._statemachineGrammarAccess.getStatemachineAccess().getCommandsKeyword_3_0(), this._statemachineGrammarAccess.getStatemachineAccess().getEndKeyword_3_2(), foldingRegionAcceptor);
+  }
+  
+  private void computeFoldingRegionBetweenKeywords(final XtextResource it, final Keyword startKeyword, final Keyword endKeyword, final IFoldingRegionAcceptor<ITextRegion> foldingRegionAcceptor) {
+    final ITextRegion region = this.textRegionBetween(it, startKeyword, endKeyword);
+    if ((region != null)) {
+      foldingRegionAcceptor.accept(region.getOffset(), region.getLength());
+    }
+  }
+  
+  /**
+   * Determine the text region between the start keyword and the end keyword.
+   */
+  private ITextRegion textRegionBetween(final XtextResource it, final Keyword startKeyword, final Keyword endKeyword) {
+    INode startNode = null;
+    BidiTreeIterable<INode> _asTreeIterable = it.getParseResult().getRootNode().getAsTreeIterable();
+    for (final INode node : _asTreeIterable) {
+      {
+        final EObject grammarElement = node.getGrammarElement();
+        boolean _equals = Objects.equal(grammarElement, startKeyword);
+        if (_equals) {
+          startNode = node;
+        }
+        if ((Objects.equal(grammarElement, endKeyword) && (startNode != null))) {
+          return this.textRegionBetween(it, startNode, node);
+        }
+      }
+    }
+    return null;
+  }
+  
+  /**
+   * Determine the text region between the start node and the end node.
+   */
+  private ITextRegion textRegionBetween(final XtextResource it, final INode startNode, final INode endNode) {
+    TextRegion _xblockexpression = null;
+    {
+      final int offset = startNode.getOffset();
+      int _endOffset = endNode.getEndOffset();
+      final int length = (_endOffset - offset);
+      _xblockexpression = new TextRegion(offset, length);
+    }
+    return _xblockexpression;
+  }
+}


### PR DESCRIPTION
- Provide the StatemachineFoldingRegionProvider custom class that
computes folding regions not only for the states, but also for the
events, resetEvent and commands blocks.
- Provide corresponding binding in the StatemachineUiModule.
- Provide corresponding StatemachineFoldingTest UI test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>