### PR TITLE
[eclipse/xtext#1129] Moved recovery build trigger to job to avoid start-up hang

### DIFF
--- a/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/ListenerRegistrar.java
+++ b/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/ListenerRegistrar.java
@@ -10,6 +10,11 @@ package org.eclipse.xtext.ui.shared.internal;
 import java.util.Arrays;
 
 import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.xtext.builder.builderState.IBuilderState;
 import org.eclipse.xtext.builder.impl.BuildScheduler;
 import org.eclipse.xtext.builder.impl.IBuildFlag;
@@ -41,9 +46,25 @@ public class ListenerRegistrar implements IEagerContribution {
 		// after the fact, the project-open event is already done. Thus no build is triggered for the newly
 		// opened project and the index state is corrupt.
 		// thus we trigger a recovery build here
-		if (builderState.isEmpty()) {
-			buildManager.scheduleBuildIfNecessary(Arrays.asList(workspace.getRoot().getProjects()), IBuildFlag.RECOVERY_BUILD);
+		class RecoveryBuildTrigger extends WorkspaceJob {
+
+			public RecoveryBuildTrigger() {
+				super("Schedule Xtext recovery build on start-up");
+			}
+
+			@Override
+			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+				if (monitor.isCanceled()) {
+					return Status.CANCEL_STATUS;
+				}
+				if (builderState.isEmpty()) {
+					buildManager.scheduleBuildIfNecessary(Arrays.asList(workspace.getRoot().getProjects()), IBuildFlag.RECOVERY_BUILD);
+				}
+				return Status.OK_STATUS;
+			}
 		}
+		RecoveryBuildTrigger recoveryBuildTrigger = new RecoveryBuildTrigger();
+		recoveryBuildTrigger.schedule();
 	}
 
 	@Override


### PR DESCRIPTION
Moved recovery build trigger to workspace job to avoid Eclipse start-up hang

Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>