### PR TITLE
Cleaning up the Xtext Examples MANIFEST.MF files.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/META-INF/MANIFEST.MF
@@ -5,10 +5,10 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.arithmetics,
+Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+ org.eclipse.xtext.example.arithmetics,
  org.eclipse.xtext.ide,
- org.eclipse.xtext.xbase.ide,
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
+ org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.arithmetics.ide.contentassist.antlr,
  org.eclipse.xtext.example.arithmetics.ide.contentassist.antlr.internal

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/META-INF/MANIFEST.MF
@@ -6,10 +6,10 @@ Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.arithmetics,
- org.junit;bundle-version="4.7.0",
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ org.eclipse.xtext.xbase.testing,
+ org.junit;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.arithmetics.tests;x-internal=true
 Import-Package: org.hamcrest.core,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
@@ -5,16 +5,16 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.arithmetics,
- org.eclipse.xtext.example.arithmetics.ui,
- org.junit;bundle-version="4.7.0",
- org.eclipse.core.runtime,
+Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,
- org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing,
- org.eclipse.xtext.ui.testing,
+ org.eclipse.xtext.example.arithmetics,
+ org.eclipse.xtext.example.arithmetics.ui,
  org.eclipse.xtext.junit4,
- org.eclipse.xtext.xbase.junit
+ org.eclipse.xtext.testing,
+ org.eclipse.xtext.ui.testing,
+ org.eclipse.xtext.xbase.junit,
+ org.eclipse.xtext.xbase.testing,
+ org.junit;bundle-version="4.7.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.arithmetics.ui.tests;x-internal=true
 Import-Package: org.hamcrest.core,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/META-INF/MANIFEST.MF
@@ -5,16 +5,17 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.arithmetics,
- org.eclipse.xtext.example.arithmetics.ide,
- org.eclipse.xtext.ui,
- org.eclipse.xtext.ui.shared,
- org.eclipse.xtext.ui.codetemplates.ui,
+Require-Bundle: org.eclipse.compare,
+ org.eclipse.ui,
  org.eclipse.ui.editors;bundle-version="3.5.0",
  org.eclipse.ui.ide;bundle-version="3.5.0",
- org.eclipse.ui,
- org.eclipse.compare,
- org.eclipse.xtext.builder,org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional,
+ org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional,
+ org.eclipse.xtext.builder,
+ org.eclipse.xtext.example.arithmetics,
+ org.eclipse.xtext.example.arithmetics.ide,
+ org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
+ org.eclipse.xtext.ui.shared,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/META-INF/MANIFEST.MF
@@ -5,15 +5,15 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext,
- org.eclipse.xtext.xbase,
- org.eclipse.equinox.common;bundle-version="3.5.0",
+Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+ org.eclipse.emf.common,
  org.eclipse.emf.ecore,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
- org.eclipse.xtext.util,
+ org.eclipse.equinox.common;bundle-version="3.5.0",
  org.eclipse.xtend.lib;bundle-version="2.14.0",
- org.eclipse.emf.common
+ org.eclipse.xtext,
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.arithmetics,
  org.eclipse.xtext.example.arithmetics.arithmetics,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ide/META-INF/MANIFEST.MF
@@ -5,10 +5,10 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.domainmodel.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.domainmodel,
+Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+ org.eclipse.xtext.example.domainmodel,
  org.eclipse.xtext.ide,
- org.eclipse.xtext.xbase.ide,
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
+ org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.domainmodel.ide.contentassist.antlr,
  org.eclipse.xtext.example.domainmodel.ide.contentassist.antlr.internal

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,8 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.domainmodel,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
- org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional,
- org.eclipse.xtext.xbase.testing
+ org.eclipse.xtext.xbase.testing,
+ org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.domainmodel.tests;x-internal=true
 Import-Package: org.hamcrest.core,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/META-INF/MANIFEST.MF
@@ -5,17 +5,17 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.domainmodel.ui.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.domainmodel,
- org.eclipse.xtext.example.domainmodel.ui,
- org.eclipse.xtext.testing,
- org.eclipse.core.runtime;bundle-version="3.13.0",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="3.13.0",
+ org.eclipse.jdt.core;bundle-version="3.13.102",
  org.eclipse.ui.workbench;bundle-version="3.110.1";resolution:=optional,
  org.eclipse.xtext.common.types.ui,
- org.eclipse.jdt.core;bundle-version="3.13.102",
- org.eclipse.xtext.xbase.testing,
- org.eclipse.xtext.ui.testing,
+ org.eclipse.xtext.example.domainmodel,
+ org.eclipse.xtext.example.domainmodel.ui,
  org.eclipse.xtext.junit4,
- org.eclipse.xtext.xbase.junit
+ org.eclipse.xtext.testing,
+ org.eclipse.xtext.ui.testing,
+ org.eclipse.xtext.xbase.junit,
+ org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.domainmodel.ui.tests;x-internal=true
 Import-Package: org.hamcrest.core,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/META-INF/MANIFEST.MF
