### PR TITLE
[#1044] Fix warning: the method setHyperlinkRegion(Region) is deprecated

### DIFF
--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/xtext/ui/JdtHyperlinkFactory.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/xtext/ui/JdtHyperlinkFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@ package org.eclipse.xtext.common.types.xtext.ui;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.ui.JavaElementLabels;
+import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.common.types.access.TypeResource;
@@ -34,6 +35,30 @@ public class JdtHyperlinkFactory {
 		return to instanceof JvmIdentifiableElement && to.eResource() instanceof TypeResource;
 	}
 
+	/**
+	 * @since 2.19
+	 */
+	public void createHyperlink(IRegion region, EObject to, IHyperlinkAcceptor acceptor) {
+		if (region instanceof Region) {
+			createHyperlink((Region) region, to, acceptor);
+		} else {
+			JvmIdentifiableElement element = (JvmIdentifiableElement) to;
+			IJavaElement javaElement = javaElementFinder.findElementFor(element);
+			if (javaElement == null)
+				return;
+			String label = JavaElementLabels.getElementLabel(javaElement, JavaElementLabels.ALL_DEFAULT);
+			JdtHyperlink result = jdtHyperlinkProvider.get();
+			result.setHyperlinkRegion(region);
+			result.setHyperlinkText(label);
+			result.setJavaElement(javaElement);
+			acceptor.accept(result);
+		}
+	}
+
+	/**
+	 * @deprecated use {@link #createHyperlink(IRegion, EObject, IHyperlinkAcceptor)} instead.
+	 */
+	@Deprecated
 	public void createHyperlink(Region region, EObject to, IHyperlinkAcceptor acceptor) {
 		JvmIdentifiableElement element = (JvmIdentifiableElement) to;
 		IJavaElement javaElement = javaElementFinder.findElementFor(element);


### PR DESCRIPTION
- Modify the org.eclipse.xtext.ui.editor.hyperlinking.HyperlinkHelper
class to use the setHyperlinkRegion(IRegion) instead of the deprecated
setHyperlinkRegion(Region) method of the AbstractHyperlink class.
- Fix the deprecation warnings also in the derived classes.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>