### PR TITLE
use newest lsp4j. no longer part of composite cause nobody knows how that is maintained

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -118,7 +118,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="p2.lsp4j"
-      value="https://download.eclipse.org/lsp4j/updates/releases/"/>
+      value="https://download.eclipse.org/lsp4j/updates/releases/0.8.1"/>
   <setupTask
       xsi:type="setup:VariableTask"
       type="URI"


### PR DESCRIPTION
use newest lsp4j. no longer part of composite cause nobody knows how that is maintained
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>