### PR TITLE
[#1202] Domainmodel example: Add duplicated property validation rule.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/ValidationTests.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/ValidationTests.xtend
@@ -16,8 +16,12 @@ import org.eclipse.xtext.testing.validation.ValidationTestHelper
 import org.junit.Test
 import org.junit.runner.RunWith
 
+import static org.eclipse.xtext.example.domainmodel.domainmodel.DomainmodelPackage.Literals.PROPERTY
+import static org.eclipse.xtext.example.domainmodel.validation.IssueCodes.DUPLICATE_PROPERTY
 import static org.eclipse.xtext.xbase.validation.IssueCodes.*
 import static org.eclipse.xtext.xtype.XtypePackage.Literals.*
+
+import static extension org.junit.Assert.assertEquals
 
 @RunWith(XtextRunner)
 @InjectWith(DomainmodelInjectorProvider)
@@ -164,5 +168,23 @@ class ValidationTests {
 			entity List2 {
 			}
 		'''.parse.assertNoErrors
+	}
+
+	@Test def void testDuplicatedProperty() {
+		val model = '''
+			entity E {
+				p : String
+				p : String
+			}
+		'''
+		model.parse => [
+			assertNumberOfIssues(2)
+			assertError(PROPERTY, DUPLICATE_PROPERTY, model.indexOf("p"), 1, "Duplicate property p")
+			assertError(PROPERTY, DUPLICATE_PROPERTY, model.lastIndexOf("p"), 1, "Duplicate property p")
+		]
+	}
+
+	private def assertNumberOfIssues(DomainModel domainModel, int expectedNumberOfIssues) {
+		expectedNumberOfIssues.assertEquals(domainModel.validate.size)
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/ValidationTests.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/ValidationTests.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.example.domainmodel.tests;
 import com.google.inject.Inject;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.example.domainmodel.domainmodel.DomainModel;
+import org.eclipse.xtext.example.domainmodel.domainmodel.DomainmodelPackage;
 import org.eclipse.xtext.example.domainmodel.tests.DomainmodelInjectorProvider;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
@@ -17,8 +18,11 @@ import org.eclipse.xtext.testing.util.ParseHelper;
 import org.eclipse.xtext.testing.validation.ValidationTestHelper;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.validation.IssueCodes;
 import org.eclipse.xtext.xtype.XtypePackage;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -333,5 +337,36 @@ public class ValidationTests {
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
+  }
+  
+  @Test
+  public void testDuplicatedProperty() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("entity E {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("p : String");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("p : String");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final String model = _builder.toString();
+      DomainModel _parse = this._parseHelper.parse(model);
+      final Procedure1<DomainModel> _function = (DomainModel it) -> {
+        this.assertNumberOfIssues(it, 2);
+        this._validationTestHelper.assertError(it, DomainmodelPackage.Literals.PROPERTY, org.eclipse.xtext.example.domainmodel.validation.IssueCodes.DUPLICATE_PROPERTY, model.indexOf("p"), 1, "Duplicate property p");
+        this._validationTestHelper.assertError(it, DomainmodelPackage.Literals.PROPERTY, org.eclipse.xtext.example.domainmodel.validation.IssueCodes.DUPLICATE_PROPERTY, model.lastIndexOf("p"), 1, "Duplicate property p");
+      };
+      ObjectExtensions.<DomainModel>operator_doubleArrow(_parse, _function);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  private void assertNumberOfIssues(final DomainModel domainModel, final int expectedNumberOfIssues) {
+    Assert.assertEquals(expectedNumberOfIssues, this._validationTestHelper.validate(domainModel).size());
   }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/validation/DomainmodelValidator.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/validation/DomainmodelValidator.xtend
@@ -7,9 +7,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.example.domainmodel.validation
 
+import com.google.common.collect.HashMultimap
+import com.google.common.collect.Multimap
 import org.eclipse.xtext.example.domainmodel.domainmodel.Entity
 import org.eclipse.xtext.example.domainmodel.domainmodel.Feature
 import org.eclipse.xtext.example.domainmodel.domainmodel.PackageDeclaration
+import org.eclipse.xtext.example.domainmodel.domainmodel.Property
 import org.eclipse.xtext.util.Strings
 import org.eclipse.xtext.validation.Check
 import org.eclipse.xtext.validation.ValidationMessageAcceptor
@@ -50,4 +53,19 @@ class DomainmodelValidator extends AbstractDomainmodelValidator {
 		}
 	}
 
+	@Check def void checkPropertyNamesAreUnique(Entity entity) {
+		val Multimap<String, Property> name2properties = HashMultimap.create
+
+		entity.features.filter(Property).filter[!name.nullOrEmpty].forEach[
+			name2properties.put(name, it)
+		]
+
+		name2properties.asMap.values.forEach[properties|
+			if (properties.size > 1) {
+				properties.forEach[
+					error("Duplicate property " + name, it, FEATURE__NAME, DUPLICATE_PROPERTY)
+				]
+			}
+		]
+	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/validation/IssueCodes.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/src/org/eclipse/xtext/example/domainmodel/validation/IssueCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,5 +19,7 @@ public interface IssueCodes {
 	String INVALID_FEATURE_NAME = PREFIX + "InvalidFeatureName";
 
 	String MISSING_TYPE = PREFIX + "MissingType";
+
+	String DUPLICATE_PROPERTY = PREFIX + "DuplicateProperty";
 
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/validation/DomainmodelValidator.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/validation/DomainmodelValidator.java
@@ -8,15 +8,24 @@
 package org.eclipse.xtext.example.domainmodel.validation;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import java.util.Collection;
+import java.util.function.Consumer;
 import org.eclipse.xtext.example.domainmodel.domainmodel.DomainmodelPackage;
 import org.eclipse.xtext.example.domainmodel.domainmodel.Entity;
 import org.eclipse.xtext.example.domainmodel.domainmodel.Feature;
 import org.eclipse.xtext.example.domainmodel.domainmodel.PackageDeclaration;
+import org.eclipse.xtext.example.domainmodel.domainmodel.Property;
 import org.eclipse.xtext.example.domainmodel.validation.AbstractDomainmodelValidator;
 import org.eclipse.xtext.example.domainmodel.validation.IssueCodes;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.validation.Check;
 import org.eclipse.xtext.validation.ValidationMessageAcceptor;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.StringExtensions;
 
 /**
  * This class contains custom validation rules.
@@ -56,5 +65,31 @@ public class DomainmodelValidator extends AbstractDomainmodelValidator {
     if (_equals) {
       this.error("Invalid package name", DomainmodelPackage.Literals.ABSTRACT_ELEMENT__NAME);
     }
+  }
+  
+  @Check
+  public void checkPropertyNamesAreUnique(final Entity entity) {
+    final Multimap<String, Property> name2properties = HashMultimap.<String, Property>create();
+    final Function1<Property, Boolean> _function = (Property it) -> {
+      boolean _isNullOrEmpty = StringExtensions.isNullOrEmpty(it.getName());
+      return Boolean.valueOf((!_isNullOrEmpty));
+    };
+    final Consumer<Property> _function_1 = (Property it) -> {
+      name2properties.put(it.getName(), it);
+    };
+    IterableExtensions.<Property>filter(Iterables.<Property>filter(entity.getFeatures(), Property.class), _function).forEach(_function_1);
+    final Consumer<Collection<Property>> _function_2 = (Collection<Property> properties) -> {
+      int _size = properties.size();
+      boolean _greaterThan = (_size > 1);
+      if (_greaterThan) {
+        final Consumer<Property> _function_3 = (Property it) -> {
+          String _name = it.getName();
+          String _plus = ("Duplicate property " + _name);
+          this.error(_plus, it, DomainmodelPackage.Literals.FEATURE__NAME, IssueCodes.DUPLICATE_PROPERTY);
+        };
+        properties.forEach(_function_3);
+      }
+    };
+    name2properties.asMap().values().forEach(_function_2);
   }
 }


### PR DESCRIPTION
- Add checkPropertyNamesAreUnique check to the DomainmodelValidator
class.
- Add DUPLICATE_PROPETY to the IssueCodes.
- Implement corresponding ValidationTests test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>