### PR TITLE
[#1229] Xtext Statemachine Example: add wizard generateToolbarButton.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/plugin.xml
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/plugin.xml
@@ -452,6 +452,28 @@
 		</perspectiveExtension>
 	</extension>
 	<extension
+		point="org.eclipse.ui.menus">
+		<menuContribution
+			allPopups="false"
+			locationURI="toolbar:org.eclipse.ui.main.toolbar">
+			<toolbar
+				id="org.eclipse.xtext.example.fowlerdsl.ui.toolbar">
+				<!--
+					For some reason the tooltip is not shown when hovering over the toolbar button
+					See also https://www.eclipse.org/forums/index.php/t/1079111/
+				-->
+				<command
+					commandId="org.eclipse.ui.newWizard"
+					tooltip="Create a new Statemachine project">
+					<parameter
+						name="newWizardId"
+						value="org.eclipse.xtext.example.fowlerdsl.ui.wizard.StatemachineNewProjectWizard">
+					</parameter>
+				</command>
+			</toolbar>
+		</menuContribution>
+	</extension>
+	<extension
 		point="org.eclipse.ui.newWizards">
 		<category id="org.eclipse.xtext.example.fowlerdsl.ui.category" name="Statemachine">
 		</category>
@@ -492,29 +514,7 @@
 				-->
 				<command
 					commandId="org.eclipse.ui.newWizard"
-					tooltip="Create a statemachine project">
-					<parameter
-						name="newWizardId"
-						value="org.eclipse.xtext.example.fowlerdsl.ui.wizard.StatemachineNewProjectWizard">
-					</parameter>
-				</command>
-			</toolbar>
-		</menuContribution>
-	</extension>
-	<extension
-		point="org.eclipse.ui.menus">
-		<menuContribution
-			allPopups="false"
-			locationURI="toolbar:org.eclipse.ui.main.toolbar">
-			<toolbar
-				id="org.eclipse.xtext.example.fowlerdsl.ui.toolbar">
-				<!--
-					For some reason the tooltip is not shown when hovering over the toolbar button
-					See also https://www.eclipse.org/forums/index.php/t/1079111/
-				-->
-				<command
-					commandId="org.eclipse.ui.newWizard"
-					tooltip="Create a statemachine file">
+					tooltip="Create a new Statemachine file">
 					<parameter
 						name="newWizardId"
 						value="org.eclipse.xtext.example.fowlerdsl.ui.wizard.StatemachineNewFileWizard">

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/GenerateStatemachine.mwe2
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/src/org/eclipse/xtext/example/fowlerdsl/GenerateStatemachine.mwe2
@@ -42,9 +42,6 @@ Workflow {
 			name = "org.eclipse.xtext.example.fowlerdsl.Statemachine"
 			fileExtensions = "statemachine"
 
-			fileWizard = {
-				generate = true
-			}
 			formatter = {
 				generateStub = true
 				generateXtendStub = true
@@ -52,15 +49,20 @@ Workflow {
 			generator = {
 				generateXtendStub = true
 			}
-			projectWizard = {
-				generate = true
-			}
 			serializer = {
 				generateStub = false
 			}
 			validator = {
 				// composedCheck = "org.eclipse.xtext.validation.NamesAreUniqueValidator"
 				generateDeprecationValidation = false
+			}
+			projectWizard = {
+				generate = true
+				generateToolbarButton = true
+			}
+			fileWizard = {
+				generate = true
+				generateToolbarButton = true
 			}
 		}
 	}


### PR DESCRIPTION
- Modify the projectWizard/fileWizard section of the
GenerateStatemachine.mwe2 workflow to generate new project wizard/new
file wizard buttons on the toolbar.
- Merge plugin.xml_gen into the plugin.xml.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>