### PR TITLE
avoid 'Directory is empty. Can't process' warning

### DIFF
--- a/releng/org.eclipse.xtext.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtext.tycho.parent/pom.xml
@@ -210,6 +210,7 @@
 					</execution>
 				</executions>
 				<configuration>
+					<showEmptyDirWarning>false</showEmptyDirWarning>
 					<outputDirectory>${basedir}/xtend-gen</outputDirectory>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
avoid 'Directory is empty. Can't process' warning
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>