### PR TITLE
Fix typo in the documentation of LabelProvider/DescriptionLabelProvider.

### DIFF
--- a/org.eclipse.xtext.purexbase.ui/src/org/eclipse/xtext/purexbase/ui/labeling/PureXbaseDescriptionLabelProvider.xtend
+++ b/org.eclipse.xtext.purexbase.ui/src/org/eclipse/xtext/purexbase/ui/labeling/PureXbaseDescriptionLabelProvider.xtend
@@ -7,7 +7,7 @@ import org.eclipse.xtext.xbase.ui.labeling.XbaseDescriptionLabelProvider
 //import org.eclipse.xtext.resource.IEObjectDescription
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.purexbase.ui/src/org/eclipse/xtext/purexbase/ui/labeling/PureXbaseLabelProvider.xtend
+++ b/org.eclipse.xtext.purexbase.ui/src/org/eclipse/xtext/purexbase/ui/labeling/PureXbaseLabelProvider.xtend
@@ -8,7 +8,7 @@ import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider
 import org.eclipse.xtext.xbase.ui.labeling.XbaseLabelProvider
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.purexbase.ui/xtend-gen/org/eclipse/xtext/purexbase/ui/labeling/PureXbaseDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.purexbase.ui/xtend-gen/org/eclipse/xtext/purexbase/ui/labeling/PureXbaseDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.purexbase.ui.labeling;
 import org.eclipse.xtext.xbase.ui.labeling.XbaseDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.purexbase.ui/xtend-gen/org/eclipse/xtext/purexbase/ui/labeling/PureXbaseLabelProvider.java
+++ b/org.eclipse.xtext.purexbase.ui/xtend-gen/org/eclipse/xtext/purexbase/ui/labeling/PureXbaseLabelProvider.java
@@ -8,7 +8,7 @@ import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
 import org.eclipse.xtext.xbase.ui.labeling.XbaseLabelProvider;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/BeeLangTestLanguageDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/BeeLangTestLanguageDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.testlanguages.backtracking.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/BeeLangTestLanguageLabelProvider.java
+++ b/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/BeeLangTestLanguageLabelProvider.java
@@ -9,7 +9,7 @@ import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 import com.google.inject.Inject;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/ExBeeLangTestLanguageDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/ExBeeLangTestLanguageDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.testlanguages.backtracking.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/ExBeeLangTestLanguageLabelProvider.java
+++ b/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/ExBeeLangTestLanguageLabelProvider.java
@@ -9,7 +9,7 @@ import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 import com.google.inject.Inject;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/SimpleBeeLangTestLanguageDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/SimpleBeeLangTestLanguageDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.testlanguages.backtracking.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/SimpleBeeLangTestLanguageLabelProvider.java
+++ b/org.eclipse.xtext.testlanguages.ui/src/org/eclipse/xtext/testlanguages/backtracking/ui/labeling/SimpleBeeLangTestLanguageLabelProvider.java
@@ -9,7 +9,7 @@ import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 import com.google.inject.Inject;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/CodetemplatesDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/CodetemplatesDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.ui.codetemplates.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/CodetemplatesLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/CodetemplatesLabelProvider.java
@@ -9,7 +9,7 @@ import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 import com.google.inject.Inject;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleCodetemplateDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleCodetemplateDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.ui.codetemplates.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleCodetemplateLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleCodetemplateLabelProvider.java
@@ -9,7 +9,7 @@ import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 import com.google.inject.Inject;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleTemplateDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleTemplateDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.ui.codetemplates.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleTemplateLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleTemplateLabelProvider.java
@@ -9,7 +9,7 @@ import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 import com.google.inject.Inject;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleTemplatesDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleTemplatesDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.ui.codetemplates.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleTemplatesLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/SingleTemplatesLabelProvider.java
@@ -9,7 +9,7 @@ import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 import com.google.inject.Inject;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/TemplatesDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/TemplatesDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.ui.codetemplates.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/TemplatesLabelProvider.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/labeling/TemplatesLabelProvider.java
@@ -9,7 +9,7 @@ import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 import com.google.inject.Inject;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xbase.testlanguages.ui/src/org/eclipse/xtext/xbase/testlanguages/ui/labeling/XImportSectionTestLangDescriptionLabelProvider.xtend
+++ b/org.eclipse.xtext.xbase.testlanguages.ui/src/org/eclipse/xtext/xbase/testlanguages/ui/labeling/XImportSectionTestLangDescriptionLabelProvider.xtend
@@ -6,7 +6,7 @@ package org.eclipse.xtext.xbase.testlanguages.ui.labeling
 //import org.eclipse.xtext.resource.IEObjectDescription
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xbase.testlanguages.ui/src/org/eclipse/xtext/xbase/testlanguages/ui/labeling/XImportSectionTestLangLabelProvider.xtend
+++ b/org.eclipse.xtext.xbase.testlanguages.ui/src/org/eclipse/xtext/xbase/testlanguages/ui/labeling/XImportSectionTestLangLabelProvider.xtend
@@ -6,7 +6,7 @@ package org.eclipse.xtext.xbase.testlanguages.ui.labeling
 import com.google.inject.Inject
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xbase.testlanguages.ui/xtend-gen/org/eclipse/xtext/xbase/testlanguages/ui/labeling/XImportSectionTestLangDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.xbase.testlanguages.ui/xtend-gen/org/eclipse/xtext/xbase/testlanguages/ui/labeling/XImportSectionTestLangDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.xbase.testlanguages.ui.labeling;
 import org.eclipse.xtext.xbase.ui.labeling.XbaseDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xbase.testlanguages.ui/xtend-gen/org/eclipse/xtext/xbase/testlanguages/ui/labeling/XImportSectionTestLangLabelProvider.java
