### PR TITLE
[eclipse/xtext-lib#224] Stable method order when using Delegate

### DIFF
--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/hierarchy/DeferredHierarchyBuilder.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/editor/hierarchy/DeferredHierarchyBuilder.java
@@ -104,6 +104,10 @@ public class DeferredHierarchyBuilder implements IHierarchyBuilder {
       return this.delegate.getElement();
     }
     
+    public Object getNavigationElement() {
+      return this.delegate.getNavigationElement();
+    }
+    
     public IHierarchyNode getParent() {
       return this.delegate.getParent();
     }
@@ -118,10 +122,6 @@ public class DeferredHierarchyBuilder implements IHierarchyBuilder {
     
     public boolean mayHaveChildren() {
       return this.delegate.mayHaveChildren();
-    }
-    
-    public Object getNavigationElement() {
-      return this.delegate.getNavigationElement();
     }
   }
   


### PR DESCRIPTION
[eclipse/xtext-lib#224] Stable method order when using Delegate annotation