### PR TITLE
[eclipse/xtext#1455] Close stream to fix Storage2UriMapperJdtImplTest.

### DIFF
--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJdtImplTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJdtImplTest.java
@@ -69,9 +69,10 @@ public class Storage2UriMapperJdtImplTest extends Assert {
 		URI uri = impl.getUri(fileInJar);
 		assertEquals("archive:platform:/resource/foo/foo.jar!/foo/bar.notindexed", uri.toString());
 		
-		InputStream stream = new ResourceSetImpl().getURIConverter().createInputStream(uri);
-		byte[] bytes = ByteStreams.toByteArray(stream);
-		assertEquals("//empty", new String(bytes));
+		try (InputStream stream = new ResourceSetImpl().getURIConverter().createInputStream(uri)) {
+			byte[] bytes = ByteStreams.toByteArray(stream);
+			assertEquals("//empty", new String(bytes));
+		}
 	}
 	
 	@Test public void testBug463258_02() throws Exception {


### PR DESCRIPTION
Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>