### PR TITLE
Xtext Arithmetics Example: Clean up AutoEditTest.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/autoedit/AutoEditTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/autoedit/AutoEditTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,6 @@ import java.util.Collections
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.runtime.CoreException
 import org.eclipse.core.runtime.NullProgressMonitor
-import org.eclipse.xtext.example.arithmetics.ui.internal.ArithmeticsActivator
 import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider
 import org.eclipse.xtext.resource.FileExtensionProvider
 import org.eclipse.xtext.testing.InjectWith
@@ -57,10 +56,6 @@ class AutoEditTest extends AbstractAutoEditTest {
 
 	override protected getFileExtension() {
 		extensionProvider.primaryFileExtension
-	}
-
-	override protected getEditorId() {
-		ArithmeticsActivator.ORG_ECLIPSE_XTEXT_EXAMPLE_ARITHMETICS_ARITHMETICS
 	}
 
 	def protected IProject createPluginProject(String name) throws CoreException {

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/autoedit/AutoEditTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/autoedit/AutoEditTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.example.arithmetics.ui.internal.ArithmeticsActivator;
 import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider;
 import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.testing.InjectWith;
@@ -87,11 +86,6 @@ public class AutoEditTest extends AbstractAutoEditTest {
   @Override
   protected String getFileExtension() {
     return this.extensionProvider.getPrimaryFileExtension();
-  }
-  
-  @Override
-  protected String getEditorId() {
-    return ArithmeticsActivator.ORG_ECLIPSE_XTEXT_EXAMPLE_ARITHMETICS_ARITHMETICS;
   }
   
   protected IProject createPluginProject(final String name) throws CoreException {


### PR DESCRIPTION
- Eliminate unnecessary getEditorId() method that does the same as the
super implementation.

- This PR is an appendum to https://github.com/eclipse/xtext-eclipse/commit/ae7f9b8f2b9a7a92bce352ab79baf106fd0c4035#diff-c376f0d7106ef132b9b489fd869fddf1

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>