+++ b/org.eclipse.xtext.xbase.testlanguages.ui/xtend-gen/org/eclipse/xtext/xbase/testlanguages/ui/labeling/XImportSectionTestLangLabelProvider.java
@@ -8,7 +8,7 @@ import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
 import org.eclipse.xtext.xbase.ui.labeling.XbaseLabelProvider;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/annotations/ui/labeling/XbaseWithAnnotationsDescriptionLabelProvider.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/annotations/ui/labeling/XbaseWithAnnotationsDescriptionLabelProvider.xtend
@@ -6,7 +6,7 @@ package org.eclipse.xtext.xbase.annotations.ui.labeling
 //import org.eclipse.xtext.resource.IEObjectDescription
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/annotations/ui/labeling/XbaseWithAnnotationsLabelProvider.xtend
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/annotations/ui/labeling/XbaseWithAnnotationsLabelProvider.xtend
@@ -6,7 +6,7 @@ package org.eclipse.xtext.xbase.annotations.ui.labeling
 import com.google.inject.Inject
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/labeling/XbaseDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/labeling/XbaseDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.xbase.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/annotations/ui/labeling/XbaseWithAnnotationsDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/annotations/ui/labeling/XbaseWithAnnotationsDescriptionLabelProvider.java
@@ -6,7 +6,7 @@ package org.eclipse.xtext.xbase.annotations.ui.labeling;
 import org.eclipse.xtext.xbase.ui.labeling.XbaseDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/annotations/ui/labeling/XbaseWithAnnotationsLabelProvider.java
+++ b/org.eclipse.xtext.xbase.ui/xtend-gen/org/eclipse/xtext/xbase/annotations/ui/labeling/XbaseWithAnnotationsLabelProvider.java
@@ -8,7 +8,7 @@ import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
 import org.eclipse.xtext.xbase.ui.labeling.XbaseLabelProvider;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsDescriptionLabelProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsDescriptionLabelProvider.xtend
@@ -13,7 +13,7 @@ import org.eclipse.xtext.resource.IEObjectDescription
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  *
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsLabelProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsLabelProvider.xtend
@@ -14,7 +14,7 @@ import org.eclipse.xtext.example.arithmetics.arithmetics.Module
 import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  *
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsDescriptionLabelProvider.java
@@ -14,7 +14,7 @@ import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsLabelProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/labeling/ArithmeticsLabelProvider.java
@@ -16,7 +16,7 @@ import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.xtend
@@ -33,7 +33,7 @@ import org.eclipse.xtext.xtype.XImportSection
 import static org.eclipse.xtext.util.Strings.*
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */
 class DomainmodelLabelProvider extends XbaseLabelProvider {

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/labeling/DomainmodelLabelProvider.java
@@ -33,7 +33,7 @@ import org.eclipse.xtext.xtype.XImportDeclaration;
 import org.eclipse.xtext.xtype.XImportSection;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */
 @SuppressWarnings("all")

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/labeling/StatemachineDescriptionLabelProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/labeling/StatemachineDescriptionLabelProvider.xtend
@@ -12,7 +12,7 @@ import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider
 //import org.eclipse.xtext.resource.IEObjectDescription
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  *
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/labeling/StatemachineLabelProvider.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src/org/eclipse/xtext/example/fowlerdsl/ui/labeling/StatemachineLabelProvider.xtend
@@ -13,7 +13,7 @@ import org.eclipse.xtext.example.fowlerdsl.statemachine.State
 import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  *
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/labeling/StatemachineDescriptionLabelProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/labeling/StatemachineDescriptionLabelProvider.java
@@ -10,7 +10,7 @@ package org.eclipse.xtext.example.fowlerdsl.ui.labeling;
 import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/labeling/StatemachineLabelProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/xtend-gen/org/eclipse/xtext/example/fowlerdsl/ui/labeling/StatemachineLabelProvider.java
@@ -13,7 +13,7 @@ import org.eclipse.xtext.example.fowlerdsl.statemachine.State;
 import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
 
 /**
- * Provides labels for a EObjects.
+ * Provides labels for EObjects.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */


### PR DESCRIPTION
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>