### PR TITLE
Cleaning up the org.eclipse.xtext.ui.wizard.template package.

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/AbstractFileTemplate.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/AbstractFileTemplate.java
@@ -24,11 +24,11 @@ public abstract class AbstractFileTemplate extends AbstractTemplate {
 	private TemplateFileInfo info;
 
 	abstract public void generateFiles(IFileGenerator generator);
-	
+
 	protected TemplateFileInfo getTemplateInfo() {
 		return info;
 	}
-	
+
 	protected String getFolder() {
 		return info.getFolder();
 	}
@@ -36,7 +36,7 @@ public abstract class AbstractFileTemplate extends AbstractTemplate {
 	protected String getName() {
 		return info.getName();
 	}
-	
+
 	void setTemplateInfo(TemplateFileInfo info) {
 		this.info = info;
 	}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/FileTemplate.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/FileTemplate.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ annotation FileTemplate {
 	 */
 	String icon
 	/**
-	 * Description of the file template presented to the user in a a text field in the new file wizard when hovering
+	 * Description of the file template presented to the user in a text field in the new file wizard when hovering
 	 * over the combo box of available templates. If only one template is available used as text for the wizard page.
 	 * 
 	 * The description is written to a file "messages.properties" and read from there at runtime. This way it is

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/ProjectTemplate.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/ProjectTemplate.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@ import java.lang.annotation.Target
 import org.eclipse.xtend.lib.macro.Active
 
 /**
- * Annotation to define a project templates that is selected by the user in the new project wizard and declared in a
+ * Annotation to define a project template that is selected by the user in the new project wizard and declared in a
  * language specific ProjectTemplateProvider.
  * 
  * @author Arne Deutsch - Initial contribution and API
@@ -34,12 +34,12 @@ annotation ProjectTemplate {
 	 */
 	String icon
 	/**
-	 * Description of the project template presented to the user in a a text field in the new project wizard. is
+	 * Description of the project template presented to the user in a text field in the new project wizard. It is
 	 * rendered inside a FormText widget and has to conform to a simplified HTML format. Example:
 	 * 
 	 * <pre>
 	 * &lt;p&gt;&lt;b&gt;Hello World&lt;/b&gt;&lt;/p&gt;
-	 * &lt;p>This is a parameterized hello world for com.daimler.pas.PAS. You can set a parameter to modify the content
+	 * &lt;p>This is a parameterized hello world for MyDsl. You can set a parameter to modify the content
 	 * in the generated file and a parameter to set the package the file is created in.&lt;/p&gt;
 	 * </pre>
 	 * 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateVariable.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateVariable.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -51,7 +51,7 @@ abstract class TemplateVariable {
 	/**
 	 * Subclasses should override to refresh the UI widget with data set to the variable in the meantime.
 	 */
-	def void refresh();
+	def void refresh()
 
 	def Control getWidget()
 
@@ -65,7 +65,7 @@ abstract class ContainerTemplateVariable extends TemplateVariable {
 		super(label, description, container)
 	}
 
-	override Composite getWidget();
+	override Composite getWidget()
 
 }
 

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/BooleanTemplateVariable.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/BooleanTemplateVariable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/ContainerTemplateVariable.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/ContainerTemplateVariable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/FileTemplate.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/FileTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,7 @@ public @interface FileTemplate {
    */
   public String icon();
   /**
-   * Description of the file template presented to the user in a a text field in the new file wizard when hovering
+   * Description of the file template presented to the user in a text field in the new file wizard when hovering
    * over the combo box of available templates. If only one template is available used as text for the wizard page.
    * 
    * The description is written to a file "messages.properties" and read from there at runtime. This way it is

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/GroupTemplateVariable.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/GroupTemplateVariable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/ProjectTemplate.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/ProjectTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ import org.eclipse.xtend.lib.macro.Active;
 import org.eclipse.xtext.ui.wizard.template.ProjectTemplateProcessor;
 
 /**
- * Annotation to define a project templates that is selected by the user in the new project wizard and declared in a
+ * Annotation to define a project template that is selected by the user in the new project wizard and declared in a
  * language specific ProjectTemplateProvider.
  * 
  * @author Arne Deutsch - Initial contribution and API
@@ -37,12 +37,12 @@ public @interface ProjectTemplate {
    */
   public String icon();
   /**
-   * Description of the project template presented to the user in a a text field in the new project wizard. is
+   * Description of the project template presented to the user in a text field in the new project wizard. It is
    * rendered inside a FormText widget and has to conform to a simplified HTML format. Example:
    * 
    * <pre>
    * &lt;p&gt;&lt;b&gt;Hello World&lt;/b&gt;&lt;/p&gt;
-   * &lt;p>This is a parameterized hello world for com.daimler.pas.PAS. You can set a parameter to modify the content
+   * &lt;p>This is a parameterized hello world for MyDsl. You can set a parameter to modify the content
    * in the generated file and a parameter to set the package the file is created in.&lt;/p&gt;
    * </pre>
    * 

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/StringSelectionTemplateVariable.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/StringSelectionTemplateVariable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/StringTemplateVariable.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/StringTemplateVariable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/TemplateVariable.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/TemplateVariable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
- Fixing typos in the documentation.
- Formating source code.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>