### PR TITLE
[eclipse#1188] Adding a jvm option that skips build before rename

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/SyncUtil.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/ui/SyncUtil.java
@@ -40,6 +40,7 @@ import com.google.inject.Inject;
  */
 public class SyncUtil {
 	private static final Logger LOG = Logger.getLogger(SyncUtil.class);
+	private static final boolean SKIP_WAIT_FOR_BUILD = Boolean.getBoolean("xtext.skipWaitForBuild");
 
 	@Inject(optional = true)
 	private IWorkbench workbench;
@@ -147,7 +148,9 @@ public class SyncUtil {
 
 	public void waitForBuild(IProgressMonitor monitor) {
 		try {
-			workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
+			if ( !SKIP_WAIT_FOR_BUILD) {
+				workspace.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
+			}
 		} catch (CoreException e) {
 			throw new OperationCanceledException(e.getMessage());
 		}


### PR DESCRIPTION
- In some cases when the user tries to rename an element, a build in
advance is not desirable.
- Added to be able to skip build workspace before rename if jvm option
is used and set to true, like -Dxtext.skipWaitForBuild=true.

Signed-off-by: Lidia Popescu <lidia.popescu@windriver.com>