@@ -5,21 +5,21 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.domainmodel.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.domainmodel,
- org.eclipse.xtext.example.domainmodel.ide,
- org.eclipse.xtext.ui,
- org.eclipse.xtext.ui.shared,
- org.eclipse.xtext.ui.codetemplates.ui,
+Require-Bundle: org.eclipse.compare;bundle-version="3.7.101",
+ org.eclipse.jdt.core;bundle-version="3.13.102";resolution:=optional;x-installation:=greedy,
+ org.eclipse.jdt.debug.ui;bundle-version="3.8.100",
  org.eclipse.ui.editors;bundle-version="3.11.0",
  org.eclipse.ui.ide;bundle-version="3.13.1",
  org.eclipse.ui;bundle-version="3.109.0",
- org.eclipse.compare;bundle-version="3.7.101",
  org.eclipse.xtext.builder,org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtext.common.types.ui,
- org.eclipse.xtext.xbase.ui,
- org.eclipse.jdt.core;bundle-version="3.13.102";resolution:=optional;x-installation:=greedy,
- org.eclipse.jdt.debug.ui;bundle-version="3.8.100"
+ org.eclipse.xtext.example.domainmodel,
+ org.eclipse.xtext.example.domainmodel.ide,
+ org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
+ org.eclipse.xtext.ui.shared,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ org.eclipse.xtext.xbase.ui
 Import-Package: org.apache.log4j,
  org.eclipse.xtext.ui.codemining;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/META-INF/MANIFEST.MF
@@ -5,16 +5,16 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.domainmodel; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext,
- org.eclipse.xtext.xbase,
- org.eclipse.equinox.common;bundle-version="3.9.0",
- org.eclipse.emf.ecore,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
- org.eclipse.xtext.util,
- org.eclipse.xtend.lib;bundle-version="2.14.0",
+Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.emf.common,
+ org.eclipse.emf.ecore,
+ org.eclipse.equinox.common;bundle-version="3.9.0",
+ org.eclipse.xtend.lib;bundle-version="2.14.0",
+ org.eclipse.xtext,
  org.eclipse.xtext.common.types,
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.domainmodel,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ide/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.fowlerdsl.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.fowlerdsl,
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+ org.eclipse.xtext.example.fowlerdsl,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.lib
 Import-Package: org.apache.log4j

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.tests/META-INF/MANIFEST.MF
@@ -6,11 +6,11 @@ Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.fowlerdsl.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.fowlerdsl,
- org.junit,
- org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ org.eclipse.xtext.xbase.testing,
+ org.junit,
+ org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.fowlerdsl.tests;x-internal=true
 Import-Package: org.hamcrest.core,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui.tests/META-INF/MANIFEST.MF
@@ -5,16 +5,16 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.fowlerdsl.ui.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.fowlerdsl.ui,
- org.eclipse.xtext.testing,
- org.eclipse.core.runtime,
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.jdt.core;bundle-version="3.13.102",
  org.eclipse.ui.workbench;bundle-version="3.110.1";resolution:=optional,
  org.eclipse.xtext.common.types.ui,
- org.eclipse.jdt.core;bundle-version="3.13.102",
- org.eclipse.xtext.xbase.testing,
- org.eclipse.xtext.ui.testing,
+ org.eclipse.xtext.example.fowlerdsl.ui,
  org.eclipse.xtext.junit4,
- org.eclipse.xtext.xbase.junit
+ org.eclipse.xtext.testing,
+ org.eclipse.xtext.ui.testing,
+ org.eclipse.xtext.xbase.junit,
+ org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.fowlerdsl.ui.tests;x-internal=true
 Import-Package: org.hamcrest.core,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/META-INF/MANIFEST.MF
@@ -5,19 +5,20 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.fowlerdsl.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.fowlerdsl;visibility:=reexport,
- org.eclipse.xtext.example.fowlerdsl.ide,
- org.eclipse.xtext.ui,
+Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+ org.eclipse.compare;bundle-version="2.1.0",
  org.eclipse.ui.editors;bundle-version="3.6.0",
  org.eclipse.ui.ide;bundle-version="3.6.0",
- org.eclipse.xtext.ui.shared,
  org.eclipse.ui;bundle-version="3.6.0",
+ org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional,
  org.eclipse.xtext.builder,
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.xtext.common.types.ui,
+ org.eclipse.xtext.example.fowlerdsl.ide,
+ org.eclipse.xtext.example.fowlerdsl;visibility:=reexport,
+ org.eclipse.xtext.ui,
  org.eclipse.xtext.ui.codetemplates.ui,
