### PR TITLE
[eclipse/xtext#1459] Change p2.buildship value to use Buildship 3.x

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -139,7 +139,7 @@
       xsi:type="setup:VariableTask"
       type="URI"
       name="p2.buildship"
-      value="https://download.eclipse.org/buildship/updates/e47/releases/2.x"/>
+      value="https://download.eclipse.org/buildship/updates/e411/releases/3.x"/>
   <setupTask
       xsi:type="setup:VariableTask"
       name="p2.m2e"


### PR DESCRIPTION
On current Eclipse installations Buildship 3.x is already picked from
the Eclipse SimRel repository. Current Buildship 3.1.0 is installable
also on Eclipse Oxygen, so changing the Buildship repository URL allows
to use the same Buildship version on Eclipse 4.7 and above.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>