### PR TITLE
Xtext Examples: Clean up the Export-Package section of the MANIFEST.MF

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/META-INF/MANIFEST.MF
@@ -18,8 +18,8 @@ Require-Bundle: org.eclipse.xtext.example.arithmetics,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.xtext.example.arithmetics.ui.internal,
- org.eclipse.xtext.example.arithmetics.ui.quickfix,
- org.eclipse.xtext.example.arithmetics.ui.contentassist
+Export-Package: org.eclipse.xtext.example.arithmetics.ui.contentassist,
+ org.eclipse.xtext.example.arithmetics.ui.internal,
+ org.eclipse.xtext.example.arithmetics.ui.quickfix
 Bundle-Activator: org.eclipse.xtext.example.arithmetics.ui.internal.ArithmeticsActivator
 Automatic-Module-Name: org.eclipse.xtext.example.arithmetics.ui

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ide/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Require-Bundle: org.eclipse.xtext.example.domainmodel,
  org.eclipse.xtext.xbase.ide,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.xtext.example.domainmodel.ide.contentassist.antlr.internal,
- org.eclipse.xtext.example.domainmodel.ide.contentassist.antlr
+Export-Package: org.eclipse.xtext.example.domainmodel.ide.contentassist.antlr,
+ org.eclipse.xtext.example.domainmodel.ide.contentassist.antlr.internal
 Automatic-Module-Name: org.eclipse.xtext.example.domainmodel.ide
-

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/META-INF/MANIFEST.MF
@@ -23,15 +23,15 @@ Require-Bundle: org.eclipse.xtext.example.domainmodel,
 Import-Package: org.apache.log4j,
  org.eclipse.xtext.ui.codemining;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.xtext.example.domainmodel.ui.contentassist,
- org.eclipse.xtext.example.domainmodel.ui.autoedit,
+Export-Package: org.eclipse.xtext.example.domainmodel.ui.autoedit,
+ org.eclipse.xtext.example.domainmodel.ui.contentassist,
+ org.eclipse.xtext.example.domainmodel.ui.editor,
  org.eclipse.xtext.example.domainmodel.ui.internal,
  org.eclipse.xtext.example.domainmodel.ui.labeling,
  org.eclipse.xtext.example.domainmodel.ui.linking,
  org.eclipse.xtext.example.domainmodel.ui.navigation,
  org.eclipse.xtext.example.domainmodel.ui.outline,
  org.eclipse.xtext.example.domainmodel.ui.quickfix,
- org.eclipse.xtext.example.domainmodel.ui.search,
- org.eclipse.xtext.example.domainmodel.ui.editor
+ org.eclipse.xtext.example.domainmodel.ui.search
 Bundle-Activator: org.eclipse.xtext.example.domainmodel.ui.internal.DomainmodelActivator
 Automatic-Module-Name: org.eclipse.xtext.example.domainmodel.ui

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/META-INF/MANIFEST.MF
@@ -17,17 +17,17 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.common.types,
  org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.xtext.example.domainmodel.serializer,
- org.eclipse.xtext.example.domainmodel.parser.antlr.internal,
- org.eclipse.xtext.example.domainmodel.services,
- org.eclipse.xtext.example.domainmodel.parser.antlr,
- org.eclipse.xtext.example.domainmodel.validation,
- org.eclipse.xtext.example.domainmodel.domainmodel.impl,
- org.eclipse.xtext.example.domainmodel.scoping,
- org.eclipse.xtext.example.domainmodel.domainmodel.util,
- org.eclipse.xtext.example.domainmodel,
+Export-Package: org.eclipse.xtext.example.domainmodel,
  org.eclipse.xtext.example.domainmodel.domainmodel,
+ org.eclipse.xtext.example.domainmodel.domainmodel.impl,
+ org.eclipse.xtext.example.domainmodel.domainmodel.util,
+ org.eclipse.xtext.example.domainmodel.formatting2,
  org.eclipse.xtext.example.domainmodel.jvmmodel,
