### PR TITLE
[eclipse/xtext#1595] Escape branch name for k8s label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     kubernetes {
-      label 'xtext-eclipse-' + env.BRANCH_NAME + '-' + env.BUILD_NUMBER
+      label 'xtext-eclipse-' + (env.BRANCH_NAME.replace('/','_')) + '-' + env.BUILD_NUMBER
       defaultContainer 'xtext-buildenv'
       yaml '''
 apiVersion: v1


### PR DESCRIPTION
The k8s agent label becomes invalid when the branch name contains '/'.
ERROR: Labels must follow required specs -
https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

This change escapes the slash character by underscore.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>