### PR TITLE
[eclipse/xtext-core#1161] Added configurable issue for generated java package names not conforming to Java package naming conventions (Default: Ignore).

### DIFF
--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/Messages.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/Messages.java
@@ -36,6 +36,7 @@ public final class Messages extends NLS {
 	public static String XtextValidatorConfigurationBlock_16;
 	public static String XtextValidatorConfigurationBlock_17;
 	public static String XtextValidatorConfigurationBlock_18;
+	public static String XtextValidatorConfigurationBlock_19;
 	
 	static {
 		// initialize resource bundle

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/XtextValidatorConfigurationBlock.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/XtextValidatorConfigurationBlock.java
@@ -41,6 +41,7 @@ public class XtextValidatorConfigurationBlock extends AbstractValidatorConfigura
 		addComboBox(DUPLICATE_ENUM_LITERAL, Messages.XtextValidatorConfigurationBlock_3, section, defaultIndent);
 		addComboBox(USAGE_OF_DEPRECATED_RULE, Messages.XtextValidatorConfigurationBlock_17, section, defaultIndent);
 		addComboBox(INVALID_FRAGMENT_AS_FIRST_RULE, Messages.XtextValidatorConfigurationBlock_18, section, defaultIndent);
+		addComboBox(INVALID_JAVAPACKAGE_NAME, Messages.XtextValidatorConfigurationBlock_19, section, defaultIndent);
 	}
 
 	protected void fillEcoreModelSection(Composite section, int defaultIndent) {

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/messages.properties
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/validation/messages.properties
@@ -9,6 +9,7 @@ XtextValidatorConfigurationBlock_15=Discouraged rule name:
 XtextValidatorConfigurationBlock_16=Info
 XtextValidatorConfigurationBlock_17=Usage of deprecated rules:
 XtextValidatorConfigurationBlock_18=Entry Rule must not be a fragment:
+XtextValidatorConfigurationBlock_19=Java package naming conventions:
 XtextValidatorConfigurationBlock_2=Terminal rule naming conventions:
 XtextValidatorConfigurationBlock_3=Duplicate enumeration literal:
 XtextValidatorConfigurationBlock_4=Package naming conventions:


### PR DESCRIPTION
Signed-off-by: Lorenzo Addazi <lorenzo.addazi@mdh.se>