### PR TITLE
[#1217] Domainmodel example: Outline view improvements.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/OutlineTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/OutlineTest.xtend
@@ -56,4 +56,14 @@ class OutlineTest extends AbstractOutlineTest {
 			'''
 		)
 	}
+
+	@Test def void testOutlineWithInheritance() {
+		'''
+			entity A {}
+			entity B extends A {}
+		'''.assertAllLabels('''
+			A
+			B extends A
+		''')
+	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/OutlineTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/OutlineTest.java
@@ -101,4 +101,23 @@ public class OutlineTest extends AbstractOutlineTest {
       throw Exceptions.sneakyThrow(_e);
     }
   }
+  
+  @Test
+  public void testOutlineWithInheritance() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("entity A {}");
+      _builder.newLine();
+      _builder.append("entity B extends A {}");
+      _builder.newLine();
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("A");
+      _builder_1.newLine();
+      _builder_1.append("B extends A");
+      _builder_1.newLine();
+      this.assertAllLabels(_builder, _builder_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.xtend
@@ -12,6 +12,7 @@ import java.util.Iterator
 import org.eclipse.emf.common.util.EList
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider
+import org.eclipse.jface.viewers.StyledString
 import org.eclipse.xtext.common.types.JvmArrayType
 import org.eclipse.xtext.common.types.JvmFormalParameter
 import org.eclipse.xtext.common.types.JvmGenericArrayTypeReference
@@ -22,6 +23,7 @@ import org.eclipse.xtext.common.types.JvmTypeConstraint
 import org.eclipse.xtext.common.types.JvmTypeReference
 import org.eclipse.xtext.common.types.JvmUpperBound
 import org.eclipse.xtext.common.types.JvmWildcardTypeReference
+import org.eclipse.xtext.example.domainmodel.domainmodel.Entity
 import org.eclipse.xtext.example.domainmodel.domainmodel.Operation
 import org.eclipse.xtext.example.domainmodel.domainmodel.Property
 import org.eclipse.xtext.xbase.ui.labeling.XbaseLabelProvider
@@ -53,15 +55,27 @@ class DomainmodelLabelProvider extends XbaseLabelProvider {
 		return super.doGetImage(element)
 	}
 
-	def String text(Property property) {
+	def Object text(Entity entity) {
+		var StringBuilder builder = new StringBuilder()
+		builder.append(notNull(entity.getName()))
+		val superType = entity.superType
+		if (superType !== null) {
+			builder.append(" extends ")
+			builder.append(notNull(superType.simpleName))
+			return builder.toString.style
+		}
+		return builder.toString()
+	}
+
+	def Object text(Property property) {
 		var StringBuilder builder = new StringBuilder()
 		builder.append(notNull(property.getName()))
 		builder.append(" : ")
 		append(builder, property.getType())
-		return builder.toString()
+		return builder.toString().style
 	}
 
-	def String text(Operation operation) {
+	def Object text(Operation operation) {
 		var StringBuilder builder = new StringBuilder()
 		builder.append(notNull(operation.getName()))
 		builder.append("(")
@@ -73,7 +87,7 @@ class DomainmodelLabelProvider extends XbaseLabelProvider {
 		}
 		builder.append(") : ")
 		append(builder, operation.getType())
-		return builder.toString()
+		return builder.toString().style
 	}
 
 	def protected void append(StringBuilder builder, JvmTypeReference typeRef) {
@@ -117,5 +131,17 @@ class DomainmodelLabelProvider extends XbaseLabelProvider {
 		} else {
 			builder.append(notNull(type.getSimpleName()))
 		}
+	}
+
+	private def style(String text) {
+		val styled = new StyledString(text)
+		var offset = text.indexOf(':')
+		if (offset == -1) {
+			offset = text.indexOf('extends')
+		}
+		if (offset != -1) {
+			styled.setStyle(offset, text.length - offset, StyledString.DECORATIONS_STYLER)
+		}
+		styled
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/outline/DomainmodelOutlineTreeProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/outline/DomainmodelOutlineTreeProvider.xtend
@@ -8,7 +8,10 @@
 package org.eclipse.xtext.example.domainmodel.ui.outline
 
 import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.common.types.JvmParameterizedTypeReference
+import org.eclipse.xtext.example.domainmodel.domainmodel.Entity
 import org.eclipse.xtext.example.domainmodel.domainmodel.Feature
+import org.eclipse.xtext.ui.editor.outline.IOutlineNode
 import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider
 import org.eclipse.xtext.ui.editor.outline.impl.DocumentRootNode
 
@@ -18,10 +21,19 @@ import org.eclipse.xtext.ui.editor.outline.impl.DocumentRootNode
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#outline
  */
 class DomainmodelOutlineTreeProvider extends DefaultOutlineTreeProvider {
+
 	override protected void _createChildren(DocumentRootNode parentNode, EObject rootElement) {
 		for (EObject content : rootElement.eContents()) {
 			createNode(parentNode, content)
 		}
+	}
+
+	protected def void _createNode(IOutlineNode parent, JvmParameterizedTypeReference modelElement) {
+		// prevent creating outline nodes for JvmParameterizedTypeReference model elements
+	}
+
+	def protected boolean _isLeaf(Entity entity) {
+		entity.features.isEmpty
 	}
 
 	def protected boolean _isLeaf(Feature feature) {

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
+import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.common.types.JvmArrayType;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
@@ -23,6 +24,7 @@ import org.eclipse.xtext.common.types.JvmTypeConstraint;
 import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.common.types.JvmUpperBound;
 import org.eclipse.xtext.common.types.JvmWildcardTypeReference;
+import org.eclipse.xtext.example.domainmodel.domainmodel.Entity;
 import org.eclipse.xtext.example.domainmodel.domainmodel.Operation;
 import org.eclipse.xtext.example.domainmodel.domainmodel.Property;
 import org.eclipse.xtext.util.Strings;
@@ -70,15 +72,27 @@ public class DomainmodelLabelProvider extends XbaseLabelProvider {
     return super.doGetImage(element);
   }
   
-  public String text(final Property property) {
+  public Object text(final Entity entity) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(Strings.notNull(entity.getName()));
+    final JvmParameterizedTypeReference superType = entity.getSuperType();
+    if ((superType != null)) {
+      builder.append(" extends ");
+      builder.append(Strings.notNull(superType.getSimpleName()));
+      return this.style(builder.toString());
+    }
+    return builder.toString();
+  }
+  
+  public Object text(final Property property) {
     StringBuilder builder = new StringBuilder();
     builder.append(Strings.notNull(property.getName()));
     builder.append(" : ");
     this.append(builder, property.getType());
-    return builder.toString();
+    return this.style(builder.toString());
   }
   
-  public String text(final Operation operation) {
+  public Object text(final Operation operation) {
     StringBuilder builder = new StringBuilder();
     builder.append(Strings.notNull(operation.getName()));
     builder.append("(");
@@ -95,7 +109,7 @@ public class DomainmodelLabelProvider extends XbaseLabelProvider {
     }
     builder.append(") : ");
     this.append(builder, operation.getType());
-    return builder.toString();
+    return this.style(builder.toString());
   }
   
   protected void append(final StringBuilder builder, final JvmTypeReference typeRef) {
@@ -154,5 +168,23 @@ public class DomainmodelLabelProvider extends XbaseLabelProvider {
     } else {
       builder.append(Strings.notNull(type.getSimpleName()));
     }
+  }
+  
+  private StyledString style(final String text) {
+    StyledString _xblockexpression = null;
+    {
+      final StyledString styled = new StyledString(text);
+      int offset = text.indexOf(":");
+      if ((offset == (-1))) {
+        offset = text.indexOf("extends");
+      }
+      if ((offset != (-1))) {
+        int _length = text.length();
+        int _minus = (_length - offset);
+        styled.setStyle(offset, _minus, StyledString.DECORATIONS_STYLER);
+      }
+      _xblockexpression = styled;
+    }
+    return _xblockexpression;
   }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/outline/DomainmodelOutlineTreeProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/outline/DomainmodelOutlineTreeProvider.java
@@ -9,7 +9,10 @@ package org.eclipse.xtext.example.domainmodel.ui.outline;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.common.types.JvmParameterizedTypeReference;
+import org.eclipse.xtext.example.domainmodel.domainmodel.Entity;
 import org.eclipse.xtext.example.domainmodel.domainmodel.Feature;
+import org.eclipse.xtext.ui.editor.outline.IOutlineNode;
 import org.eclipse.xtext.ui.editor.outline.impl.DefaultOutlineTreeProvider;
 import org.eclipse.xtext.ui.editor.outline.impl.DocumentRootNode;
 
@@ -26,6 +29,13 @@ public class DomainmodelOutlineTreeProvider extends DefaultOutlineTreeProvider {
     for (final EObject content : _eContents) {
       this.createNode(parentNode, content);
     }
+  }
+  
+  protected void _createNode(final IOutlineNode parent, final JvmParameterizedTypeReference modelElement) {
+  }
+  
+  protected boolean _isLeaf(final Entity entity) {
+    return entity.getFeatures().isEmpty();
   }
   
   protected boolean _isLeaf(final Feature feature) {


### PR DESCRIPTION
- Modify the implementation of the DomainmodelLabelProvider and the
DomainmodelOutlineTreeProvider to not to create any outline view nodes
for the Jvm Parameterized Type Reference elements, to use B extends
LinkedList<String> text instead of the B label, to use styled String
after the : similar to Xtend.
- Implement corresponding OutlineTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>