### PR TITLE
[eclipse/xtext#1455] Close streams to fix various tests on windows.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 
 import org.eclipse.core.resources.ICommand;
@@ -237,9 +236,9 @@ public class IResourcesSetupUtil {
 					InterruptedException {
 				create(file.getParent());
 				file.delete(true, monitor());
-				try {
-					file.create(new StringInputStream(s, file.getCharset(true)), true, monitor());
-				} catch (UnsupportedEncodingException exc) {
+				try (InputStream stream = new StringInputStream(s, file.getCharset(true))) {
+					file.create(stream, true, monitor());
+				} catch (IOException exc) {
 					throw new CoreException(new Status(IStatus.ERROR, "org.eclipse.xtext.ui.testing", exc.getMessage(), exc));
 				}
 			}
@@ -251,11 +250,8 @@ public class IResourcesSetupUtil {
 	public static File createTempFile(String fileName, String suffix, String content)
 			throws Exception {
 		File file = File.createTempFile(fileName, suffix);
-		FileWriter writer = new FileWriter(file);
-		try {
+		try (FileWriter writer = new FileWriter(file)) {
 			writer.write(content);
-		} finally {
-			writer.close();
 		}
 		return file;
 	}
@@ -265,13 +261,8 @@ public class IResourcesSetupUtil {
 	}
 	
 	public static byte[] fileToByteArray(IFile file) throws CoreException, IOException {
-		InputStream contents = null;
-		try {
-			contents = file.getContents();
+		try (InputStream contents = file.getContents()) {
 			return ByteStreams.toByteArray(contents);
-		} finally {
-			if (contents != null)
-				contents.close();
 		}
 	}
 

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
@@ -81,16 +81,14 @@ public class JavaProjectSetupUtil {
 	 * creates a JarInputStream containing the passed text files. Each Pair<String
 	 */
 	public static InputStream jarInputStream(TextFile... files) {
-		try {
-			ByteArrayOutputStream out2 = new ByteArrayOutputStream();
-			JarOutputStream jo = new JarOutputStream(new BufferedOutputStream(out2));
+		try (ByteArrayOutputStream out2 = new ByteArrayOutputStream();
+				JarOutputStream jo = new JarOutputStream(new BufferedOutputStream(out2))) {
 			for (TextFile textFile : files) {
 				JarEntry je = new JarEntry(textFile.path);
 				jo.putNextEntry(je);
 				byte[] bytes = textFile.content.getBytes();
 				jo.write(bytes, 0, bytes.length);
 			}
-			jo.close();
 			return new ByteArrayInputStream(out2.toByteArray());
 		} catch (IOException e) {
 			throw new WrappedException(e);
@@ -98,15 +96,12 @@ public class JavaProjectSetupUtil {
 	}
 	
 	public static InputStream jarInputStream(@SuppressWarnings("unchecked") Pair<String, InputStream> ...entries) {
-		try {
-			ByteArrayOutputStream out2 = new ByteArrayOutputStream();
-			JarOutputStream jo = new JarOutputStream(new BufferedOutputStream(out2));
+		try (ByteArrayOutputStream out2 = new ByteArrayOutputStream(); JarOutputStream jo = new JarOutputStream(new BufferedOutputStream(out2))) {
 			for (Pair<String, InputStream> entry : entries) {
 				JarEntry je = new JarEntry(entry.getKey());
 				jo.putNextEntry(je);
 				ByteStreams.copy(entry.getValue(), jo);
 			}
-			jo.close();
 			return new ByteArrayInputStream(out2.toByteArray());
 		} catch (IOException e) {
 			throw new WrappedException(e);

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/JavaProjectSetupUtil.java
@@ -89,6 +89,7 @@ public class JavaProjectSetupUtil {
 				byte[] bytes = textFile.content.getBytes();
 				jo.write(bytes, 0, bytes.length);
 			}
+			jo.close();
 			return new ByteArrayInputStream(out2.toByteArray());
 		} catch (IOException e) {
 			throw new WrappedException(e);
@@ -102,6 +103,7 @@ public class JavaProjectSetupUtil {
 				jo.putNextEntry(je);
 				ByteStreams.copy(entry.getValue(), jo);
 			}
+			jo.close();
 			return new ByteArrayInputStream(out2.toByteArray());
 		} catch (IOException e) {
 			throw new WrappedException(e);

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/ProgressReportingTest.xtend
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/refactoring/ProgressReportingTest.xtend
@@ -16,6 +16,8 @@ import org.junit.Test
 
 import static org.junit.Assert.*
 
+import static extension org.eclipse.xtext.util.Strings.*
+
 /**
  * @author Christian Schneider - Initial contribution and API
  */
@@ -111,8 +113,8 @@ class ProgressReportingTest extends AbstractResourceRelocationTest {
 		
 		def assertLogged(String expectation) {
 			val eventsDump = events.join('\n')
-			if (!eventsDump.startsWith(expectation))
-				throw new ComparisonFailure('', expectation, eventsDump)
+			if (!eventsDump.startsWith(expectation.toUnixLineSeparator))
+				throw new ComparisonFailure('', expectation.toUnixLineSeparator, eventsDump)
 		}
 	}
 }

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/refactoring/ProgressReportingTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/refactoring/ProgressReportingTest.java
@@ -15,6 +15,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.ltk.core.refactoring.resource.RenameResourceDescriptor;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ui.tests.refactoring.AbstractResourceRelocationTest;
+import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ObjectExtensions;
@@ -86,10 +87,11 @@ public class ProgressReportingTest extends AbstractResourceRelocationTest {
     
     public void assertLogged(final String expectation) {
       final String eventsDump = IterableExtensions.join(this.events, "\n");
-      boolean _startsWith = eventsDump.startsWith(expectation);
+      boolean _startsWith = eventsDump.startsWith(Strings.toUnixLineSeparator(expectation));
       boolean _not = (!_startsWith);
       if (_not) {
-        throw new ComparisonFailure("", expectation, eventsDump);
+        String _unixLineSeparator = Strings.toUnixLineSeparator(expectation);
+        throw new ComparisonFailure("", _unixLineSeparator, eventsDump);
       }
     }
   }


### PR DESCRIPTION
e.g. MarkOccurrencesTest and AbstractCompositeHoverTest.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>