### PR TITLE
[#https://github.com/eclipse/xtext-xtend/issues/789] Improve Xbase UI

### DIFF
--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegate.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelection;
@@ -55,6 +56,8 @@ public class JavaElementDelegate implements IAdaptable {
 
 	private IEditorPart editor;
 	private IResource resource;
+	private IPackageFragment packageFragment;
+
 	@Inject
 	private IDerivedResourceMarkers derivedResourceMarkers;
 
@@ -86,6 +89,10 @@ public class JavaElementDelegate implements IAdaptable {
 		this.resource = resource;
 	}
 
+	public void initializeWith(IPackageFragment packageFragment) {
+		this.packageFragment = packageFragment;
+	}
+
 	@Override
 	public <T> T getAdapter(Class<T> adapter) {
 		if (IJavaElement.class.equals(adapter)) {
@@ -97,6 +104,9 @@ public class JavaElementDelegate implements IAdaptable {
 			}
 			if (resource != null && fileExtensionProvider.isValid(resource.getFileExtension())) {
 				return adapter.cast(getJavaElementForResource(resource));
+			}
+			if (packageFragment != null) {
+				return adapter.cast(getJavaElementForPackage(packageFragment));
 			}
 		}
 		return null;
@@ -222,6 +232,14 @@ public class JavaElementDelegate implements IAdaptable {
 				log.debug(e.getMessage(), e);
 			}
 		}
+		return null;
+	}
+	
+	/**
+	 * Subclasses may override.
+	 * @since 2.21 
+	 */
+	protected IJavaElement getJavaElementForPackage(IPackageFragment packageFragment) {
 		return null;
 	}
 

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateAdapterFactory.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaElementDelegateAdapterFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@ package org.eclipse.xtext.xbase.ui.launching;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IAdapterFactory;
+import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
 
@@ -54,6 +55,10 @@ public class JavaElementDelegateAdapterFactory implements IAdapterFactory {
 			}
 			if (adaptableObject instanceof IEditorPart) {
 				result.initializeWith((IEditorPart) adaptableObject);
+				return adapterType.cast(result);
+			}
+			if (adaptableObject instanceof IPackageFragment) {
+				result.initializeWith((IPackageFragment) adaptableObject);
 				return adapterType.cast(result);
 			}
 		}

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/LaunchShortcutUtil.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/LaunchShortcutUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@ package org.eclipse.xtext.xbase.ui.launching;
 
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 
@@ -22,7 +23,7 @@ public class LaunchShortcutUtil {
 		Object[] fakeSelection = new Object[originalSelection.length];
 		for(int i = 0; i < originalSelection.length; i++) {
 			Object original = originalSelection[i];
-			if (original == null || original instanceof IJavaElement || original instanceof JavaElementDelegate || !(original instanceof IAdaptable)) {
+			if (original == null || (original instanceof IJavaElement && !(original instanceof IPackageFragment)) || original instanceof JavaElementDelegate || !(original instanceof IAdaptable)) {
 				fakeSelection[i] = original;
 			} else {
 				IAdaptable adaptable = (IAdaptable) original;


### PR DESCRIPTION
- Modify the Xbase launching infrastrukture to provide possibilities to
replace selection on an IPackageFragment element using the
JavaElementDelegate.getJavaElementForPackage(IPackageFragment) method.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>