### PR TITLE
[eclipse/xtext-eclipse#1027] change getAdapter(..) to Adapters.adapt(..)

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/nature/ToggleXtextNatureCommand.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/nature/ToggleXtextNatureCommand.java
@@ -16,8 +16,8 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.handlers.HandlerUtil;
@@ -37,11 +37,7 @@ public class ToggleXtextNatureCommand extends AbstractHandler {
 		ISelection selection = HandlerUtil.getCurrentSelection(event);
 		if (selection instanceof IStructuredSelection) {
 			for (Iterator<?> it = ((IStructuredSelection) selection).iterator(); it.hasNext();) {
-				Object element = it.next();
-				IProject project = null;
-				if (element instanceof IAdaptable) {
-					project = ((IAdaptable) element).getAdapter(IProject.class);
-				}
+				IProject project = Adapters.adapt(it.next(), IProject.class);
 				if (project != null) {
 					toggleNature(project);
 				}

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/StratumBreakpointAdapterFactory.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/StratumBreakpointAdapterFactory.java
@@ -18,6 +18,7 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdapterFactory;
 import org.eclipse.debug.core.DebugPlugin;
@@ -121,8 +122,9 @@ public class StratumBreakpointAdapterFactory implements IAdapterFactory, IToggle
 					result.types = getClassNamePattern(state);
 					result.lang = provider.get(LanguageInfo.class);
 					result.sourceUri = state.getURI();
-					if (editorInput.getAdapter(IClassFile.class) != null) {
-						result.classHandle = editorInput.getAdapter(IClassFile.class).getHandleIdentifier();
+					IClassFile classFile = Adapters.adapt(editorInput, IClassFile.class);
+					if (classFile != null) {
+						result.classHandle = classFile.getHandleIdentifier();
 					}
 					return result;
 				}

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/XbaseLineBreakpoint.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/smap/XbaseLineBreakpoint.java
@@ -11,7 +11,7 @@ package org.eclipse.xtext.builder.smap;
 import java.util.Map;
 
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
@@ -75,14 +75,9 @@ public class XbaseLineBreakpoint extends JavaStratumLineBreakpoint {
 		if (sourceElement == null) {
 			sourceElement = locator.getSourceElement(stackFrame);
 		}
-		if (!(sourceElement instanceof IJavaElement)
-				&& sourceElement instanceof IAdaptable) {
-			Object element = ((IAdaptable) sourceElement)
-					.getAdapter(IJavaElement.class);
-			if (element != null) {
-				sourceElement = element;
-			}
-		}
+		
+		sourceElement = Adapters.adapt(sourceElement, IJavaElement.class);
+		
 		if (sourceElement instanceof IJavaElement) {
 			return ((IJavaElement) sourceElement).getJavaProject();
 		} else if (sourceElement instanceof IResource) {

--- a/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/trace/ClassFileBasedOpenerContributor.java
+++ b/org.eclipse.xtext.common.types.ui/src/org/eclipse/xtext/common/types/ui/trace/ClassFileBasedOpenerContributor.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.common.types.ui.trace;
 
 import org.apache.log4j.Logger;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.ui.IEditorDescriptor;
@@ -39,7 +40,7 @@ public class ClassFileBasedOpenerContributor extends OppositeFileOpenerContribut
 	@Override
 	public boolean collectGeneratedFileOpeners(IEditorPart editor, IAcceptor<FileOpener> acceptor) {
 		if (editor instanceof XtextEditor && editor.getEditorInput() != null) {
-			if (editor.getEditorInput().getAdapter(IClassFile.class) != null) {
+			if (Adapters.adapt(editor.getEditorInput(), IClassFile.class) != null) {
 				acceptor.accept(createEditorOpener(editor.getEditorInput(), JavaUI.ID_CF_EDITOR));
 				return true;
 			}
@@ -51,7 +52,7 @@ public class ClassFileBasedOpenerContributor extends OppositeFileOpenerContribut
 	public boolean collectSourceFileOpeners(IEditorPart editor, IAcceptor<FileOpener> acceptor) {
 		if (!(editor instanceof XtextEditor) && editor.getEditorInput() != null) {
 			try {
-				IClassFile classFile = editor.getEditorInput().getAdapter(IClassFile.class);
+				IClassFile classFile = Adapters.adapt(editor, IClassFile.class);
 				if (classFile == null) {
 					return false;
 				}

--- a/org.eclipse.xtext.ui.ecore/src/org/eclipse/xtext/ui/ecore/EcoreEditorOpener.java
+++ b/org.eclipse.xtext.ui.ecore/src/org/eclipse/xtext/ui/ecore/EcoreEditorOpener.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.ui.ecore;
 
 import java.util.Collections;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -23,7 +24,7 @@ public class EcoreEditorOpener extends LanguageSpecificURIEditorOpener {
 	protected void selectAndReveal(IEditorPart openEditor, URI uri,
 			EReference crossReference, int indexInList, boolean select) {
 		if (uri.fragment() != null) {
-			EcoreEditor ecoreEditor = openEditor.getAdapter(EcoreEditor.class);
+			EcoreEditor ecoreEditor = Adapters.adapt(openEditor, EcoreEditor.class);
 			if (ecoreEditor != null) {
 				EObject eObject = ecoreEditor.getEditingDomain().getResourceSet().getEObject(uri, true);
 				ecoreEditor.setSelectionToViewer(Collections.singletonList(eObject));

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultMergeViewer.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/compare/DefaultMergeViewer.java
@@ -20,8 +20,8 @@ import org.eclipse.compare.contentmergeviewer.IMergeViewerContentProvider;
 import org.eclipse.compare.contentmergeviewer.TextMergeViewer;
 import org.eclipse.compare.structuremergeviewer.ICompareInput;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.text.ITextViewer;
@@ -127,7 +127,7 @@ public class DefaultMergeViewer extends TextMergeViewer {
 	}
 
 	private boolean supportsSharedDocuments(Object object) {
-		return object instanceof IAdaptable && ((IAdaptable) object).getAdapter(ISharedDocumentAdapter.class) != null;
+		return Adapters.adapt(object, ISharedDocumentAdapter.class) != null;
 	}
 
 	@Override

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditor.java
@@ -20,6 +20,7 @@ import org.eclipse.core.commands.operations.IUndoContext;
 import org.eclipse.core.commands.operations.IUndoableOperation;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -366,11 +367,7 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 	}
 
 	public IResource getResource() {
-		Object adapter = getEditorInput().getAdapter(IResource.class);
-		if (adapter != null) {
-			return (IResource) adapter;
-		}
-		return null;
+		return Adapters.adapt(getEditorInput(), IResource.class);
 	}
 
 	@Override
@@ -492,7 +489,7 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 
 			protected IStatus validateEditorInputState(IAdaptable info, IStatus status) {
 				if (Status.OK_STATUS.equals(status) && info != null
-						&& info.getAdapter(ITextEditor.class) == XtextEditor.this) {
+						&& Adapters.adapt(info, ITextEditor.class) == XtextEditor.this) {
 					if (!XtextEditor.this.validateEditorInputState()) {
 						return Status.CANCEL_STATUS;
 					}
@@ -1471,11 +1468,7 @@ public class XtextEditor extends TextEditor implements IDirtyStateEditorSupportC
 	 */
 	@Override
 	public void forceReconcile() {
-		IAdaptable iAdaptable = (IAdaptable) getInternalSourceViewer();
-		if (iAdaptable == null) {
-			return;
-		}
-		Object reconciler = iAdaptable.getAdapter(IReconciler.class);
+		IReconciler reconciler = Adapters.adapt(getInternalSourceViewer(), IReconciler.class);
 		if (reconciler instanceof XtextReconciler)
 			((XtextReconciler)reconciler).forceReconcile();
 	}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditorPropertyTester.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/XtextEditorPropertyTester.java
@@ -9,7 +9,7 @@
 package org.eclipse.xtext.ui.editor;
 
 import org.eclipse.core.expressions.PropertyTester;
-import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.xtext.Constants;
 
 /**
@@ -24,13 +24,10 @@ public class XtextEditorPropertyTester extends PropertyTester {
 
 	@Override
 	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
-		if (receiver instanceof IAdaptable) {
-			IAdaptable adaptable = (IAdaptable) receiver;
-			XtextEditor xtextEditor = adaptable.getAdapter(XtextEditor.class);
+		if (Constants.LANGUAGE_NAME.equals(property)) {
+			XtextEditor xtextEditor = Adapters.adapt(receiver, XtextEditor.class);
 			if (xtextEditor != null) {
-				if (Constants.LANGUAGE_NAME.equals(property)) {
-					return xtextEditor.getLanguageName().equals(expectedValue);
-				}
+				return xtextEditor.getLanguageName().equals(expectedValue);
 			}
 		}
 		return false;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
@@ -28,8 +28,8 @@ import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IEncodedStorage;
 import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.resources.IStorage;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -401,13 +401,11 @@ public class XtextDocumentProvider extends FileDocumentProvider {
 	@Override
 	public long getModificationStamp(Object element) {
 		if (isWorkspaceExternalEditorInput(element)) {
-			if (element instanceof IAdaptable) {
-				IFileStore fileStore = ((IAdaptable) element).getAdapter(IFileStore.class);
-				if (fileStore != null) {
-					IFileInfo info = fileStore.fetchInfo();
-					if (info.exists()) {
-						return info.getLastModified();
-					}
+			IFileStore fileStore = Adapters.adapt(element, IFileStore.class);
+			if (fileStore != null) {
+				IFileInfo info = fileStore.fetchInfo();
+				if (info.exists()) {
+					return info.getLastModified();
 				}
 			}
 			return IDocumentExtension4.UNKNOWN_MODIFICATION_STAMP;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/AbstractPreferencePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/AbstractPreferencePage.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
@@ -88,7 +89,7 @@ public abstract class AbstractPreferencePage extends FieldEditorPreferencePage i
 
 	@Override
 	public void setElement(IAdaptable element) {
-		this.project = element.getAdapter(IProject.class);
+		this.project = Adapters.adapt(element, IProject.class);
 	}
 
 	@Override

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/MarkerResolutionGenerator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/quickfix/MarkerResolutionGenerator.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
@@ -179,7 +180,7 @@ public class MarkerResolutionGenerator extends AbstractIssueResolutionProviderAd
 				if (editor instanceof XtextEditor) {
 					result = (XtextEditor) editor;
 				} else if (editor != null) {
-					result = editor.getAdapter(XtextEditor.class);
+					result = Adapters.adapt(editor, XtextEditor.class);
 				}
 			} catch (PartInitException e) {
 				return null;
@@ -196,7 +197,7 @@ public class MarkerResolutionGenerator extends AbstractIssueResolutionProviderAd
 			if(editor instanceof XtextEditor) {
 				return (XtextEditor)editor;
 			} else if (editor != null) {
-				return editor.getAdapter(XtextEditor.class);
+				return Adapters.adapt(editor, XtextEditor.class);
 			}
 		}
 		return null;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/toggleComments/ToggleSLCommentAction.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/toggleComments/ToggleSLCommentAction.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 
 import org.apache.log4j.Logger;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -285,7 +286,7 @@ public class ToggleSLCommentAction extends TextEditorAction {
 
 		ITextEditor editor= getTextEditor();
 		if (fOperationTarget == null && editor != null)
-			fOperationTarget= editor.getAdapter(ITextOperationTarget.class);
+			fOperationTarget= Adapters.adapt(editor, ITextOperationTarget.class);
 
 		boolean isEnabled= (fOperationTarget != null && fOperationTarget.canDoOperation(ITextOperationTarget.PREFIX) && fOperationTarget.canDoOperation(ITextOperationTarget.STRIP_PREFIX));
 		setEnabled(isEnabled);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/utils/EditorUtils.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/utils/EditorUtils.java
@@ -13,6 +13,7 @@ import org.apache.log4j.Logger;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IStorage;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jdt.core.IJarEntryResource;
 import org.eclipse.jdt.internal.ui.javaeditor.JarEntryEditorInput;
 import org.eclipse.jface.preference.PreferenceConverter;
@@ -85,8 +86,8 @@ public class EditorUtils {
 		IEditorPart activeEditor = HandlerUtil.getActiveEditor(event);
 		if (activeEditor == null)
 			return null;
-		XtextEditor xtextEditor = activeEditor.getAdapter(XtextEditor.class);
-		return xtextEditor;
+		
+		return Adapters.adapt(activeEditor, XtextEditor.class);
 	}
 
 	public static XtextEditor getActiveXtextEditor() {
@@ -94,21 +95,20 @@ public class EditorUtils {
 		IWorkbenchWindow workbenchWindow = workbench.getActiveWorkbenchWindow();
 		if (workbenchWindow == null) 
 			return null;
+		
 		IWorkbenchPage activePage = workbenchWindow.getActivePage();
 		if (activePage == null) 
 			return null;
+		
 		IEditorPart activeEditor = activePage.getActiveEditor();
 		if (activeEditor == null)
 			return null;
-		XtextEditor xtextEditor = activeEditor.getAdapter(XtextEditor.class);
-		return xtextEditor;
+		
+		return Adapters.adapt(activeEditor, XtextEditor.class);
 	}
 
 	public static XtextEditor getXtextEditor(IEditorPart openEditor) {
-		if (openEditor != null) {
-			return openEditor.getAdapter(XtextEditor.class);
-		}
-		return null;
+		return Adapters.adapt(openEditor, XtextEditor.class);
 	}
 	
 	/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/FileOpener.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/generator/trace/FileOpener.java
@@ -8,8 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.generator.trace;
 
-import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.IWorkbenchPage;
 
@@ -19,17 +18,7 @@ import org.eclipse.ui.IWorkbenchPage;
 public abstract class FileOpener {
 
 	protected <T> T adapt(Object object, Class<T> type) {
-		if (type.isInstance(object))
-			return type.cast(object);
-		if (object instanceof IAdaptable) {
-			Object result = ((IAdaptable) object).getAdapter(type);
-			if (type.isInstance(result))
-				return type.cast(result);
-		}
-		Object result = Platform.getAdapterManager().getAdapter(object, type);
-		if (type.isInstance(result))
-			return type.cast(object);
-		return null;
+		return Adapters.adapt(object, type);
 	}
 
 	public abstract ImageDescriptor getImageDescriptor();

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/preferences/PropertyAndPreferencePage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/preferences/PropertyAndPreferencePage.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.ControlEnableState;
@@ -316,7 +317,7 @@ public abstract class PropertyAndPreferencePage extends PreferencePage implement
 
 	@Override
 	public void setElement(IAdaptable element) {
-		project = (IProject) element.getAdapter(IResource.class);
+		project = Adapters.adapt(element, IProject.class);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DefaultRefactoringDocumentProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/DefaultRefactoringDocumentProvider.java
@@ -14,6 +14,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
@@ -21,7 +22,6 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.TextFileChange;
 import org.eclipse.text.edits.TextEdit;
-import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
@@ -84,12 +84,11 @@ public class DefaultRefactoringDocumentProvider implements IRefactoringDocument.
 						protected ITextEditor run() throws Exception {
 							IWorkbenchWindow activeWorkbenchWindow = workbench.getActiveWorkbenchWindow();
 							IWorkbenchPage activePage = activeWorkbenchWindow.getActivePage();
-							IEditorPart editor = activePage.findEditor(fileEditorInput);
-							if (editor instanceof ITextEditor) {
-								if (editor instanceof ITextEditorExtension
-										&& ((ITextEditorExtension) editor).isEditorInputReadOnly())
+							ITextEditor editor = Adapters.adapt(activePage.findEditor(fileEditorInput), ITextEditor.class);
+							if (editor != null) {
+								if (editor instanceof ITextEditorExtension && ((ITextEditorExtension) editor).isEditorInputReadOnly())
 									status.add(ERROR, "Editor for {0} is read only", fileEditorInput.getName());
-								return ((ITextEditor) editor);
+								return (editor);
 							}
 							return null;
 						}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring2/ChangeConverter.xtend
@@ -13,6 +13,7 @@ import com.google.inject.Inject
 import java.io.ByteArrayOutputStream
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IWorkspace
+import org.eclipse.core.runtime.Adapters
 import org.eclipse.ltk.core.refactoring.Change
 import org.eclipse.ltk.core.refactoring.CompositeChange
 import org.eclipse.ltk.core.refactoring.TextFileChange
@@ -168,7 +169,7 @@ class ChangeConverter implements IAcceptor<IEmfResourceChange> {
 					.activeWorkbenchWindow
 					.activePage
 					.editorReferences
-					.map[ getEditor(false) ]
+					.map[ Adapters.adapt(getEditor(false), ITextEditor) ]
 					.filter(ITextEditor)
 					.findFirst[ it.editorInput == editorInput ]
 			}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/NewFileWizardPrimaryPage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/NewFileWizardPrimaryPage.java
@@ -16,7 +16,7 @@ import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
@@ -130,19 +130,12 @@ public class NewFileWizardPrimaryPage extends WizardPage implements IParameterPa
 	}
 
 	private String getFolderFromSelection() {
-		Object element = selection.getFirstElement();
+		Object element = Adapters.adapt(selection.getFirstElement(), IResource.class);
 		IContainer container = null;
 		if (element instanceof IContainer) {
 			container = (IContainer) element;
 		} else if (element instanceof IResource) {
 			container = ((IResource) element).getParent();
-		} else if (element instanceof IAdaptable) {
-			IResource adapter = ((IAdaptable) element).getAdapter(IResource.class);
-			if (adapter instanceof IContainer) {
-				container = (IContainer) adapter;
-			} else if (adapter != null) {
-				container = adapter.getParent();
-			}
 		}
 		if (container != null) {
 			return getFolderStringFromContainer(container);

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/refactoring2/ChangeConverter.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.ltk.core.refactoring.Change;
@@ -30,7 +31,6 @@ import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.part.FileEditorInput;
@@ -266,14 +266,14 @@ public class ChangeConverter implements IAcceptor<IEmfResourceChange> {
         @Override
         protected ITextEditor run() throws Exception {
           final FileEditorInput editorInput = new FileEditorInput(file);
-          final Function1<IEditorReference, IEditorPart> _function = (IEditorReference it) -> {
-            return it.getEditor(false);
+          final Function1<IEditorReference, ITextEditor> _function = (IEditorReference it) -> {
+            return Adapters.<ITextEditor>adapt(it.getEditor(false), ITextEditor.class);
           };
           final Function1<ITextEditor, Boolean> _function_1 = (ITextEditor it) -> {
             IEditorInput _editorInput = it.getEditorInput();
             return Boolean.valueOf(Objects.equal(_editorInput, editorInput));
           };
-          return IterableExtensions.<ITextEditor>findFirst(Iterables.<ITextEditor>filter(ListExtensions.<IEditorReference, IEditorPart>map(((List<IEditorReference>)Conversions.doWrapArray(ChangeConverter.this.workbench.getActiveWorkbenchWindow().getActivePage().getEditorReferences())), _function), ITextEditor.class), _function_1);
+          return IterableExtensions.<ITextEditor>findFirst(Iterables.<ITextEditor>filter(ListExtensions.<IEditorReference, ITextEditor>map(((List<IEditorReference>)Conversions.doWrapArray(ChangeConverter.this.workbench.getActiveWorkbenchWindow().getActivePage().getEditorReferences())), _function), ITextEditor.class), _function_1);
         }
       }.syncExec();
     }

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/actions/ImportsAwareClipboardAction.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/actions/ImportsAwareClipboardAction.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -255,7 +256,7 @@ public class ImportsAwareClipboardAction extends TextEditorAction {
 	}
 
 	private void doPasteXbaseCode(XbaseClipboardData xbaseClipboardData, boolean withImports) {
-		IRewriteTarget target = getTextEditor().getAdapter(IRewriteTarget.class);
+		IRewriteTarget target = Adapters.adapt(getTextEditor(), IRewriteTarget.class);
 		if (target != null) {
 			target.beginCompoundChange();
 		}
@@ -276,7 +277,7 @@ public class ImportsAwareClipboardAction extends TextEditorAction {
 	}
 
 	private void doPasteJavaCode(String textFromClipboard, JavaImportData javaImportsContent, boolean withImports) {
-		IRewriteTarget target = getTextEditor().getAdapter(IRewriteTarget.class);
+		IRewriteTarget target = Adapters.adapt(getTextEditor(), IRewriteTarget.class);
 		if (target != null) {
 			target.beginCompoundChange();
 		}
@@ -346,9 +347,9 @@ public class ImportsAwareClipboardAction extends TextEditorAction {
 			setEnabled(false);
 			return;
 		}
-		ITextEditor editor = getTextEditor();
-		if (textOperationTarget == null && editor != null)
-			textOperationTarget = editor.getAdapter(ITextOperationTarget.class);
+		if (textOperationTarget == null) {
+			textOperationTarget = Adapters.adapt(getTextEditor(), ITextOperationTarget.class);
+		}
 		boolean isEnabled = (textOperationTarget != null && textOperationTarget.canDoOperation(getOperationCode()));
 		setEnabled(isEnabled);
 	}

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/actions/XbaseFoldingActionContributor.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/editor/actions/XbaseFoldingActionContributor.java
@@ -10,6 +10,7 @@ package org.eclipse.xtext.xbase.ui.editor.actions;
 
 import java.util.ResourceBundle;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jface.text.ITextOperationTarget;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
@@ -67,7 +68,7 @@ public class XbaseFoldingActionContributor extends FoldingActionContributor {
 
 		@Override
 		public void update() {
-			ITextOperationTarget target = getTextEditor().getAdapter(ITextOperationTarget.class);
+			ITextOperationTarget target = Adapters.adapt(getTextEditor(), ITextOperationTarget.class);
 			boolean isEnabled = (target instanceof ProjectionViewer);
 			setEnabled(isEnabled);
 		}

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JUnitLaunchShortcut.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JUnitLaunchShortcut.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.ui.launching;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -28,7 +29,7 @@ public class JUnitLaunchShortcut extends org.eclipse.jdt.junit.launcher.JUnitLau
 	
 	@Override
 	public void launch(IEditorPart editor, String mode) {
-		JavaElementDelegate javaElementDelegate = editor.getAdapter(JavaElementDelegateJunitLaunch.class);
+		JavaElementDelegate javaElementDelegate = Adapters.adapt(editor, JavaElementDelegateJunitLaunch.class);
 		if (javaElementDelegate != null) {
 			launch(new StructuredSelection(javaElementDelegate), mode);
 		} else {

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JUnitPDELaunchShortcut.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JUnitPDELaunchShortcut.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.ui.launching;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -28,7 +29,7 @@ public class JUnitPDELaunchShortcut extends org.eclipse.pde.ui.launcher.JUnitWor
 	
 	@Override
 	public void launch(IEditorPart editor, String mode) {
-		JavaElementDelegate javaElementDelegate = editor.getAdapter(JavaElementDelegateJunitLaunch.class);
+		JavaElementDelegate javaElementDelegate = Adapters.adapt(editor, JavaElementDelegateJunitLaunch.class);
 		if (javaElementDelegate != null) {
 			launch(new StructuredSelection(javaElementDelegate), mode);
 		} else {

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaApplicationLaunchShortcut.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/JavaApplicationLaunchShortcut.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.ui.launching;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.StructuredSelection;
@@ -29,7 +30,7 @@ public class JavaApplicationLaunchShortcut extends
 
 	@Override
 	public void launch(IEditorPart editor, String mode) {
-		JavaElementDelegate javaElementDelegate = editor.getAdapter(JavaElementDelegateMainLaunch.class);
+		JavaElementDelegate javaElementDelegate = Adapters.adapt(editor, JavaElementDelegateMainLaunch.class);
 		if (javaElementDelegate != null) {
 			launch(new StructuredSelection(javaElementDelegate), mode);
 		} else {

--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/LaunchShortcutUtil.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/launching/LaunchShortcutUtil.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.ui.launching;
 
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -26,8 +27,8 @@ public class LaunchShortcutUtil {
 			if (original == null || original instanceof IJavaElement || original instanceof JavaElementDelegate || !(original instanceof IAdaptable)) {
 				fakeSelection[i] = original;
 			} else {
-				IAdaptable adaptable = (IAdaptable) original;
-				JavaElementDelegate javaElementDelegate = adaptable.getAdapter(delegateType);
+				
+				JavaElementDelegate javaElementDelegate = Adapters.adapt(original, delegateType);
 				if (javaElementDelegate != null) {
 					fakeSelection[i] = javaElementDelegate;
 				} else {

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/launcher/SelectionUtil.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/launcher/SelectionUtil.java
@@ -11,7 +11,7 @@ package org.eclipse.xtext.xtext.launcher;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.common.util.URI;
@@ -56,8 +56,9 @@ public class SelectionUtil {
 		if (selection instanceof IStructuredSelection) {
 			IStructuredSelection ssel = (IStructuredSelection) selection;
 			Object firstElement = ssel.getFirstElement();
-			if (firstElement instanceof IAdaptable) {
-				return ((IAdaptable) firstElement).getAdapter(IFile.class);
+			IFile file = Adapters.adapt(firstElement, IFile.class);
+			if (file != null) {
+				return file;
 			}
 			else if (firstElement instanceof IOutlineNode) {
 				IOutlineNode outlineNode = (IOutlineNode) firstElement;


### PR DESCRIPTION
change most of the direct calls to
org.eclipse.core.runtime.IAdaptable.getAdapter(Class<T>) to
org.eclipse.core.runtime.Adapters.adapt(Object, Class<T>) to also invite
registered AdapterFactories.

Signed-off-by: Mathias Rieder <mathias.rieder@gmail.com>