### PR TITLE
[#1155] Avoid assumptions about the used implementation of IXtextDocument

### DIFF
--- a/org.eclipse.xtext.purexbase.ui/src/org/eclipse/xtext/purexbase/ui/autoedit/ReplAutoEdit.java
+++ b/org.eclipse.xtext.purexbase.ui/src/org/eclipse/xtext/purexbase/ui/autoedit/ReplAutoEdit.java
@@ -54,6 +54,12 @@ public class ReplAutoEdit implements IAutoEditStrategy {
 
 	@Inject
 	private IResourceValidator validator;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
 
 	@Override
 	public void customizeDocumentCommand(final IDocument document, final DocumentCommand command) {
@@ -61,7 +67,7 @@ public class ReplAutoEdit implements IAutoEditStrategy {
 			return;
 		}
 		try {
-			IXtextDocument doc = XtextDocumentUtil.get(document);
+			IXtextDocument doc = xtextDocumentUtil.getXtextDocument(document);
 			String result = doc.tryReadOnly(new IUnitOfWork<String, XtextResource>() {
 				@Override
 				public String exec(XtextResource resource) throws Exception {

--- a/org.eclipse.xtext.purexbase.ui/src/org/eclipse/xtext/purexbase/ui/autoedit/ReplAutoEdit.java
+++ b/org.eclipse.xtext.purexbase.ui/src/org/eclipse/xtext/purexbase/ui/autoedit/ReplAutoEdit.java
@@ -28,6 +28,7 @@ import org.eclipse.xtext.purexbase.pureXbase.Model;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.validation.CheckMode;
@@ -60,7 +61,7 @@ public class ReplAutoEdit implements IAutoEditStrategy {
 			return;
 		}
 		try {
-			IXtextDocument doc = (IXtextDocument) document;
+			IXtextDocument doc = XtextDocumentUtil.get(document);
 			String result = doc.tryReadOnly(new IUnitOfWork<String, XtextResource>() {
 				@Override
 				public String exec(XtextResource resource) throws Exception {

--- a/org.eclipse.xtext.ui.codemining/src/org/eclipse/xtext/ui/codemining/AbstractXtextCodeMiningProvider.java
+++ b/org.eclipse.xtext.ui.codemining/src/org/eclipse/xtext/ui/codemining/AbstractXtextCodeMiningProvider.java
@@ -32,6 +32,7 @@ import org.eclipse.xtext.util.IAcceptor;
 import org.eclipse.xtext.util.concurrent.CancelableUnitOfWork;
 
 import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
 
 /**
  * Xtext integration for Code Mining support. Clients have to subclass and
@@ -43,6 +44,13 @@ import com.google.common.annotations.Beta;
  */
 @Beta
 public abstract class AbstractXtextCodeMiningProvider extends AbstractCodeMiningProvider {
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
+	
 	/*
 	 * This indicator checks if monitor is canceled or if
 	 * CancelableUnitOfWork-cancelIndicator is canceled.
@@ -78,7 +86,7 @@ public abstract class AbstractXtextCodeMiningProvider extends AbstractCodeMining
 				}
 
 			};
-			return XtextDocumentUtil.get(viewer).tryReadOnly(uow, () -> Collections.emptyList());
+			return xtextDocumentUtil.getXtextDocument(viewer).tryReadOnly(uow, () -> Collections.emptyList());
 		});
 		return future;
 	}

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.xtend
@@ -23,14 +23,13 @@ import org.eclipse.xtext.ui.XtextProjectHelper
 import org.eclipse.xtext.ui.editor.XtextEditor
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper
 import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink
-import org.eclipse.xtext.ui.editor.model.IXtextDocument
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
 import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
 import org.eclipse.xtext.ui.resource.IResourceSetProvider
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
 import org.eclipse.xtext.util.concurrent.IUnitOfWork
 
 import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.addNature
-import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
 
 /**
  * @author miklossy - Initial contribution and API
@@ -45,6 +44,11 @@ abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
 	@Inject protected extension SyncUtil
 
 	@Inject protected IResourceSetProvider resourceSetProvider
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject	protected extension XtextDocumentUtil
 
 	protected IProject project
 
@@ -98,7 +102,7 @@ abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
 
 	protected def IHyperlink[] hyperlinkingOn(IFile dslFile, int offset) {
 		val editor = dslFile.openInEditor
-		val document = XtextDocumentUtil.get(editor.internalSourceViewer)
+		val document = editor.internalSourceViewer.xtextDocument
 		val resource = document.readOnly(new IUnitOfWork<XtextResource, XtextResource>(){
 
 			override exec(XtextResource state) {

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.xtend
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.xtend
@@ -30,6 +30,7 @@ import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
 import org.eclipse.xtext.util.concurrent.IUnitOfWork
 
 import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.addNature
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
 
 /**
  * @author miklossy - Initial contribution and API
@@ -97,7 +98,7 @@ abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
 
 	protected def IHyperlink[] hyperlinkingOn(IFile dslFile, int offset) {
 		val editor = dslFile.openInEditor
-		val document = editor.internalSourceViewer.document as IXtextDocument
+		val document = XtextDocumentUtil.get(editor.internalSourceViewer)
 		val resource = document.readOnly(new IUnitOfWork<XtextResource, XtextResource>(){
 
 			override exec(XtextResource state) {

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.java
@@ -16,7 +16,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
-import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
@@ -30,6 +29,7 @@ import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
 import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
 import org.eclipse.xtext.ui.testing.AbstractEditorTest;
@@ -127,8 +127,7 @@ public abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
     IHyperlink[] _xblockexpression = null;
     {
       final XtextEditor editor = this.openInEditor(dslFile);
-      IDocument _document = editor.getInternalSourceViewer().getDocument();
-      final IXtextDocument document = ((IXtextDocument) _document);
+      final IXtextDocument document = XtextDocumentUtil.get(editor.getInternalSourceViewer());
       final XtextResource resource = document.<XtextResource>readOnly(new IUnitOfWork<XtextResource, XtextResource>() {
         @Override
         public XtextResource exec(final XtextResource state) {

--- a/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.java
+++ b/org.eclipse.xtext.ui.testing/xtend-gen/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.java
@@ -68,6 +68,13 @@ public abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
   @Inject
   protected IResourceSetProvider resourceSetProvider;
   
+  /**
+   * @since 2.19
+   */
+  @Inject
+  @Extension
+  protected XtextDocumentUtil _xtextDocumentUtil;
+  
   protected IProject project;
   
   protected final String c = new Function0<String>() {
@@ -127,7 +134,7 @@ public abstract class AbstractHyperlinkingTest extends AbstractEditorTest {
     IHyperlink[] _xblockexpression = null;
     {
       final XtextEditor editor = this.openInEditor(dslFile);
-      final IXtextDocument document = XtextDocumentUtil.get(editor.getInternalSourceViewer());
+      final IXtextDocument document = this._xtextDocumentUtil.getXtextDocument(editor.getInternalSourceViewer());
       final XtextResource resource = document.<XtextResource>readOnly(new IUnitOfWork<XtextResource, XtextResource>() {
         @Override
         public XtextResource exec(final XtextResource state) {

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/ImportURINavigationTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/ImportURINavigationTest.java
@@ -59,6 +59,12 @@ public class ImportURINavigationTest {
 	@Inject
 	private IWorkbench workbench;
 	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
+	
 	@Test
 	public void testNavigateToFileURI() throws Exception {
 		doTestNavigation(new IUnitOfWork<URI, IFile>() {
@@ -111,7 +117,7 @@ public class ImportURINavigationTest {
 			hyperlinks[0].open();
 			IEditorPart editor = activePage.getActiveEditor();
 			Assert.assertNotNull(editor);
-			IXtextDocument document = XtextDocumentUtil.get(editor);
+			IXtextDocument document = xtextDocumentUtil.getXtextDocument(editor);
 			document.readOnly(new IUnitOfWork.Void<XtextResource>() {
 				@Override
 				public void process(XtextResource state) throws Exception {

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/SimpleEditorTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/SimpleEditorTest.java
@@ -20,7 +20,6 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
-import org.eclipse.xtext.ui.editor.model.XtextDocument;
 import org.eclipse.xtext.ui.testing.AbstractEditorTest;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
@@ -82,7 +81,7 @@ public class SimpleEditorTest extends AbstractEditorTest {
 		IFile file = createFile("foo/y.testlanguage", "/* multi line */\n" + "stuff foo\n" + "stuff bar\n" + "// end");
 		XtextEditor openEditor = openEditor(file);
 		assertNotNull(openEditor);
-		XtextDocument document = (XtextDocument) openEditor.getDocument();
+		IXtextDocument document = openEditor.getDocument();
 
 		Display.getDefault().readAndDispatch();
 		document.readOnly(new IUnitOfWork.Void<XtextResource>() {
@@ -116,7 +115,7 @@ public class SimpleEditorTest extends AbstractEditorTest {
 		IFile file = createFile("foo/z.testlanguage", "/* multi line */\n" + "stuff foo\n" + "stuff bar\n" + "// end");
 		XtextEditor openEditor = openEditor(file);
 		assertNotNull(openEditor);
-		XtextDocument document = (XtextDocument) openEditor.getDocument();
+		IXtextDocument document = openEditor.getDocument();
 
 		Display.getDefault().readAndDispatch();
 		document.readOnly(new IUnitOfWork.Void<XtextResource>() {

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/Bug369087Test.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/model/Bug369087Test.java
@@ -23,7 +23,6 @@ import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
-import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.ui.testing.AbstractAutoEditTest;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.util.JREContainerProvider;
@@ -78,7 +77,7 @@ public class Bug369087Test extends AbstractAutoEditTest {
 				"    'package' name=ID '{'\n" +
 				"'}';";
 		XtextEditor editor = openEditor(model);
-		IXtextDocument xtextDocument = XtextDocumentUtil.get(editor);
+		IXtextDocument xtextDocument = editor.getDocument();
 		String category = getContentTypeCategory(xtextDocument).toString();
 		Position[] positions = xtextDocument.getPositions(category);
 		for(int i=1; i<xtextDocument.getLength(); ++i) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultMergeViewer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultMergeViewer.java
@@ -71,6 +71,10 @@ public class DefaultMergeViewer extends TextMergeViewer {
 	protected IDocumentProvider documentProvider;
 	protected Map<ISourceViewer, DefaultMergeEditor> sourceViewerEditorMap;
 	protected Provider<XtextSourceViewerConfiguration> sourceViewerConfigurationProvider;
+	/**
+	 * @since 2.19
+	 */
+	protected XtextDocumentUtil xtextDocumentUtil;
 
 	private Map<Object, IStreamContentAccessor> inputObjectStreamContentAccessorMap = Maps.newHashMap();
 
@@ -164,7 +168,7 @@ public class DefaultMergeViewer extends TextMergeViewer {
 		SourceViewerConfiguration sourceViewerConfiguration = createSourceViewerConfiguration(sourceViewer, editorInput);
 		sourceViewer.unconfigure();
 		sourceViewer.configure(sourceViewerConfiguration);
-		IXtextDocument xtextDocument = XtextDocumentUtil.get(sourceViewer);
+		IXtextDocument xtextDocument = xtextDocumentUtil.getXtextDocument(sourceViewer);
 		if (xtextDocument != null) {
 			if (!xtextDocument.readOnly(TEST_EXISTING_XTEXT_RESOURCE)) {
 				String[] configuredContentTypes = sourceViewerConfiguration.getConfiguredContentTypes(sourceViewer);
@@ -279,6 +283,13 @@ public class DefaultMergeViewer extends TextMergeViewer {
 			mergeEditor = sourceViewerEditorMap.get(sourceViewer);
 		}
 		return mergeEditor;
+	}
+
+	/**
+	 * @since 2.19
+	 */
+	protected void setXtextDocumentUtil(XtextDocumentUtil xtextDocumentUtil) {
+		this.xtextDocumentUtil = xtextDocumentUtil;
 	}
 
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultMergeViewer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultMergeViewer.java
@@ -45,6 +45,7 @@ import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.CompoundXtextEditorCallback;
 import org.eclipse.xtext.ui.editor.XtextSourceViewerConfiguration;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 
 import com.google.common.collect.Maps;
@@ -163,8 +164,8 @@ public class DefaultMergeViewer extends TextMergeViewer {
 		SourceViewerConfiguration sourceViewerConfiguration = createSourceViewerConfiguration(sourceViewer, editorInput);
 		sourceViewer.unconfigure();
 		sourceViewer.configure(sourceViewerConfiguration);
-		if (sourceViewer.getDocument() instanceof IXtextDocument) {
-			IXtextDocument xtextDocument = (IXtextDocument) sourceViewer.getDocument();
+		IXtextDocument xtextDocument = XtextDocumentUtil.get(sourceViewer);
+		if (xtextDocument != null) {
 			if (!xtextDocument.readOnly(TEST_EXISTING_XTEXT_RESOURCE)) {
 				String[] configuredContentTypes = sourceViewerConfiguration.getConfiguredContentTypes(sourceViewer);
 				for (String contentType : configuredContentTypes) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultViewerCreator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultViewerCreator.java
@@ -14,6 +14,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.xtext.ui.UIBindings;
 import org.eclipse.xtext.ui.editor.XtextSourceViewerConfiguration;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -33,6 +34,11 @@ public class DefaultViewerCreator implements IViewerCreator {
 	protected Provider<XtextSourceViewerConfiguration> sourceViewerConfigurationProvider;
 	@Inject(optional=true) @Named(UIBindings.COMPARE_VIEWER_TITLE)
 	protected String compareViewerTitle = "Text Compare";
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	protected XtextDocumentUtil xtextDocumentUtil;
 
 	@Override
 	public Viewer createViewer(Composite parent, CompareConfiguration compareConfiguration) {
@@ -44,7 +50,7 @@ public class DefaultViewerCreator implements IViewerCreator {
 
 	protected Viewer createMergeViewer(Composite parent, CompareConfiguration compareConfiguration) {
 		compareConfiguration.setProperty(DefaultMergeEditor.PROVIDER, mergeEditorProvider);
-		return new DefaultMergeViewer(parent, SWT.NULL, compareConfiguration, documentProvider,
+		DefaultMergeViewer result = new DefaultMergeViewer(parent, SWT.NULL, compareConfiguration, documentProvider,
 				sourceViewerConfigurationProvider) {
 			@Override
 			public String getTitle() {
@@ -54,6 +60,8 @@ public class DefaultViewerCreator implements IViewerCreator {
 				return super.getTitle();
 			}
 		};
+		result.setXtextDocumentUtil(xtextDocumentUtil);
+		return result;
 	}
 
 	protected Viewer createContentViever(Composite parent, CompareConfiguration compareConfiguration) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/PresentationDamager.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/PresentationDamager.java
@@ -34,7 +34,7 @@ import com.google.inject.Inject;
 public class PresentationDamager implements IPresentationDamager {
 
 	@Inject
-	protected DocumentTokenSourceAccess tokenSourceAccess;
+	protected DocumentTokenSourceAccess tokenSourceAccess = new DocumentTokenSourceAccess();
 	
 	@Override
 	public void setDocument(IDocument document) {}
@@ -44,7 +44,7 @@ public class PresentationDamager implements IPresentationDamager {
 		IRegion lastDamage = tokenSourceAccess.getLastDamage(e.getDocument());
 		// check whether this is just a presentation invalidation not based on a real document change
 		if (lastDamage == null || !isEventMatchingLastDamage(e, lastDamage)) {
-			IRegion result = computeInterSection(partition, e, e.getDocument());
+			IRegion result = computeIntersection(partition, e, e.getDocument());
 			return result;
 		}
 		
@@ -65,24 +65,24 @@ public class PresentationDamager implements IPresentationDamager {
 	 * @return the common region of the given partition and the changed region in the DocumentEvent based on the underlying tokens.
 	 * @since 2.19
 	 */
-	protected IRegion computeInterSection(ITypedRegion partition, DocumentEvent e, IDocument document) {
+	protected IRegion computeIntersection(ITypedRegion partition, DocumentEvent e, IDocument document) {
 		if (document instanceof XtextDocument) {
 			// for backwards compatiblity
 			return computeInterSection(partition, e, (XtextDocument) document);
 		}
-		return doComputeInterSection(partition, e, document);
+		return doComputeIntersection(partition, e, document);
 	}
 
 	/**
 	 * @return the common region of the given partition and the changed region in the DocumentEvent based on the underlying tokens.
-	 * @deprecated use {@link #computeInterSection(ITypedRegion, DocumentEvent, IDocument)} instead.
+	 * @deprecated use {@link #computeIntersection(ITypedRegion, DocumentEvent, IDocument)} instead.
 	 */
 	@Deprecated
 	protected IRegion computeInterSection(ITypedRegion partition, DocumentEvent e, XtextDocument document) {
-		return doComputeInterSection(partition, e, document);
+		return doComputeIntersection(partition, e, document);
 	}
 	
-	private IRegion doComputeInterSection(ITypedRegion partition, DocumentEvent e, IDocument document) {
+	private IRegion doComputeIntersection(ITypedRegion partition, DocumentEvent e, IDocument document) {
 		Iterable<ILexerTokenRegion> tokensInPartition = Iterables.filter(tokenSourceAccess.getTokens(document, false), Regions.overlaps(partition.getOffset(), partition.getLength()));
 		Iterator<ILexerTokenRegion> tokens = Iterables.filter(tokensInPartition, Regions.overlaps(e.getOffset(), e.getLength())).iterator();
 		if (tokens.hasNext()) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -96,7 +96,6 @@ import org.eclipse.xtext.ui.editor.model.CommonWordIterator;
 import org.eclipse.xtext.ui.editor.model.DocumentCharacterIterator;
 import org.eclipse.xtext.ui.editor.model.ITokenTypeToPartitionTypeMapperExtension;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
-import org.eclipse.xtext.ui.editor.model.XtextDocument;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentProvider;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess;
@@ -189,6 +188,12 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 	 */
 	@Inject
 	private DirtyStateEditorSupport dirtyStateEditorSupport;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
 
 	private String keyBindingScope;
 
@@ -213,7 +218,11 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 
 	@Override
 	public IXtextDocument getDocument() {
-		return XtextDocumentUtil.get(getSourceViewer());
+		ISourceViewer sourceViewer = getSourceViewer();
+		if (sourceViewer != null) {
+			return xtextDocumentUtil.getXtextDocument(sourceViewer);
+		}
+		return null;
 	}
 
 	@Inject

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -96,6 +96,7 @@ import org.eclipse.xtext.ui.editor.model.CommonWordIterator;
 import org.eclipse.xtext.ui.editor.model.DocumentCharacterIterator;
 import org.eclipse.xtext.ui.editor.model.ITokenTypeToPartitionTypeMapperExtension;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocument;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentProvider;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess;
@@ -104,6 +105,7 @@ import org.eclipse.xtext.ui.editor.reconciler.XtextReconciler;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingHelper;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.TextAttributeProvider;
 import org.eclipse.xtext.ui.editor.toggleComments.ToggleSLCommentAction;
+import org.eclipse.xtext.ui.editor.validation.ValidationJob;
 import org.eclipse.xtext.ui.internal.Activator;
 import org.eclipse.xtext.ui.util.DisplayRunnable;
 
@@ -365,6 +367,10 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 	public <T> T getAdapter(Class<T> adapter) {
 		if (IContentOutlinePage.class.isAssignableFrom(adapter)) {
 			return adapter.cast(getContentOutlinePage());
+		}
+		if (ValidationJob.class.equals(adapter)) {
+			IXtextDocument document = getDocument();
+			return document.getAdapter(adapter);
 		}
 		return super.getAdapter(adapter);
 	}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextInformationProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextInformationProvider.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtext.ui.editor;
 
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IInformationControlCreator;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextHover;
@@ -71,9 +70,9 @@ public class XtextInformationProvider  implements IInformationProvider, IInforma
 	@Override
 	public IRegion getSubject(ITextViewer textViewer, final int offset) {
 		if(textViewer instanceof XtextSourceViewer){
-			IDocument document = ((XtextSourceViewer) textViewer).getDocument();
-			if(document instanceof IXtextDocument){
-				Object resolvedObject = ((IXtextDocument) document).priorityReadOnly(new IUnitOfWork<Object, XtextResource>() {
+			IXtextDocument document = ((XtextSourceViewer) textViewer).getXtextDocument();
+			if (document != null) {
+				Object resolvedObject = document.priorityReadOnly(new IUnitOfWork<Object, XtextResource>() {
 					@Override
 					public Object exec(XtextResource state) throws Exception {
 						return eObjectAtOffsetHelper.resolveElementAt(state, offset);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
@@ -31,6 +31,8 @@ import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 
 import com.google.inject.ImplementedBy;
+import com.google.inject.Inject;
+import com.google.inject.MembersInjector;
 
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
@@ -47,13 +49,27 @@ public class XtextSourceViewer extends ProjectionViewer implements IAdaptable {
 	
 	public static class DefaultFactory implements Factory {
 
+		/**
+		 * @since 2.19
+		 */
+		@Inject
+		private MembersInjector<XtextSourceViewer> membersInjector;
+		
 		@Override
 		public XtextSourceViewer createSourceViewer(Composite parent, IVerticalRuler ruler,
 				IOverviewRuler overviewRuler, boolean showsAnnotationOverview, int styles) {
-			return new XtextSourceViewer(parent, ruler, overviewRuler, showsAnnotationOverview, styles);
+			XtextSourceViewer result = new XtextSourceViewer(parent, ruler, overviewRuler, showsAnnotationOverview, styles);
+			membersInjector.injectMembers(result);
+			return result;
 		}
 		
 	}
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil = new XtextDocumentUtil();
 	
 	public XtextSourceViewer(Composite parent, IVerticalRuler ruler, IOverviewRuler overviewRuler,
 			boolean showsAnnotationOverview, int styles) {
@@ -152,6 +168,6 @@ public class XtextSourceViewer extends ProjectionViewer implements IAdaptable {
 	 * @since 2.19
 	 */
 	public IXtextDocument getXtextDocument() {
-		return XtextDocumentUtil.get(getDocument());
+		return xtextDocumentUtil.getXtextDocument(getDocument());
 	}
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewer.java
@@ -27,6 +27,8 @@ import org.eclipse.jface.text.source.IOverviewRuler;
 import org.eclipse.jface.text.source.IVerticalRuler;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 
 import com.google.inject.ImplementedBy;
 
@@ -131,13 +133,25 @@ public class XtextSourceViewer extends ProjectionViewer implements IAdaptable {
 	}
 
 	/**
+	 * Supported adapter types are {@link IReconciler} and {@link IXtextDocument}.
+	 * 
 	 * @since 2.3
 	 */
 	@Override
 	public <T> T getAdapter(Class<T> adapter) {
-		if (IReconciler.class.isAssignableFrom(adapter)) {
+		if (IReconciler.class.isAssignableFrom(adapter) && adapter.isInstance(fReconciler)) {
 			return adapter.cast(fReconciler);
 		}
+		if (IXtextDocument.class.equals(adapter)) {
+			return adapter.cast(getXtextDocument());
+		}
 		return Platform.getAdapterManager().getAdapter(this, adapter);
+	}
+	
+	/**
+	 * @since 2.19
+	 */
+	public IXtextDocument getXtextDocument() {
+		return XtextDocumentUtil.get(getDocument());
 	}
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewerConfiguration.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextSourceViewerConfiguration.java
@@ -299,6 +299,5 @@ public class XtextSourceViewerConfiguration extends TextSourceViewerConfiguratio
 		presenter.setSizeConstraints(100, 12, true, true);
 		return presenter;
 	}
-
 	
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/ContentAssistContext.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/ContentAssistContext.java
@@ -17,6 +17,7 @@ import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.ITextRegion;
 
 import com.google.common.collect.ImmutableList;
@@ -266,7 +267,7 @@ public class ContentAssistContext {
 	 * The actual document.
 	 */
 	public IXtextDocument getDocument() {
-		return (IXtextDocument) viewer.getDocument();
+		return XtextDocumentUtil.get(viewer);
 	}
 	
 	/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/ContentAssistContext.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/ContentAssistContext.java
@@ -200,6 +200,12 @@ public class ContentAssistContext {
 	private Provider<Builder> builderProvider;
 	
 	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
+	
+	/**
 	 * Protected contructor to allow subclassing.
 	 */
 	protected ContentAssistContext() {
@@ -267,7 +273,7 @@ public class ContentAssistContext {
 	 * The actual document.
 	 */
 	public IXtextDocument getDocument() {
-		return XtextDocumentUtil.get(viewer);
+		return xtextDocumentUtil.getXtextDocument(viewer);
 	}
 	
 	/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/RepeatedContentAssistProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/RepeatedContentAssistProcessor.java
@@ -20,6 +20,7 @@ import org.eclipse.ui.IWorkbenchCommandConstants;
 import org.eclipse.ui.keys.IBindingService;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 
 import com.google.inject.Inject;
 
@@ -77,7 +78,7 @@ public class RepeatedContentAssistProcessor extends XtextContentAssistProcessor 
 			proposalProvider.nextMode();
 			if (currentAssistant != null)
 				currentAssistant.setStatusMessage(getStatusMessage());
-			ICompletionProposal[] result = computeCompletionProposals((IXtextDocument) viewer.getDocument(), proposalComputer);
+			ICompletionProposal[] result = computeCompletionProposals(XtextDocumentUtil.get(viewer), proposalComputer);
 			if (result != null && result.length > 0)
 				return result;
 			if (proposalProvider.isLastMode()) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/RepeatedContentAssistProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/RepeatedContentAssistProcessor.java
@@ -58,8 +58,13 @@ public class RepeatedContentAssistProcessor extends XtextContentAssistProcessor 
 	}
 	
 	@Inject(optional = true)
-	/* @Nullable */
 	private IWorkbench workbench;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
 	
 	private IContentAssistantExtension2 currentAssistant;
 	
@@ -78,7 +83,7 @@ public class RepeatedContentAssistProcessor extends XtextContentAssistProcessor 
 			proposalProvider.nextMode();
 			if (currentAssistant != null)
 				currentAssistant.setStatusMessage(getStatusMessage());
-			ICompletionProposal[] result = computeCompletionProposals(XtextDocumentUtil.get(viewer), proposalComputer);
+			ICompletionProposal[] result = computeCompletionProposals(xtextDocumentUtil.getXtextDocument(viewer), proposalComputer);
 			if (result != null && result.length > 0)
 				return result;
 			if (proposalProvider.isLastMode()) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/XtextContentAssistProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/XtextContentAssistProcessor.java
@@ -61,12 +61,18 @@ public class XtextContentAssistProcessor implements IContentAssistProcessor, Com
 	@Named(value=ERROR_MESSAGE)
 	private String errorMessage = null;
 	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
+	
 	@Override
 	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
 		if (contentProposalProvider == null)
 			return null;
 		
-		IXtextDocument document = XtextDocumentUtil.get(viewer);
+		IXtextDocument document = xtextDocumentUtil.getXtextDocument(viewer);
 		ICompletionProposal[] result = document.priorityReadOnly(createCompletionProposalComputer(viewer, offset));
 		Arrays.sort(result, completionProposalComparator);
 		result = completionProposalPostProcessor.postProcess(result);
@@ -82,7 +88,7 @@ public class XtextContentAssistProcessor implements IContentAssistProcessor, Com
 		if (contextInformationProvider == null)
 			return null;
 		
-		IXtextDocument document = XtextDocumentUtil.get(viewer);
+		IXtextDocument document = xtextDocumentUtil.getXtextDocument(viewer);
 		return document.priorityReadOnly(createContextInformationComputer(viewer, offset));
 	}
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/XtextContentAssistProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/contentassist/XtextContentAssistProcessor.java
@@ -15,6 +15,7 @@ import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -65,7 +66,7 @@ public class XtextContentAssistProcessor implements IContentAssistProcessor, Com
 		if (contentProposalProvider == null)
 			return null;
 		
-		IXtextDocument document = (IXtextDocument) viewer.getDocument();
+		IXtextDocument document = XtextDocumentUtil.get(viewer);
 		ICompletionProposal[] result = document.priorityReadOnly(createCompletionProposalComputer(viewer, offset));
 		Arrays.sort(result, completionProposalComparator);
 		result = completionProposalPostProcessor.postProcess(result);
@@ -81,7 +82,7 @@ public class XtextContentAssistProcessor implements IContentAssistProcessor, Com
 		if (contextInformationProvider == null)
 			return null;
 		
-		IXtextDocument document = (IXtextDocument) viewer.getDocument();
+		IXtextDocument document = XtextDocumentUtil.get(viewer);
 		return document.priorityReadOnly(createContextInformationComputer(viewer, offset));
 	}
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditor.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.ui.editor.embedded;
 import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 import org.eclipse.xtext.ui.editor.XtextSourceViewerConfiguration;
 import org.eclipse.xtext.ui.editor.model.XtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 
 /**
  * Handle for an embedded Xtext editor. It allows to initialize the edited model
@@ -30,7 +31,12 @@ public class EmbeddedEditor {
 	private final XtextSourceViewerConfiguration configuration;
 
 	private final Runnable afterSetDocument;
-
+	
+	/**
+	 * @since 2.19
+	 */
+	private XtextDocumentUtil xtextDocumentUtil = new XtextDocumentUtil();
+	
 	public EmbeddedEditor(XtextDocument document, XtextSourceViewer viewer, XtextSourceViewerConfiguration configuration, IEditedResourceProvider resourceProvider, Runnable afterSetDocumet) {
 		this.document = document;
 		this.viewer = viewer;
@@ -52,6 +58,20 @@ public class EmbeddedEditor {
 	}
 	
 	/**
+	 * @since 2.19
+	 */
+	public void setXtextDocumentUtil(XtextDocumentUtil xtextDocumentUtil) {
+		this.xtextDocumentUtil = xtextDocumentUtil;
+	}
+	
+	/**
+	 * @since 2.19
+	 */
+	public XtextDocumentUtil getXtextDocumentUtil() {
+		return xtextDocumentUtil;
+	}
+	
+	/**
 	 * Obtain the {@link EmbeddedEditorModelAccess model access} for this editor instance. 
  	 * It can be used to query the currently edited text or update it externally.
  	 * The prefix and the suffix will not be visible in the editor. It is possible to 
@@ -60,6 +80,7 @@ public class EmbeddedEditor {
 	 */
 	public EmbeddedEditorModelAccess createPartialEditor(String prefix, String editablePart, String suffix, boolean insertLineBreaks) {
 		EmbeddedEditorModelAccess result = new EmbeddedEditorModelAccess(this.viewer, this.resourceProvider, insertLineBreaks);
+		result.setXtextDocumentUtil(xtextDocumentUtil);
 		result.setModel(getDocument(), prefix, editablePart, suffix);
 		afterSetDocument.run();
 		return result;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorFactory.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorFactory.java
@@ -56,6 +56,7 @@ import org.eclipse.xtext.ui.editor.XtextSourceViewerConfiguration;
 import org.eclipse.xtext.ui.editor.bracketmatching.BracketMatchingPreferencesInitializer;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.XtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.ui.editor.model.edit.IModificationContext;
 import org.eclipse.xtext.ui.editor.model.edit.IssueModificationContext;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess;
@@ -132,6 +133,12 @@ public class EmbeddedEditorFactory {
 		
 		@Inject
 		protected HighlightingHelper highlightingHelper;
+		
+		/**
+		 * @since 2.19
+		 */
+		@Inject
+		protected XtextDocumentUtil xtextDocumentUtil;
 
 		protected IEditedResourceProvider resourceProvider;
 		protected String[] annotationTypes;
@@ -286,6 +293,7 @@ public class EmbeddedEditorFactory {
 							highlightingHelper.install(viewerConfiguration, viewer);
 						}
 					});
+			result.setXtextDocumentUtil(xtextDocumentUtil);
 			viewer.setEditable(!Boolean.TRUE.equals(readonly));
 			viewer.getContentAssistantFacade().addCompletionListener(new ICompletionListener() {
 				

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorModelAccess.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorModelAccess.java
@@ -42,6 +42,11 @@ public class EmbeddedEditorModelAccess {
 	private final boolean insertLineBreaks;
 
 	private final IEditedResourceProvider resourceProvider;
+	
+	/**
+	 * @since 2.19
+	 */
+	private XtextDocumentUtil xtextDocumentUtil = new XtextDocumentUtil();
 
 	public EmbeddedEditorModelAccess(SourceViewer viewer, IEditedResourceProvider resourceProvider,
 			boolean insertLineBreaks) {
@@ -125,7 +130,7 @@ public class EmbeddedEditorModelAccess {
 	}
 	
 	public void updateModel(String model, final IUnitOfWork<ITextRegion, XtextResource> editablePartSelector) {
-		IXtextDocument document = XtextDocumentUtil.get(this.viewer);
+		IXtextDocument document = xtextDocumentUtil.getXtextDocument(this.viewer);
 		this.viewer.setRedraw(false);
 		this.viewer.getUndoManager().disconnect();
 		document.set(model);
@@ -177,4 +182,10 @@ public class EmbeddedEditorModelAccess {
 		return this.viewer.getDocument().get();
 	}
 
+	/**
+	 * @since 2.19
+	 */
+	protected void setXtextDocumentUtil(XtextDocumentUtil xtextDocumentUtil) {
+		this.xtextDocumentUtil = xtextDocumentUtil;
+	}
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorModelAccess.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorModelAccess.java
@@ -20,7 +20,9 @@ import org.eclipse.jface.text.source.SourceViewer;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.XtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.LazyStringInputStream;
 import org.eclipse.xtext.util.TextRegion;
@@ -123,7 +125,7 @@ public class EmbeddedEditorModelAccess {
 	}
 	
 	public void updateModel(String model, final IUnitOfWork<ITextRegion, XtextResource> editablePartSelector) {
-		XtextDocument document = (XtextDocument) this.viewer.getDocument();
+		IXtextDocument document = XtextDocumentUtil.get(this.viewer);
 		this.viewer.setRedraw(false);
 		this.viewer.getUndoManager().disconnect();
 		document.set(model);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting/ContentFormatterFactory.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting/ContentFormatterFactory.java
@@ -21,6 +21,7 @@ import org.eclipse.xtext.formatting.INodeModelFormatter.IFormattedRegion;
 import org.eclipse.xtext.parser.IParseResult;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.ui.editor.reconciler.ReplaceRegion;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 
@@ -31,7 +32,7 @@ public class ContentFormatterFactory implements IContentFormatterFactory {
 	public class ContentFormatter implements IContentFormatter {
 		@Override
 		public void format(IDocument document, IRegion region) {
-			IXtextDocument doc = (IXtextDocument) document;
+			IXtextDocument doc = XtextDocumentUtil.get(document);
 			ReplaceRegion r = doc.priorityReadOnly(new FormattingUnitOfWork(region));
 			try {
 				if (r != null) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting/ContentFormatterFactory.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting/ContentFormatterFactory.java
@@ -32,7 +32,7 @@ public class ContentFormatterFactory implements IContentFormatterFactory {
 	public class ContentFormatter implements IContentFormatter {
 		@Override
 		public void format(IDocument document, IRegion region) {
-			IXtextDocument doc = XtextDocumentUtil.get(document);
+			IXtextDocument doc = xtextDocumentUtil.getXtextDocument(document);
 			ReplaceRegion r = doc.priorityReadOnly(new FormattingUnitOfWork(region));
 			try {
 				if (r != null) {
@@ -78,6 +78,12 @@ public class ContentFormatterFactory implements IContentFormatterFactory {
 
 	@Inject
 	protected INodeModelFormatter formatter;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject 
+	protected XtextDocumentUtil xtextDocumentUtil;
 
 	@Override
 	public IContentFormatter createConfiguredFormatter(

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting2/ContentFormatter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting2/ContentFormatter.java
@@ -73,6 +73,12 @@ public class ContentFormatter implements IContentFormatter {
 
 	@Inject
 	private Provider<FormatterRequest> requestProvider;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject 
+	private XtextDocumentUtil xtextDocumentUtil;
 
 	protected TextEdit createTextEdit(List<ITextReplacement> replacements) {
 		final MultiTextEdit mte = new MultiTextEdit();
@@ -100,7 +106,7 @@ public class ContentFormatter implements IContentFormatter {
 
 	@Override
 	public void format(IDocument document, IRegion region) {
-		IXtextDocument doc = XtextDocumentUtil.get(document);
+		IXtextDocument doc = xtextDocumentUtil.getXtextDocument(document);
 		TextEdit r = doc.priorityReadOnly(new FormattingUnitOfWork(doc, region));
 		try {
 			if (r != null)

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting2/ContentFormatter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/formatting2/ContentFormatter.java
@@ -32,6 +32,7 @@ import org.eclipse.xtext.preferences.IPreferenceValuesProvider;
 import org.eclipse.xtext.preferences.TypedPreferenceValues;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.ExceptionAcceptor;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.TextRegion;
@@ -99,7 +100,7 @@ public class ContentFormatter implements IContentFormatter {
 
 	@Override
 	public void format(IDocument document, IRegion region) {
-		IXtextDocument doc = (IXtextDocument) document;
+		IXtextDocument doc = XtextDocumentUtil.get(document);
 		TextEdit r = doc.priorityReadOnly(new FormattingUnitOfWork(doc, region));
 		try {
 			if (r != null)

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AbstractEObjectHover.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/AbstractEObjectHover.java
@@ -45,10 +45,16 @@ public abstract class AbstractEObjectHover extends AbstractHover implements IEOb
 
 	@Inject
 	private ILocationInFileProvider locationInFileProvider;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
 
 	@Override
 	public IRegion getHoverRegion(final ITextViewer textViewer, final int offset) {
-		IXtextDocument xtextDocument = XtextDocumentUtil.get(textViewer);
+		IXtextDocument xtextDocument = xtextDocumentUtil.getXtextDocument(textViewer);
 		if(xtextDocument == null) 
 			return null;
 		//TODO this is being called on change in the UI-thread. Not a good idea to do such expensive stuff.
@@ -76,7 +82,7 @@ public abstract class AbstractEObjectHover extends AbstractHover implements IEOb
 	public Object getHoverInfo2(final ITextViewer textViewer, final IRegion hoverRegion) {
 		if (hoverRegion == null)
 			return null;
-		IXtextDocument xtextDocument = XtextDocumentUtil.get(textViewer);
+		IXtextDocument xtextDocument = xtextDocumentUtil.getXtextDocument(textViewer);
 		if(xtextDocument == null) 
 			return null;
 		try {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hyperlinking/DefaultHyperlinkDetector.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hyperlinking/DefaultHyperlinkDetector.java
@@ -15,7 +15,7 @@ import org.eclipse.jface.text.hyperlink.IHyperlinkDetector;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.ISourceViewerAware;
-import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 
 import com.google.inject.Inject;
@@ -36,7 +36,7 @@ public class DefaultHyperlinkDetector implements IHyperlinkDetector {
 
 	@Override
 	public IHyperlink[] detectHyperlinks(final ITextViewer textViewer, final IRegion region, final boolean canShowMultipleHyperlinks) {
-		return ((IXtextDocument)textViewer.getDocument()).tryReadOnly(new IUnitOfWork<IHyperlink[],XtextResource>() {
+		return XtextDocumentUtil.get(textViewer).tryReadOnly(new IUnitOfWork<IHyperlink[],XtextResource>() {
 			@Override
 			public IHyperlink[] exec(XtextResource resource) throws Exception {
 				if (helper instanceof ISourceViewerAware && textViewer instanceof ISourceViewer) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hyperlinking/DefaultHyperlinkDetector.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hyperlinking/DefaultHyperlinkDetector.java
@@ -33,10 +33,16 @@ public class DefaultHyperlinkDetector implements IHyperlinkDetector {
 
 	@Inject
 	private IHyperlinkHelper helper;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
 
 	@Override
 	public IHyperlink[] detectHyperlinks(final ITextViewer textViewer, final IRegion region, final boolean canShowMultipleHyperlinks) {
-		return XtextDocumentUtil.get(textViewer).tryReadOnly(new IUnitOfWork<IHyperlink[],XtextResource>() {
+		return xtextDocumentUtil.getXtextDocument(textViewer).tryReadOnly(new IUnitOfWork<IHyperlink[],XtextResource>() {
 			@Override
 			public IHyperlink[] exec(XtextResource resource) throws Exception {
 				if (helper instanceof ISourceViewerAware && textViewer instanceof ISourceViewer) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/DocumentTokenSourceAccess.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/DocumentTokenSourceAccess.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtext.ui.editor.model;
+
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+/**
+ * Provides access to the tokens of an IDocument.
+ * 
+ * @author Sebastian Zarnekow - Initial contribution and API
+ * @since 2.19
+ */
+public class DocumentTokenSourceAccess {
+
+	@Inject
+	private Provider<DocumentTokenSource> tokenSourceProvider;
+	
+	public IRegion getLastDamage(IDocument document) {
+		if (document instanceof XtextDocument) {
+			return ((XtextDocument) document).getLastDamage();
+		}
+		return new Region(0, document.getLength());
+	}
+	
+	public Iterable<ILexerTokenRegion> getTokens(IDocument document, boolean nullIfNotCached) {
+		if (document instanceof XtextDocument) {
+			return ((XtextDocument) document).getTokens();
+		}
+		if (nullIfNotCached) {
+			return null;
+		}
+		DocumentTokenSource tokenSource = tokenSourceProvider.get();
+		tokenSource.computeDamageRegion(new DocumentEvent(document, 0, document.getLength(), document.get()));
+		return tokenSource.getTokenInfos();
+	}
+	
+}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/IXtextDocument.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/IXtextDocument.java
@@ -8,6 +8,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.editor.model;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentExtension3;
 import org.eclipse.xtext.resource.XtextResource;
@@ -21,14 +27,39 @@ import org.eclipse.xtext.util.concurrent.IWriteAccess;
  */
 public interface IXtextDocument extends IDocument, IDocumentExtension3, IReadAccess<XtextResource>, IReadAccess.Priority<XtextResource>, IWriteAccess<XtextResource> {
 
-	public <T> T getAdapter(Class<T> adapterType);
+	/**
+	 * Supported adapter types are {@link IFile}, {@link IResource}, {@link URI} and real supertypes of the implementation class, e.g. all
+	 * document extensions.
+	 */
+	default public <T> T getAdapter(Class<T> adapterType) {
+		if (adapterType.isInstance(this)) {
+			return adapterType.cast(this);
+		}
+		if (URI.class.equals(adapterType)) {
+			return adapterType.cast(getResourceURI());
+		}
+		if (IFile.class.equals(adapterType) || IResource.class.equals(adapterType)) {
+			URI resourceURI = getResourceURI();
+			if (resourceURI.isPlatformResource()) {
+				return adapterType.cast(ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(resourceURI.toPlatformString(true))));
+			}
+		}
+		return Platform.getAdapterManager().getAdapter(this, adapterType);
+	}
+
+	/**
+	 * @since 2.19
+	 */
+	default public URI getResourceURI() {
+		return tryReadOnly(r -> r.getURI());
+	}
 	
 	public void addModelListener(IXtextModelListener listener);
 
 	public void removeModelListener(IXtextModelListener listener);
-	
+
 	void addXtextDocumentContentObserver(IXtextDocumentContentObserver listener);
-	
+
 	void removeXtextDocumentContentObserver(IXtextDocumentContentObserver listener);
 
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/PartitionTokenScanner.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/PartitionTokenScanner.java
@@ -64,7 +64,7 @@ public class PartitionTokenScanner implements IPartitionTokenScanner {
 	@Inject
 	private ITokenTypeToPartitionTypeMapper mapper;
 	@Inject
-	private DocumentTokenSourceAccess tokenSourceAccess;
+	private DocumentTokenSourceAccess tokenSourceAccess = new DocumentTokenSourceAccess();
 	private int currentPartitionLength;
 	
 	public void setMapper(ITokenTypeToPartitionTypeMapper mapper) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/PartitionTokenScanner.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/PartitionTokenScanner.java
@@ -63,6 +63,8 @@ public class PartitionTokenScanner implements IPartitionTokenScanner {
 
 	@Inject
 	private ITokenTypeToPartitionTypeMapper mapper;
+	@Inject
+	private DocumentTokenSourceAccess tokenSourceAccess;
 	private int currentPartitionLength;
 	
 	public void setMapper(ITokenTypeToPartitionTypeMapper mapper) {
@@ -85,7 +87,7 @@ public class PartitionTokenScanner implements IPartitionTokenScanner {
 	}
 
 	protected Iterable<ILexerTokenRegion> getTokens(IDocument document) {
-		return ((XtextDocument) document).getTokens();
+		return tokenSourceAccess.getTokens(document, false);
 	}
 
 	@Override

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocument.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocument.java
@@ -19,13 +19,9 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.log4j.Logger;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
@@ -49,6 +45,7 @@ import org.eclipse.xtext.ui.editor.model.IXtextDocumentContentObserver.Processor
 import org.eclipse.xtext.ui.editor.model.edit.ITextEditComposer;
 import org.eclipse.xtext.ui.editor.model.edit.ReconcilingUnitOfWork;
 import org.eclipse.xtext.ui.editor.model.edit.ReconcilingUnitOfWork.ReconcilingUnitOfWorkProvider;
+import org.eclipse.xtext.ui.editor.validation.ValidationJob;
 import org.eclipse.xtext.ui.util.DisplayRunnable;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.concurrent.CancelableUnitOfWork;
@@ -636,6 +633,7 @@ public class XtextDocument extends Document implements IXtextDocument {
 	 * @return the resource uri if available.
 	 * @since 2.1
 	 */
+	@Override
 	public URI getResourceURI() {
 		XtextResource resource = this.resource;
 		if (resource != null)
@@ -644,16 +642,11 @@ public class XtextDocument extends Document implements IXtextDocument {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T> T getAdapter(Class<T> adapterType) {
-		XtextResource resource = this.resource;
-		if (resource == null)
-			return null;
-		URI uri = resource.getURI();
-		if ((adapterType == IFile.class || adapterType == IResource.class) && uri.isPlatformResource()) {
-			return (T) ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(uri.toPlatformString(true)));
+		if (ValidationJob.class.equals(adapterType)) {
+			return adapterType.cast(validationJob);
 		}
-		return null;
+		return IXtextDocument.super.getAdapter(adapterType);
 	}
 
 	/*

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentUtil.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentUtil.java
@@ -7,14 +7,22 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 
 public class XtextDocumentUtil {
 	
+	/**
+	 * @deprecated Inject an instance of {@link XtextDocumentUtil} instead and use {@link #getXtextDocument(Object)}
+	 * instead. This allows to override the lookup of documents.
+	 */
+	@Deprecated
 	public static IXtextDocument get(Object ctx) {
 		if (ctx instanceof IXtextDocument)
 			return (IXtextDocument) ctx;
 		if (ctx instanceof ProjectionDocument)
 			return get(((ProjectionDocument) ctx).getMasterDocument());
+		if (ctx instanceof XtextSourceViewer)
+			return ((XtextSourceViewer) ctx).getXtextDocument();
 		if (ctx instanceof ITextViewer)
 			return get(((ITextViewer) ctx).getDocument());
 		if (ctx instanceof XtextEditor)
@@ -25,4 +33,12 @@ public class XtextDocumentUtil {
 		}
 		return null;
 	}
+	
+	/**
+	 * @since 2.19
+	 */
+	public IXtextDocument getXtextDocument(Object context) {
+		return get(context);
+	}
+	
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentUtil.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentUtil.java
@@ -1,18 +1,24 @@
 package org.eclipse.xtext.ui.editor.model;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.projection.ProjectionDocument;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.ui.texteditor.DocumentProviderRegistry;
+import org.eclipse.ui.texteditor.IDocumentProvider;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 
 public class XtextDocumentUtil {
 	
 	/**
-	 * @deprecated Inject an instance of {@link XtextDocumentUtil} instead and use {@link #getXtextDocument(Object)}
+	 * @deprecated Inject an instance of {@link XtextDocumentUtil} instead and use {@code getXtextDocument(..)}
 	 * instead. This allows to override the lookup of documents.
 	 */
 	@Deprecated
@@ -37,8 +43,65 @@ public class XtextDocumentUtil {
 	/**
 	 * @since 2.19
 	 */
-	public IXtextDocument getXtextDocument(Object context) {
-		return get(context);
+	public IXtextDocument getXtextDocument(IDocument document) {
+		if (document instanceof IXtextDocument) {
+			return (IXtextDocument) document;
+		}
+		if (document instanceof ProjectionDocument) {
+			return getXtextDocument(((ProjectionDocument) document).getMasterDocument());
+		}
+		return null;
+	}
+	
+	/**
+	 * @since 2.19
+	 */
+	public IXtextDocument getXtextDocument(ITextViewer viewer) {
+		if (viewer instanceof XtextSourceViewer) {
+			return ((XtextSourceViewer) viewer).getXtextDocument();
+		}
+		return getXtextDocument(viewer.getDocument());
+	}
+	
+	/**
+	 * @since 2.19
+	 */
+	public IXtextDocument getXtextDocument(IEditorPart editor) {
+		if (editor instanceof XtextEditor) {
+			return ((XtextEditor) editor).getDocument();
+		}
+		IEditorInput editorInput = editor.getEditorInput();
+		return getXtextDocument(editorInput);
+	}
+
+	/**
+	 * @since 2.19
+	 */
+	public IXtextDocument getXtextDocument(IEditorInput editorInput) {
+		IDocumentProvider documentProvider = DocumentProviderRegistry.getDefault().getDocumentProvider(editorInput);
+		if (documentProvider == null) {
+			return null;
+		}
+		IDocument document = documentProvider.getDocument(editorInput);
+		if (document != null) {
+			return getXtextDocument(document);
+		}
+		return null;
+	}
+	
+	/**
+	 * @since 2.19
+	 */
+	public IXtextDocument getXtextDocument(IResource resource) {
+		if (resource instanceof IFile) {
+			IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+			IEditorPart editor = activePage.findEditor(new FileEditorInput((IFile) resource));
+			if (editor != null) {
+				return getXtextDocument(editor);
+			}
+			return getXtextDocument(new FileEditorInput((IFile) resource));
+		}
+		return null;
 	}
 	
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/outline/impl/OutlinePage.java
@@ -91,6 +91,12 @@ public class OutlinePage extends ContentOutlinePage implements ISourceViewerAwar
 
 	@Inject
 	private OutlineRefreshJob refreshJob;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
 
 	@Override
 	public void createControl(Composite parent) {
@@ -223,7 +229,7 @@ public class OutlinePage extends ContentOutlinePage implements ISourceViewerAwar
 	public void setSourceViewer(ISourceViewer sourceViewer) {
 		this.sourceViewer = sourceViewer;
 		IDocument document = sourceViewer.getDocument();
-		xtextDocument = XtextDocumentUtil.get(document);
+		xtextDocument = xtextDocumentUtil.getXtextDocument(document);
 		Assert.isNotNull(xtextDocument);
 		configureTextInputListener();
 	}
@@ -238,7 +244,7 @@ public class OutlinePage extends ContentOutlinePage implements ISourceViewerAwar
 				try {
 					if (xtextDocument != null && modelListener != null)
 						xtextDocument.removeModelListener(modelListener);
-					xtextDocument = XtextDocumentUtil.get(newInput);
+					xtextDocument = xtextDocumentUtil.getXtextDocument(newInput);
 					if (xtextDocument != null && modelListener != null) {
 						xtextDocument.addModelListener(modelListener);
 						scheduleRefresh();
@@ -309,7 +315,7 @@ public class OutlinePage extends ContentOutlinePage implements ISourceViewerAwar
 						}
 						treeViewer.setInput(rootNode);
 						treeViewer.expandToLevel(1);
-						treeViewer.setExpandedElements(Iterables.toArray(nodesToBeExpanded, IOutlineNode.class));
+						treeViewer.setExpandedElements(Iterables.toArray(nodesToBeExpanded, Object.class));
 						treeViewer.setSelection(new StructuredSelection(Iterables.toArray(selectedNodes,
 								IOutlineNode.class)));
 						treeUpdated();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/AbstractIssueResolutionProviderAdapter.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/AbstractIssueResolutionProviderAdapter.java
@@ -38,8 +38,11 @@ public abstract class AbstractIssueResolutionProviderAdapter {
 		return resolutionProvider;
 	}
 	
+	/**
+	 * @deprecated use {@link IssueResolutionProvider#getResolutions(Issue)} instead. 
+	 */
 	@Deprecated
-	public Iterable<IssueResolution> getResolutions(final Issue issue, final IXtextDocument document) {
+	public Iterable<IssueResolution> getResolutions(Issue issue, IXtextDocument document) {
 		Iterable<IssueResolution> result = resolutionProvider.getResolutions(issue);
 		return result;
 	}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/MarkerResolutionGenerator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/MarkerResolutionGenerator.java
@@ -59,6 +59,12 @@ public class MarkerResolutionGenerator extends AbstractIssueResolutionProviderAd
 	
 	@Inject
 	private TextualMultiModificationWorkbenchMarkerResolutionAdapter.Factory textualMultiModificationAdapterFactory;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
 
 	public IssueUtil getIssueUtil() {
 		return issueUtil;
@@ -145,18 +151,19 @@ public class MarkerResolutionGenerator extends AbstractIssueResolutionProviderAd
 	// handled by org.eclipse.xtext.ui.editor.model.edit.IssueModificationContext.getXtextDocument(URI)
 	@Deprecated
 	public IXtextDocument getXtextDocument(IResource resource) {
-		IXtextDocument result = XtextDocumentUtil.get(resource);
+		IXtextDocument result = xtextDocumentUtil.getXtextDocument(resource);
 		if(result == null) {
 			IWorkbenchPage page = workbench.getActiveWorkbenchWindow().getActivePage();
 			try {
 				IFile file = ResourceUtil.getFile(resource);
 				IEditorInput input = new FileEditorInput(file);
-				page.openEditor(input, getEditorId());
+				IEditorPart newEditor = page.openEditor(input, getEditorId());
+				return xtextDocumentUtil.getXtextDocument(newEditor);
 			} catch (PartInitException e) {
 				return null;
 			}
 		}
-		return XtextDocumentUtil.get(resource);
+		return result;
 	}
 	
 	// handled by org.eclipse.xtext.ui.editor.model.edit.IssueModificationContext.getXtextDocument(URI)

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/XtextQuickAssistProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/XtextQuickAssistProcessor.java
@@ -110,13 +110,10 @@ public class XtextQuickAssistProcessor extends AbstractIssueResolutionProviderAd
 			}
 		}
 		final IDocument document = sourceViewer.getDocument();
-		if (!(document instanceof IXtextDocument))
-			return new ICompletionProposal[0];
-		final IXtextDocument xtextDocument = (IXtextDocument) document;
 		final IAnnotationModel annotationModel = sourceViewer.getAnnotationModel();
 		List<ICompletionProposal> result = Lists.newArrayList();
 		try {
-			Set<Annotation> applicableAnnotations = getApplicableAnnotations(xtextDocument, annotationModel, invocationContext.getOffset());
+			Set<Annotation> applicableAnnotations = getApplicableAnnotations(document, annotationModel, invocationContext.getOffset());
 			result = createQuickfixes(invocationContext, applicableAnnotations);
             selectAndRevealQuickfix(invocationContext, applicableAnnotations, result);
 		} catch (BadLocationException e) {
@@ -147,6 +144,7 @@ public class XtextQuickAssistProcessor extends AbstractIssueResolutionProviderAd
 				final Issue issue = issueUtil.getIssueFromAnnotation(annotation);
 				Position pos = annotationModel.getPosition(annotation);
 				if (issue != null && pos != null) {
+					@SuppressWarnings("deprecation")
 					Iterable<IssueResolution> resolutions = getResolutions(issue, xtextDocument);
 					if (resolutions.iterator().hasNext()) {
 						for (IssueResolution resolution : resolutions) {
@@ -188,9 +186,20 @@ public class XtextQuickAssistProcessor extends AbstractIssueResolutionProviderAd
 	protected void sortQuickfixes(List<ICompletionProposal> quickFixes) {
 		Collections.sort(quickFixes, comparator);
 	}
-
-	protected Set<Annotation> getApplicableAnnotations(final IXtextDocument document, final IAnnotationModel annotationModel,
+	
+	/**
+	 * @since 2.19
+	 */
+	protected Set<Annotation> getApplicableAnnotations(final IDocument document, final IAnnotationModel annotationModel,
 			final int offset) throws BadLocationException {
+		if (document instanceof IXtextDocument) {
+			return getApplicableAnnotations((IXtextDocument)document, annotationModel, offset);
+		}
+		return doGetApplicableAnnotations(document, annotationModel, offset);
+	}
+
+	private Set<Annotation> doGetApplicableAnnotations(final IDocument document, final IAnnotationModel annotationModel, final int offset)
+			throws BadLocationException {
 		final int line = document.getLineOfOffset(offset);
 		final String delim = document.getLineDelimiter(line);
 		final int delimLength = delim != null ? delim.length() : 0;
@@ -262,6 +271,15 @@ public class XtextQuickAssistProcessor extends AbstractIssueResolutionProviderAd
 				nearestAnnotations.add(entry.getKey());
 		}
 		return nearestAnnotations;
+	}
+
+	/**
+	 * Use {@link #getApplicableAnnotations(IDocument, IAnnotationModel, int)} instead.
+	 */
+	@Deprecated
+	protected Set<Annotation> getApplicableAnnotations(final IXtextDocument document, final IAnnotationModel annotationModel,
+			final int offset) throws BadLocationException {
+		return doGetApplicableAnnotations(document, annotationModel, offset);
 	}
 	
 	public IssueUtil getIssueUtil() {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/XtextQuickAssistProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/XtextQuickAssistProcessor.java
@@ -50,6 +50,12 @@ public class XtextQuickAssistProcessor extends AbstractIssueResolutionProviderAd
 	@Inject
 	private ICompletionProposalComparator comparator;
 	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
+	
 	private String errorMessage;
 
 	@Override
@@ -132,7 +138,7 @@ public class XtextQuickAssistProcessor extends AbstractIssueResolutionProviderAd
     	List<ICompletionProposal> result = Lists.newArrayList();
     	ISourceViewer sourceViewer = invocationContext.getSourceViewer();
 		IAnnotationModel annotationModel = sourceViewer.getAnnotationModel();
-		IXtextDocument xtextDocument = XtextDocumentUtil.get(sourceViewer);
+		IXtextDocument xtextDocument = xtextDocumentUtil.getXtextDocument(sourceViewer);
     	for(Annotation annotation : applicableAnnotations) {
 			if (annotation instanceof SpellingAnnotation) {
 				SpellingProblem spellingProblem = ((SpellingAnnotation) annotation).getSpellingProblem();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextDocumentReconcileStrategy.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextDocumentReconcileStrategy.java
@@ -108,7 +108,7 @@ public class XtextDocumentReconcileStrategy implements IReconcilingStrategy, IRe
 	@Override
 	public void setDocument(IDocument document) {
 		if (!(document instanceof XtextDocument)) {
-			throw new IllegalArgumentException("Document must be an " + XtextDocument.class.getSimpleName());
+			throw new IllegalArgumentException("Document must be an " + XtextDocument.class + " but was " + document.getClass().getName());
 		}
 		for (IReconcilingStrategy strategy: strategies) {
 			strategy.setDocument(document);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextReconciler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/reconciler/XtextReconciler.java
@@ -81,6 +81,12 @@ public class XtextReconciler extends Job implements IReconciler {
 	@Inject 
 	private OperationCanceledManager canceledManager;
 	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
+	
 	private LinkedBlockingQueue<DocumentEvent> pendingChanges = new LinkedBlockingQueue<DocumentEvent>();
 
 	/**
@@ -276,7 +282,7 @@ public class XtextReconciler extends Job implements IReconciler {
 			}
 			if (newInput instanceof IXtextDocument) {
 				((IXtextDocument) newInput).addXtextDocumentContentObserver(documentListener);
-				final IXtextDocument document = XtextDocumentUtil.get(textViewer);
+				final IXtextDocument document = xtextDocumentUtil.getXtextDocument(textViewer);
 				strategy.setDocument(document);
 				if (!initalProcessDone && strategy instanceof IReconcilingStrategyExtension) {
 					initalProcessDone = true;
@@ -356,7 +362,7 @@ public class XtextReconciler extends Job implements IReconciler {
 			return Status.OK_STATUS;
 		}
 		long start = System.currentTimeMillis();
-		final IXtextDocument document = XtextDocumentUtil.get(textViewer);
+		final IXtextDocument document = xtextDocumentUtil.getXtextDocument(textViewer);
 		if (document instanceof XtextDocument) {
 			((XtextDocument) document).internalModify(new IUnitOfWork.Void<XtextResource>() {
 				@Override

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/syntaxcoloring/HighlightingReconciler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/syntaxcoloring/HighlightingReconciler.java
@@ -33,6 +33,7 @@ import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.IXtextModelListener;
 import org.eclipse.xtext.ui.editor.model.IXtextModelListenerExtension;
 import org.eclipse.xtext.ui.editor.model.XtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.concurrent.CancelableUnitOfWork;
 
@@ -273,7 +274,7 @@ public class HighlightingReconciler implements ITextInputListener, IXtextModelLi
 		this.sourceViewer = sourceViewer;
 		if (oldCalculator != null || newCalculator != null) {
 			if(editor == null){
-				((IXtextDocument) sourceViewer.getDocument()).addModelListener(this);
+				sourceViewer.getXtextDocument().addModelListener(this);
 			} else if (editor.getDocument() != null)
 				editor.getDocument().addModelListener(this);
 
@@ -291,7 +292,7 @@ public class HighlightingReconciler implements ITextInputListener, IXtextModelLi
 
 		if (sourceViewer.getDocument() != null) {
 			if (oldCalculator != null || newCalculator != null) {
-				XtextDocument document = (XtextDocument) sourceViewer.getDocument();
+				IXtextDocument document = XtextDocumentUtil.get(sourceViewer);
 				document.removeModelListener(this);
 				sourceViewer.removeTextInputListener(this);
 			}
@@ -307,7 +308,7 @@ public class HighlightingReconciler implements ITextInputListener, IXtextModelLi
 	@Override
 	public void inputDocumentAboutToBeChanged(IDocument oldInput, IDocument newInput) {
 		if (oldInput != null)
-			((IXtextDocument) oldInput).removeModelListener(this);
+			XtextDocumentUtil.get(oldInput).removeModelListener(this);
 	}
 
 	/*
@@ -317,7 +318,7 @@ public class HighlightingReconciler implements ITextInputListener, IXtextModelLi
 	public void inputDocumentChanged(IDocument oldInput, IDocument newInput) {
 		if (newInput != null) {
 			refresh();
-			((IXtextDocument) newInput).addModelListener(this);
+			XtextDocumentUtil.get(newInput).addModelListener(this);
 		}
 	}
 
@@ -331,7 +332,7 @@ public class HighlightingReconciler implements ITextInputListener, IXtextModelLi
 				protected IStatus run(IProgressMonitor monitor) {
 					XtextSourceViewer mySourceViewer = sourceViewer;
 					if (mySourceViewer != null) {
-						IXtextDocument document = (IXtextDocument) mySourceViewer.getDocument();
+						IXtextDocument document = mySourceViewer.getXtextDocument();
 						if (document != null) {
 							document.tryReadOnly(new CancelableUnitOfWork<Void,XtextResource>() {
 								@Override

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/syntaxcoloring/HighlightingReconciler.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/syntaxcoloring/HighlightingReconciler.java
@@ -32,7 +32,6 @@ import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.IXtextModelListener;
 import org.eclipse.xtext.ui.editor.model.IXtextModelListenerExtension;
-import org.eclipse.xtext.ui.editor.model.XtextDocument;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.concurrent.CancelableUnitOfWork;
@@ -56,6 +55,12 @@ public class HighlightingReconciler implements ITextInputListener, IXtextModelLi
 	
 	@Inject
 	private ITextAttributeProvider attributeProvider;
+
+	/**
+	 * @since 2.19
+	 */
+	@Inject 
+	private XtextDocumentUtil xtextDocumentUtil;
 	
 	/** The Xtext editor this highlighting reconciler is installed on */
 	private XtextEditor editor;
@@ -292,8 +297,10 @@ public class HighlightingReconciler implements ITextInputListener, IXtextModelLi
 
 		if (sourceViewer.getDocument() != null) {
 			if (oldCalculator != null || newCalculator != null) {
-				IXtextDocument document = XtextDocumentUtil.get(sourceViewer);
-				document.removeModelListener(this);
+				IXtextDocument document = xtextDocumentUtil.getXtextDocument(sourceViewer);
+				if (document != null) {
+					document.removeModelListener(this);
+				}
 				sourceViewer.removeTextInputListener(this);
 			}
 		}
@@ -307,8 +314,12 @@ public class HighlightingReconciler implements ITextInputListener, IXtextModelLi
 	 */
 	@Override
 	public void inputDocumentAboutToBeChanged(IDocument oldInput, IDocument newInput) {
-		if (oldInput != null)
-			XtextDocumentUtil.get(oldInput).removeModelListener(this);
+		if (oldInput != null) {
+			IXtextDocument xtextDocument = xtextDocumentUtil.getXtextDocument(oldInput);
+			if (xtextDocument != null) {
+				xtextDocument.removeModelListener(this);
+			}
+		}
 	}
 
 	/*
@@ -318,7 +329,10 @@ public class HighlightingReconciler implements ITextInputListener, IXtextModelLi
 	public void inputDocumentChanged(IDocument oldInput, IDocument newInput) {
 		if (newInput != null) {
 			refresh();
-			XtextDocumentUtil.get(newInput).addModelListener(this);
+			IXtextDocument xtextDocument = xtextDocumentUtil.getXtextDocument(newInput);
+			if (xtextDocument != null) {
+				xtextDocument.addModelListener(this);
+			}
 		}
 	}
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/syntaxcoloring/TokenScanner.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/syntaxcoloring/TokenScanner.java
@@ -15,6 +15,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.rules.IToken;
 import org.eclipse.jface.text.rules.Token;
+import org.eclipse.xtext.ui.editor.model.DocumentTokenSourceAccess;
 import org.eclipse.xtext.ui.editor.model.ILexerTokenRegion;
 import org.eclipse.xtext.ui.editor.model.Regions;
 import org.eclipse.xtext.ui.editor.model.XtextDocument;
@@ -123,6 +124,8 @@ public class TokenScanner extends AbstractTokenScanner {
 
 	@Inject
 	private AbstractAntlrTokenToAttributeIdMapper tokenIdMapper;
+	@Inject
+	private DocumentTokenSourceAccess tokenSourceAccess;
 
 	public void setTokenIdMapper(AbstractAntlrTokenToAttributeIdMapper tokenIdMapper) {
 		this.tokenIdMapper = tokenIdMapper;
@@ -135,14 +138,14 @@ public class TokenScanner extends AbstractTokenScanner {
 	}
 
 	protected Iterable<ILexerTokenRegion> getTokens(IDocument document) {
-		if (!(document instanceof XtextDocument)) {
+		Iterable<ILexerTokenRegion> result = tokenSourceAccess.getTokens(document, true);
+		if (result == null) {
 			// User might have selected a non-xtext document in e.g. a compare operation.
 			// Return an empty iterable, this will disable syntax highlighting
 			// for the "non-xtext editor".
 			return Collections.emptyList();
 		}
-		XtextDocument doc = (XtextDocument) document;
-		return doc.getTokens();
+		return result;
 	}
 
 	@Override

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/SyncUtil.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/SyncUtil.java
@@ -28,7 +28,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.ui.editor.XtextEditor;
-import org.eclipse.xtext.ui.editor.model.XtextDocument;
+import org.eclipse.xtext.ui.editor.validation.ValidationJob;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 
 import com.google.inject.Inject;
@@ -133,7 +133,7 @@ public class SyncUtil {
 				}
 			});
 			// reconciling schedules both, validation and dirty state
-			Job validationJob = ((XtextDocument)editor.getDocument()).getValidationJob();
+			Job validationJob = editor.getAdapter(ValidationJob.class);
 			if (validationJob != null) {
 				validationJob.join();
 			}

--- a/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.xtend
+++ b/org.eclipse.xtext.xbase.ui.tests/src/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.xtend
@@ -14,7 +14,6 @@ import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.testing.logging.LoggingTester
-import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
 import org.eclipse.xtext.ui.testing.AbstractEditorTest
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
 import org.eclipse.xtext.ui.testing.util.TargetPlatformUtil
@@ -52,7 +51,7 @@ class Bug462047Test extends AbstractEditorTest {
 		IResourcesSetupUtil.assertNoErrorsInWorkspace
 		LoggingTester.captureLogging(Level.ERROR, BatchLinkableResource) [
 			val editor = openEditor(file)
-			val document = XtextDocumentUtil.get(editor)
+			val document = editor.document
 			document.readOnly [ XtextResource res |
 				EcoreUtil.resolveAll(res)
 				val resourceSet = res.resourceSet

--- a/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.java
+++ b/org.eclipse.xtext.xbase.ui.tests/xtend-gen/org/eclipse/xtext/xbase/ui/tests/bug462047/Bug462047Test.java
@@ -18,7 +18,6 @@ import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.testing.logging.LoggingTester;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
-import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.ui.testing.AbstractEditorTest;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.TargetPlatformUtil;
@@ -69,7 +68,7 @@ public class Bug462047Test extends AbstractEditorTest {
       final Runnable _function = () -> {
         try {
           final XtextEditor editor = this.openEditor(file);
-          final IXtextDocument document = XtextDocumentUtil.get(editor);
+          final IXtextDocument document = editor.getDocument();
           final IUnitOfWork<Object, XtextResource> _function_1 = (XtextResource res) -> {
             EcoreUtil.resolveAll(res);
             final ResourceSet resourceSet = res.getResourceSet();

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/XbaseDocumentProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/XbaseDocumentProvider.java
@@ -64,7 +64,7 @@ public class XbaseDocumentProvider extends XtextDocumentProvider {
 
 	@Override
 	protected boolean setDocumentContent(IDocument document, IEditorInput input, String encoding) throws CoreException {
-		if (input instanceof IClassFileEditorInput) {
+		if (input instanceof IClassFileEditorInput && document instanceof XtextDocument) {
 			IClassFile classFile = ((IClassFileEditorInput) input).getClassFile();
 			ILocationInEclipseResource source = getClassFileSourceStorage(classFile);
 			if (source == null) {

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseDispatchingEObjectTextHover.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/hover/XbaseDispatchingEObjectTextHover.java
@@ -50,6 +50,12 @@ public class XbaseDispatchingEObjectTextHover extends DispatchingEObjectTextHove
 	@Inject
 	private IJavaDocTypeReferenceProvider javaDocTypeReferenceProvider;
 	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
+	
 	@Override
 	public Object getHoverInfo2(ITextViewer textViewer, IRegion hoverRegion) {
 		IInformationControlCreatorProvider creatorProvider = javaDebugHoverProvider
@@ -63,7 +69,7 @@ public class XbaseDispatchingEObjectTextHover extends DispatchingEObjectTextHove
 	
 	@Override
 	public IRegion getHoverRegion(ITextViewer textViewer, int offset) {
-		IXtextDocument xtextDocument = XtextDocumentUtil.get(textViewer);
+		IXtextDocument xtextDocument = xtextDocumentUtil.getXtextDocument(textViewer);
 		if(xtextDocument == null || offset<0 || xtextDocument.getLength() < offset) 
 			return null;
 		@SuppressWarnings("restriction")

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/templates/XbaseTemplateContext.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/templates/XbaseTemplateContext.java
@@ -27,7 +27,8 @@ import org.eclipse.xtext.common.types.util.TypeReferences;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.scoping.IScopeProvider;
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext;
-import org.eclipse.xtext.ui.editor.model.XtextDocument;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.ui.editor.templates.XtextTemplateContext;
 import org.eclipse.xtext.util.ReplaceRegion;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
@@ -62,6 +63,12 @@ public class XbaseTemplateContext extends XtextTemplateContext {
 
 	@Inject
 	private ReplaceConverter replaceConverter;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
 
 	private List<String> imports = new ArrayList<String>();
 
@@ -79,7 +86,7 @@ public class XbaseTemplateContext extends XtextTemplateContext {
 
 	@Override
 	public TemplateBuffer evaluate(Template template) throws BadLocationException, TemplateException {
-		XtextDocument xDocument = (XtextDocument) getDocument();
+		IXtextDocument xDocument = xtextDocumentUtil.getXtextDocument(getDocument());
 		// Ensure clean state before evaluation starts
 		imports.clear();
 		TemplateBuffer resolvedContent = super.evaluate(template);
@@ -113,7 +120,7 @@ public class XbaseTemplateContext extends XtextTemplateContext {
 		return resolvedContent;
 	}
 
-	private List<ReplaceRegion> createImports(final List<String> types, XtextDocument document) {
+	private List<ReplaceRegion> createImports(final List<String> types, IXtextDocument document) {
 		return document.priorityReadOnly(new IUnitOfWork<List<ReplaceRegion>, XtextResource>() {
 			@Override
 			public List<ReplaceRegion> exec(XtextResource state) throws Exception {
@@ -129,7 +136,7 @@ public class XbaseTemplateContext extends XtextTemplateContext {
 		});
 	}
 
-	private boolean checkImports(final List<String> types, XtextDocument document) {
+	private boolean checkImports(final List<String> types, IXtextDocument document) {
 		return document.priorityReadOnly(new IUnitOfWork<Boolean, XtextResource>() {
 			@Override
 			public Boolean exec(XtextResource state) throws Exception {
@@ -156,7 +163,7 @@ public class XbaseTemplateContext extends XtextTemplateContext {
 	public boolean canEvaluate(Template template) {
 		boolean canEvaluate = super.canEvaluate(template);
 		if (canEvaluate && !imports.isEmpty()) {
-			XtextDocument xDocument = (XtextDocument) getDocument();
+			IXtextDocument xDocument = xtextDocumentUtil.getXtextDocument(getDocument());
 			return checkImports(imports, xDocument);
 		}
 		return canEvaluate;

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.xtend
@@ -17,7 +17,7 @@ import org.eclipse.xtext.example.arithmetics.arithmetics.Module
 import org.eclipse.xtext.example.arithmetics.interpreter.Calculator
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.eclipse.xtext.resource.XtextResource
-import org.eclipse.xtext.ui.editor.model.IXtextDocument
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
 
 /** 
  * An interactive interpreter as an {@link IAutoEditStrategy}
@@ -43,7 +43,7 @@ class InterpreterAutoEdit implements IAutoEditStrategy {
 	}
 
 	def private BigDecimal computeResult(IDocument document, DocumentCommand command) {
-		return ((document as IXtextDocument)).tryReadOnly([ resource |
+		return XtextDocumentUtil.get(document).tryReadOnly([ resource |
 			val stmt = findEvaluation(command, resource)
 			if(stmt === null) 
 				return null

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.xtend
@@ -18,11 +18,14 @@ import org.eclipse.xtext.example.arithmetics.interpreter.Calculator
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
+import com.google.inject.Inject
 
 /** 
  * An interactive interpreter as an {@link IAutoEditStrategy}
  */
 class InterpreterAutoEdit implements IAutoEditStrategy {
+	
+	@Inject extension XtextDocumentUtil
 
 	override void customizeDocumentCommand(IDocument document, DocumentCommand command) {
 		for (lineDelimiter : document.legalLineDelimiters) {
@@ -43,7 +46,7 @@ class InterpreterAutoEdit implements IAutoEditStrategy {
 	}
 
 	def private BigDecimal computeResult(IDocument document, DocumentCommand command) {
-		return XtextDocumentUtil.get(document).tryReadOnly([ resource |
+		return document.xtextDocument.tryReadOnly([ resource |
 			val stmt = findEvaluation(command, resource)
 			if(stmt === null) 
 				return null

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.java
@@ -9,6 +9,7 @@ package org.eclipse.xtext.example.arithmetics.ui.autoedit;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
+import com.google.inject.Inject;
 import java.math.BigDecimal;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentCommand;
@@ -22,6 +23,7 @@ import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
 /**
@@ -29,6 +31,10 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
  */
 @SuppressWarnings("all")
 public class InterpreterAutoEdit implements IAutoEditStrategy {
+  @Inject
+  @Extension
+  private XtextDocumentUtil _xtextDocumentUtil;
+  
   @Override
   public void customizeDocumentCommand(final IDocument document, final DocumentCommand command) {
     String[] _legalLineDelimiters = document.getLegalLineDelimiters();
@@ -64,7 +70,7 @@ public class InterpreterAutoEdit implements IAutoEditStrategy {
       }
       return this.evaluate(stmt);
     };
-    return XtextDocumentUtil.get(document).<BigDecimal>tryReadOnly(_function);
+    return this._xtextDocumentUtil.getXtextDocument(document).<BigDecimal>tryReadOnly(_function);
   }
   
   protected BigDecimal evaluate(final Evaluation stmt) {

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/autoedit/InterpreterAutoEdit.java
@@ -19,7 +19,7 @@ import org.eclipse.xtext.example.arithmetics.interpreter.Calculator;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
@@ -64,7 +64,7 @@ public class InterpreterAutoEdit implements IAutoEditStrategy {
       }
       return this.evaluate(stmt);
     };
-    return ((IXtextDocument) document).<BigDecimal>tryReadOnly(_function);
+    return XtextDocumentUtil.get(document).<BigDecimal>tryReadOnly(_function);
   }
   
   protected BigDecimal evaluate(final Evaluation stmt) {


### PR DESCRIPTION
This is a preparation for text file buffer based Xtext documents. The lookup of IXtextDocument from a given IDocument was extracted into an injectable service.