### PR TITLE
Xtext Domainmodel Example: format plugin.xml file.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/plugin.xml
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/plugin.xml
@@ -603,7 +603,6 @@
 			type="text">
 		</fileTypes>
 	</extension>
-
 	<!-- code mining -->
 	<extension point="org.eclipse.ui.workbench.texteditor.codeMiningProviders">
 		<codeMiningProvider
@@ -622,14 +621,13 @@
 			</enabledWhen>
 		</codeMiningProvider>
 	</extension>
-	
+
 	<!-- manual additions start here -->
 	<extension point="org.eclipse.xtext.ui.searchFilter">
 		<filter
 			class="org.eclipse.xtext.example.domainmodel.ui.DomainmodelExecutableExtensionFactory:org.eclipse.xtext.example.domainmodel.ui.search.DomainmodelSearchFilter">
 		</filter>
 	</extension>
-
 	<extension point="org.eclipse.ui.views">
 		<view
 				class="org.eclipse.xtext.example.domainmodel.ui.DomainmodelExecutableExtensionFactory:org.eclipse.xtext.example.domainmodel.ui.editor.hierarchy.AssociationHierarchyViewPart"
@@ -652,7 +650,7 @@
 				locationURI="popup:#TextEditorContext?after=xtext.ui.openDeclaration">
 			<command
 					commandId="org.eclipse.xtext.example.domainmodel.ui.editor.OpenAssociationHierarchy"
-				 style="push">
+					style="push">
 				<visibleWhen checkEnabled="false">
 					<reference definitionId="org.eclipse.xtext.example.domainmodel.Domainmodel.Editor.opened" />
 				</visibleWhen>


### PR DESCRIPTION
- Align the plugin.xml file to the plugin.xml_gen file to get a better
diff when comparing them.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>