### PR TITLE
[eclipse/xtext#1279] use orbit simrel alias directly

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -27,7 +27,7 @@
       <unit id="org.apache.commons.cli" version="1.2.0.v201404270220"/>
       <unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
       <unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201606061308"/>

--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -102,7 +102,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="p2.orbit"
-      value="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+      value="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
   <setupTask
       xsi:type="setup:VariableTask"
       name="p2.mwe2"

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
@@ -113,7 +113,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-oxygen.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-oxygen.target
@@ -101,7 +101,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-photon.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-photon.target
@@ -101,7 +101,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201809.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201809.target
@@ -101,7 +101,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201812.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201812.target
@@ -101,7 +101,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201903.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201903.target
@@ -101,7 +101,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201906.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201906.target
@@ -101,7 +101,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>


### PR DESCRIPTION
[eclipse/xtext#1279] use orbit simrel alias directly
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>