### PR TITLE
[#491694] Statemachine example: bind Sample Ecore Editor.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/plugin.xml
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/plugin.xml
@@ -11,6 +11,10 @@
 			id="org.eclipse.xtext.example.fowlerdsl.Statemachine"
 			name="Statemachine Editor">
 		</editor>
+		<editorContentTypeBinding
+			contentTypeId="org.eclipse.xtext.example.fowlerdsl.Statemachine.contenttype"
+			editorId="org.eclipse.emf.ecore.presentation.EcoreEditorID">
+		</editorContentTypeBinding>
 	</extension>
 	<extension
 		point="org.eclipse.ui.handlers">


### PR DESCRIPTION
- Extend the plugin.xml of the Xtext Statemachine example with the
corresponding editorContentTypeBinding to be able to open the
*.statemachine files with the Sample Ecore Editor.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=491694

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>