### PR TITLE
[eclipse/xtext#1425] show number of matches in ReferenceSearchViewPage

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/Messages.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/Messages.java
@@ -19,6 +19,7 @@ public class Messages extends NLS {
 	public static String FindReferencesHandler_3;
 	public static String FindReferencesHandler_labelPrefix;
 	public static String ReferenceQuery_monitor;
+	public static String ReferenceSearchResult_Matches;
 	public static String ReferenceSearchResultContentProvider_label;
 	public static String ReferenceSearchResultLabelProvider_invalid;
 	public static String ReferenceSearchViewPage_busyLabel;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceSearchResultContentProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceSearchResultContentProvider.java
@@ -8,11 +8,13 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.search.ui.ISearchResultListener;
 import org.eclipse.search.ui.SearchResultEvent;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.progress.UIJob;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.IReferenceDescription;
@@ -197,8 +199,26 @@ public class ReferenceSearchResultContentProvider implements ITreeContentProvide
 				}
 			}
 			viewer.refresh();
-			viewer.expandToLevel(1);
+			expandToFirstChild();
 			return Status.OK_STATUS;
+		}
+	}
+	
+
+	private void expandToFirstChild() {
+		if (rootNodes != null && !rootNodes.isEmpty()){
+			ReferenceSearchViewTreeNode[] rootNodesArray = Iterables.toArray(
+					rootNodes, ReferenceSearchViewTreeNode.class);
+			//find the top element
+			viewer.getComparator().sort(viewer, rootNodesArray);
+			
+			ReferenceSearchViewTreeNode topElement = rootNodesArray[0];
+			Object[] firstChildren = topElement.getChildren().toArray();
+			
+			if (firstChildren.length >= 0) {
+				viewer.getSorter().sort(viewer, firstChildren);
+				viewer.setSelection(new StructuredSelection(firstChildren[0]), true);
+			}
 		}
 	}
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceSearchResultEvents.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceSearchResultEvents.java
@@ -2,6 +2,7 @@ package org.eclipse.xtext.ui.editor.findrefs;
 
 import org.eclipse.search.ui.ISearchResult;
 import org.eclipse.search.ui.SearchResultEvent;
+import org.eclipse.xtext.ide.serializer.hooks.IReferenceSnapshot;
 import org.eclipse.xtext.resource.IReferenceDescription;
 
 /**
@@ -20,6 +21,20 @@ public interface ReferenceSearchResultEvents {
 
 		public IReferenceDescription getReferenceDescription() {
 			return referenceDescription;
+		}
+	}
+	
+	public static class Removed extends SearchResultEvent {
+		private static final long serialVersionUID = 1L;
+		private final IReferenceDescription[] removedDescriptions;
+		
+		public Removed(ISearchResult searchResult, IReferenceDescription[] removedDescriptions) {
+			super(searchResult);
+			this.removedDescriptions = removedDescriptions;
+		}
+		
+		public IReferenceDescription[] getRemovedDescriptions() {
+			return removedDescriptions;
 		}
 	}
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceSearchViewTreeNode.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceSearchViewTreeNode.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.xtext.ide.editor.navigation.INavigatable;
+import org.eclipse.xtext.resource.IReferenceDescription;
+import org.eclipse.xtext.util.IAcceptor;
 
 import com.google.common.collect.Lists;
 
@@ -73,5 +75,17 @@ public class ReferenceSearchViewTreeNode implements INavigatable {
 	public Object getNavigationElement() {
 		return getDescription();
 	}
-
+	
+	/**
+	 * recursively collects the node's description into the given {@link IAcceptor} including the node's children.
+	 * Only IReferenceDescriptions are collected
+	 */
+	public void collectReferenceDescriptions(IAcceptor<IReferenceDescription> descriptionsAcceptor) {
+		if(description instanceof IReferenceDescription) {
+			descriptionsAcceptor.accept((IReferenceDescription) description);
+		}
+		for (ReferenceSearchViewTreeNode child : getChildren()) {
+			child.collectReferenceDescriptions(descriptionsAcceptor);
+		}
+	}
 }

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/messages.properties
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/messages.properties
@@ -3,6 +3,7 @@ FindReferencesHandler_2=)
 FindReferencesHandler_3=Error finding references
 FindReferencesHandler_labelPrefix=Xtext References to 
 ReferenceQuery_monitor=Find Xtext references
+ReferenceSearchResult_Matches=Matches
 ReferenceSearchResultContentProvider_label=ReferenceSearchViewUpdater
 ReferenceSearchResultLabelProvider_invalid=<invalid>
 ReferenceSearchViewPage_busyLabel=Searching...


### PR DESCRIPTION
The Find-References page now shows number of matches as a suffix in the
label that describes the search result.
The label is refreshed when the search finished - not after every single
hit was added to search result to avoid extensive redraws.

Signed-off-by: Mathias Rieder <mathias.rieder@gmail.com>