- org.eclipse.xtext.example.domainmodel.formatting2
+ org.eclipse.xtext.example.domainmodel.parser.antlr,
+ org.eclipse.xtext.example.domainmodel.parser.antlr.internal,
+ org.eclipse.xtext.example.domainmodel.scoping,
+ org.eclipse.xtext.example.domainmodel.serializer,
+ org.eclipse.xtext.example.domainmodel.services,
+ org.eclipse.xtext.example.domainmodel.validation
 Import-Package: org.apache.log4j
 Automatic-Module-Name: org.eclipse.xtext.example.domainmodel

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ide/META-INF/MANIFEST.MF
@@ -11,6 +11,6 @@ Require-Bundle: org.eclipse.xtext.example.fowlerdsl,
  org.eclipse.xtext.xbase.lib
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.xtext.example.fowlerdsl.ide.contentassist.antlr.internal,
- org.eclipse.xtext.example.fowlerdsl.ide.contentassist.antlr
+Export-Package: org.eclipse.xtext.example.fowlerdsl.ide.contentassist.antlr,
+ org.eclipse.xtext.example.fowlerdsl.ide.contentassist.antlr.internal
 Automatic-Module-Name: org.eclipse.xtext.example.fowlerdsl.ide

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/META-INF/MANIFEST.MF
@@ -20,8 +20,8 @@ Require-Bundle: org.eclipse.xtext.example.fowlerdsl;visibility:=reexport,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.xtext.example.fowlerdsl.ui.quickfix,
- org.eclipse.xtext.example.fowlerdsl.ui.contentassist,
- org.eclipse.xtext.example.fowlerdsl.ui.internal
+Export-Package: org.eclipse.xtext.example.fowlerdsl.ui.contentassist,
+ org.eclipse.xtext.example.fowlerdsl.ui.internal,
+ org.eclipse.xtext.example.fowlerdsl.ui.quickfix
 Bundle-Activator: org.eclipse.xtext.example.fowlerdsl.ui.internal.FowlerdslActivator
 Automatic-Module-Name: org.eclipse.xtext.example.fowlerdsl.ui

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/META-INF/MANIFEST.MF
@@ -17,16 +17,15 @@ Require-Bundle: org.eclipse.xtext,
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.fowlerdsl,
+ org.eclipse.xtext.example.fowlerdsl.formatting2,
+ org.eclipse.xtext.example.fowlerdsl.generator,
+ org.eclipse.xtext.example.fowlerdsl.parser.antlr,
+ org.eclipse.xtext.example.fowlerdsl.parser.antlr.internal,
+ org.eclipse.xtext.example.fowlerdsl.scoping,
+ org.eclipse.xtext.example.fowlerdsl.serializer,
  org.eclipse.xtext.example.fowlerdsl.services,
  org.eclipse.xtext.example.fowlerdsl.statemachine,
  org.eclipse.xtext.example.fowlerdsl.statemachine.impl,
  org.eclipse.xtext.example.fowlerdsl.statemachine.util,
- org.eclipse.xtext.example.fowlerdsl.serializer,
- org.eclipse.xtext.example.fowlerdsl.parser.antlr,
- org.eclipse.xtext.example.fowlerdsl.parser.antlr.internal,
- org.eclipse.xtext.example.fowlerdsl.validation,
- org.eclipse.xtext.example.fowlerdsl.scoping,
- org.eclipse.xtext.example.fowlerdsl.generator,
- org.eclipse.xtext.example.fowlerdsl.formatting2
+ org.eclipse.xtext.example.fowlerdsl.validation
 Automatic-Module-Name: org.eclipse.xtext.example.fowlerdsl
-

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui/META-INF/MANIFEST.MF
@@ -22,8 +22,8 @@ Require-Bundle: org.eclipse.xtext.example.homeautomation,
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.ui.contentassist,
- org.eclipse.xtext.example.homeautomation.ui.quickfix,
+ org.eclipse.xtext.example.homeautomation.ui.editor,
  org.eclipse.xtext.example.homeautomation.ui.internal,
- org.eclipse.xtext.example.homeautomation.ui.editor
+ org.eclipse.xtext.example.homeautomation.ui.quickfix
 Bundle-Activator: org.eclipse.xtext.example.homeautomation.ui.internal.HomeautomationActivator
 Automatic-Module-Name: org.eclipse.xtext.example.homeautomation.ui

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/META-INF/MANIFEST.MF
@@ -17,18 +17,18 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.common.types,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.xtext.example.homeautomation.ruleEngine.util,
+Export-Package: org.eclipse.xtext.example.homeautomation,
+ org.eclipse.xtext.example.homeautomation.formatting2,
+ org.eclipse.xtext.example.homeautomation.jvmmodel,
+ org.eclipse.xtext.example.homeautomation.parser.antlr,
+ org.eclipse.xtext.example.homeautomation.parser.antlr.internal,
+ org.eclipse.xtext.example.homeautomation.parser.antlr.lexer,
  org.eclipse.xtext.example.homeautomation.ruleEngine,
  org.eclipse.xtext.example.homeautomation.ruleEngine.impl,
- org.eclipse.xtext.example.homeautomation,
- org.eclipse.xtext.example.homeautomation.parser.antlr.lexer,
- org.eclipse.xtext.example.homeautomation.parser.antlr.internal,
- org.eclipse.xtext.example.homeautomation.validation,
- org.eclipse.xtext.example.homeautomation.jvmmodel,
+ org.eclipse.xtext.example.homeautomation.ruleEngine.util,
  org.eclipse.xtext.example.homeautomation.scoping,
  org.eclipse.xtext.example.homeautomation.serializer,
- org.eclipse.xtext.example.homeautomation.parser.antlr,
  org.eclipse.xtext.example.homeautomation.services,
- org.eclipse.xtext.example.homeautomation.formatting2
+ org.eclipse.xtext.example.homeautomation.validation
 Import-Package: org.apache.log4j
 Automatic-Module-Name: org.eclipse.xtext.example.homeautomation


### PR DESCRIPTION
- Sort the exported packages lexicographically ascending in the
MANIFEST.MF file to ensure that the packages are shown in the same order
on the MANIFEST.MF editor page as on the Runtime editor page.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>