- org.eclipse.compare;bundle-version="2.1.0",
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional
+ org.eclipse.xtext.ui.shared,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.fowlerdsl.ui.contentassist,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/META-INF/MANIFEST.MF
@@ -5,15 +5,15 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.fowlerdsl; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext,
- org.eclipse.xtext.xbase,
- org.eclipse.equinox.common;bundle-version="3.5.0",
+Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+ org.eclipse.emf.common,
  org.eclipse.emf.ecore,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
- org.eclipse.xtext.util,
+ org.eclipse.equinox.common;bundle-version="3.5.0",
  org.eclipse.xtend.lib;bundle-version="2.14.0",
- org.eclipse.emf.common
+ org.eclipse.xtext,
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.fowlerdsl,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ide/META-INF/MANIFEST.MF
@@ -5,10 +5,10 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.homeautomation.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.homeautomation,
+Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
+ org.eclipse.xtext.example.homeautomation,
  org.eclipse.xtext.ide,
- org.eclipse.xtext.xbase.ide,
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
+ org.eclipse.xtext.xbase.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.ide.contentassist.antlr,
  org.eclipse.xtext.example.homeautomation.ide.contentassist.antlr.internal,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.tests/META-INF/MANIFEST.MF
@@ -6,11 +6,11 @@ Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.homeautomation.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext.example.homeautomation,
- org.junit;bundle-version="4.7.0",
- org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ org.eclipse.xtext.xbase.testing,
+ org.junit;bundle-version="4.7.0",
+ org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.tests;x-internal=true
 Import-Package: org.junit.runners;version="4.5.0",

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui.tests/META-INF/MANIFEST.MF
@@ -5,16 +5,16 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.homeautomation.ui.tests;singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.homeautomation.ui,
- org.eclipse.xtext.testing,
- org.eclipse.core.runtime;bundle-version="3.13.0",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="3.13.0",
+ org.eclipse.jdt.core;bundle-version="3.13.102",
  org.eclipse.ui.workbench;bundle-version="3.110.1";resolution:=optional,
  org.eclipse.xtext.common.types.ui,
- org.eclipse.jdt.core;bundle-version="3.13.102",
- org.eclipse.xtext.xbase.testing,
- org.eclipse.xtext.ui.testing,
+ org.eclipse.xtext.example.homeautomation.ui,
  org.eclipse.xtext.junit4,
- org.eclipse.xtext.xbase.junit
+ org.eclipse.xtext.testing,
+ org.eclipse.xtext.ui.testing,
+ org.eclipse.xtext.xbase.junit,
+ org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.ui.tests;x-internal=true
 Import-Package: org.hamcrest.core,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui/META-INF/MANIFEST.MF
@@ -5,20 +5,21 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.homeautomation.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext.example.homeautomation,
- org.eclipse.xtext.example.homeautomation.ide,
- org.eclipse.xtext.ui,
- org.eclipse.xtext.ui.shared,
- org.eclipse.xtext.ui.codetemplates.ui,
+Require-Bundle: org.eclipse.compare;bundle-version="3.7.101",
+ org.eclipse.jdt.debug.ui;bundle-version="3.8.100",
+ org.eclipse.ui,
  org.eclipse.ui.editors;bundle-version="3.11.0",
  org.eclipse.ui.ide;bundle-version="3.13.1",
- org.eclipse.jdt.debug.ui;bundle-version="3.8.100",
- org.eclipse.compare;bundle-version="3.7.101",
- org.eclipse.ui,org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional,
+ org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional,
+ org.eclipse.xtext.builder,
  org.eclipse.xtext.common.types.ui,
+ org.eclipse.xtext.example.homeautomation,
+ org.eclipse.xtext.example.homeautomation.ide,
+ org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
+ org.eclipse.xtext.ui.shared,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
- org.eclipse.xtext.xbase.ui,
- org.eclipse.xtext.builder
+ org.eclipse.xtext.xbase.ui
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation.ui.contentassist,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/META-INF/MANIFEST.MF
@@ -5,17 +5,17 @@ Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.20.0.qualifier
 Bundle-SymbolicName: org.eclipse.xtext.example.homeautomation; singleton:=true
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.xtext,
- org.eclipse.xtext.xbase,
- org.eclipse.equinox.common;bundle-version="3.5.0",
- org.eclipse.emf.ecore,
- org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional,
- org.eclipse.xtext.util,
- org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
- org.eclipse.xtend.lib;bundle-version="2.14.0",
+Require-Bundle: org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.emf.common,
+ org.eclipse.emf.ecore,
+ org.eclipse.equinox.common;bundle-version="3.5.0",
+ org.eclipse.xtend.lib;bundle-version="2.14.0",
+ org.eclipse.xtext,
  org.eclipse.xtext.common.types,
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase,
+ org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+ org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.homeautomation,
  org.eclipse.xtext.example.homeautomation.formatting2,


### PR DESCRIPTION
- Sort the 'Require-Bundle' entries lexicographically ascending to
enable a better comparison between them.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>