### PR TITLE
[eclipse/xtext#1508] Trigger downstream build

### DIFF
--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -38,6 +38,8 @@ spec:
       readOnly: true
     - name: m2-repo
       mountPath: /home/jenkins/.m2/repository
+    - name: volume-known-hosts
+      mountPath: /home/jenkins/.ssh
   volumes:
   - name: volume-known-hosts
     configMap:
@@ -54,8 +56,17 @@ spec:
     }
   }
   
+  environment {
+    DOWNSTREAM_JOBS = 'xtext-xtend'
+  }
+
   parameters {
     choice(name: 'target_platform', choices: ['oxygen', 'latest', 'r201812', 'r201809', 'r201903', 'r201906', 'photon'], description: 'Which Target Platform should be used?')
+    booleanParam(
+      name: 'TRIGGER_DOWNSTREAM_BUILD', 
+      defaultValue: (env.BRANCH_NAME.startsWith('milestone')||env.BRANCH_NAME.startsWith('release')), 
+      description: 'Should downstream jobs for the same branch be triggered on successful build?'
+    )
   }
 
   options {
@@ -123,6 +134,17 @@ spec:
     }
     success {
       archiveArtifacts artifacts: 'build/**'
+      script {
+        if (TRIGGER_DOWNSTREAM_BUILD=='true') {
+          DOWNSTREAM_JOBS.split(',').each {
+            def downstreamUrl = new URL("${env.JENKINS_URL}/job/$it/job/${env.BRANCH_NAME}")
+            def boolean downstreamJobExists = sh(script: "curl -L -s -o /dev/null -I -w '%{http_code}' ${downstreamUrl}", returnStdout: true) == "200"
+            if (downstreamJobExists) {
+              build job: "$it/${env.BRANCH_NAME}", wait: false, parameters: [booleanParam(name: 'TRIGGER_DOWNSTREAM_BUILD', value: "$TRIGGER_DOWNSTREAM_BUILD")]
+            }
+          }
+        }
+      }
     }
     failure {
       archiveArtifacts artifacts: '**/target/work/data/.metadata/.log, **/hs_err_pid*.log'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,17 @@
 pipeline {
   agent any
 
+  environment {
+    DOWNSTREAM_JOBS = 'xtext-xtend'
+  }
+
   parameters {
     choice(name: 'target_platform', choices: ['oxygen', 'latest', 'r201906', 'r201903', 'r201812', 'r201809', 'photon'], description: 'Which Target Platform should be used?')
+    booleanParam(
+      name: 'TRIGGER_DOWNSTREAM_BUILD', 
+      defaultValue: (env.BRANCH_NAME.startsWith('milestone')||env.BRANCH_NAME.startsWith('release')), 
+      description: 'Should downstream jobs for the same branch be triggered on successful build?'
+    )
   }
 
   options {
@@ -76,6 +85,17 @@ pipeline {
     }
     success {
       archiveArtifacts artifacts: 'build/**'
+      script {
+        if (TRIGGER_DOWNSTREAM_BUILD=='true') {
+          DOWNSTREAM_JOBS.split(',').each {
+            def downstreamUrl = new URL("${env.JENKINS_URL}/job/$it/job/${env.BRANCH_NAME}")
+            def boolean downstreamJobExists = sh(script: "curl -L -s -o /dev/null -I -w '%{http_code}' ${downstreamUrl}", returnStdout: true) == "200"
+            if (downstreamJobExists) {
+              build job: "$it/${env.BRANCH_NAME}", wait: false, parameters: [booleanParam(name: 'TRIGGER_DOWNSTREAM_BUILD', value: "$TRIGGER_DOWNSTREAM_BUILD")]
+            }
+          }
+        }
+      }
     }
     failure {
       archiveArtifacts artifacts: '**/target/work/data/.metadata/.log, **/hs_err_pid*.log'


### PR DESCRIPTION
Introduce boolean parameter TRIGGER_DOWNSTREAM_BUILD. The parameter
defaults to false normally except for milestone/release branches.
When the TRIGGER_DOWNSTREAM_BUILD flag is set, a test for a downstream
job with the same branch name is done via a curl command. When the
downstream job exists, it is triggered and the parameter value
TRIGGER_DOWNSTREAM_BUILD is propagated.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>