### PR TITLE
[eclipse/xtext-eclipse#1336] fix check to prevent OutOfBoundsException

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceSearchResultContentProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/findrefs/ReferenceSearchResultContentProvider.java
@@ -213,7 +213,7 @@ public class ReferenceSearchResultContentProvider implements ITreeContentProvide
 			ReferenceSearchViewTreeNode topElement = rootNodesArray[0];
 			Object[] firstChildren = topElement.getChildren().toArray();
 			
-			if (firstChildren.length >= 0) {
+			if (firstChildren.length > 0) {
 				viewer.getComparator().sort(viewer, firstChildren);
 				viewer.setSelection(new StructuredSelection(firstChildren[0]), true);
 			}


### PR DESCRIPTION
the first child should not be selected if there are no children.

Signed-off-by: Mathias Rieder <mathias.rieder@gmail.com>