### PR TITLE
[#1192] Domainmodel Example: Harmozie whitespaces in template proposals.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/ContentAssistTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/ContentAssistTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,14 +35,14 @@ class ContentAssistTest extends AbstractContentAssistTest {
 	@Test def void testEntityTemplateProposal() {
 		newBuilder.applyProposal("Entity - template for an Entity").expectContent('''
 		entity name {
-			 
+			
 		}''')
 	}
 
 	@Test def void testPackageTemplateProposal() {
 		newBuilder.applyProposal("Package - template for a Package").expectContent('''
-		package name { 
-		       
+		package name {
+			
 		}''')
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/ContentAssistTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/ContentAssistTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -58,7 +58,7 @@ public class ContentAssistTest extends AbstractContentAssistTest {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("entity name {");
       _builder.newLine();
-      _builder.append("\t ");
+      _builder.append("\t");
       _builder.newLine();
       _builder.append("}");
       _applyProposal.expectContent(_builder.toString());
@@ -72,9 +72,9 @@ public class ContentAssistTest extends AbstractContentAssistTest {
     try {
       ContentAssistProcessorTestBuilder _applyProposal = this.newBuilder().applyProposal("Package - template for a Package");
       StringConcatenation _builder = new StringConcatenation();
-      _builder.append("package name { ");
+      _builder.append("package name {");
       _builder.newLine();
-      _builder.append("       ");
+      _builder.append("\t");
       _builder.newLine();
       _builder.append("}");
       _applyProposal.expectContent(_builder.toString());

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/templates/templates.xml
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/templates/templates.xml
@@ -3,15 +3,15 @@
     <template name="Package" description="template for a Package"
         id="org.eclipse.xtext.example.domainmodel.Domainmodel.PackageDeclaration"
         context="org.eclipse.xtext.example.domainmodel.Domainmodel.PackageDeclaration"
-        enabled="true">package ${name} { 
-    ${cursor}   
+        enabled="true">package ${name} {
+	${cursor}
 }</template>
     <template name="Entity" description="template for an Entity"
         id="org.eclipse.xtext.example.domainmodel.Domainmodel.Entity"
         context="org.eclipse.xtext.example.domainmodel.Domainmodel.Entity"
         enabled="true"
 >entity ${name} {
-	${cursor} 
+	${cursor}
 }</template>
     <template name="Property" description="template for a Property"
         id="org.eclipse.xtext.example.domainmodel.Domainmodel.Property"


### PR DESCRIPTION
- Use correct the whitespaces in the template.xml file.
- Adapt the corresponding ContentAssistTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>