### PR TITLE
[eclipse/xtext-eclipse#1361] fixed embedded editor context activation in templates editor in preference pages

### DIFF
--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/SingleCodetemplateUiModule.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/SingleCodetemplateUiModule.java
@@ -12,6 +12,7 @@ import org.eclipse.xtext.scoping.IScopeProvider;
 import org.eclipse.xtext.service.SingletonBinding;
 import org.eclipse.xtext.ui.codetemplates.ui.contentassist.SingleCodetemplateProposalProvider;
 import org.eclipse.xtext.ui.codetemplates.ui.contentassist.SingleTemplateProposalConflictHelper;
+import org.eclipse.xtext.ui.codetemplates.ui.editor.embedded.CodetemplatesEmbeddedEditorActions;
 import org.eclipse.xtext.ui.codetemplates.ui.highlighting.SemanticHighlighter;
 import org.eclipse.xtext.ui.codetemplates.ui.highlighting.SingleTemplateTokenDefProvider;
 import org.eclipse.xtext.ui.codetemplates.ui.highlighting.TemplatesHighlightingConfiguration;
@@ -24,6 +25,7 @@ import org.eclipse.xtext.ui.codetemplates.validation.CodetemplatesValidator;
 import org.eclipse.xtext.ui.editor.contentassist.IContentProposalProvider;
 import org.eclipse.xtext.ui.editor.contentassist.IProposalConflictHelper;
 import org.eclipse.xtext.ui.editor.contentassist.RepeatedContentAssistProcessor;
+import org.eclipse.xtext.ui.editor.embedded.EmbeddedEditorActions;
 import org.eclipse.xtext.ui.editor.model.IResourceForEditorInputFactory;
 import org.eclipse.xtext.ui.editor.model.ResourceForIEditorInputFactory;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess;
@@ -122,6 +124,10 @@ public class SingleCodetemplateUiModule extends org.eclipse.xtext.ui.codetemplat
 	public Provider<LanguageRegistry> provideLanguageRegistry() {
 		Injector injector = CodetemplatesActivator.getInstance().getInjector("org.eclipse.xtext.ui.codetemplates.Codetemplates");
 		return injector.getProvider(LanguageRegistry.class);
+	}
+	
+	public Class<? extends EmbeddedEditorActions.Factory> bindEmbeddedEditorActions$Factory() {
+		return CodetemplatesEmbeddedEditorActions.Factory.class;
 	}
 
 }

--- a/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/editor/embedded/CodetemplatesEmbeddedEditorActions.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src/org/eclipse/xtext/ui/codetemplates/ui/editor/embedded/CodetemplatesEmbeddedEditorActions.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ui.codetemplates.ui.editor.embedded;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.commands.ActionHandler;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.ActiveShellExpression;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.contexts.IContextActivation;
+import org.eclipse.ui.contexts.IContextService;
+import org.eclipse.ui.handlers.IHandlerActivation;
+import org.eclipse.ui.handlers.IHandlerService;
+import org.eclipse.xtext.ui.editor.embedded.EmbeddedEditorActions;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+
+/**
+ * @author cdietrich - Initial contribution and API
+ */
+public class CodetemplatesEmbeddedEditorActions extends EmbeddedEditorActions {
+
+	public static class Factory extends EmbeddedEditorActions.Factory {
+
+		@Inject(optional = true)
+		protected IWorkbench workbench;
+
+		@Override
+		protected EmbeddedEditorActions createActions(ISourceViewer viewer) {
+			return new CodetemplatesEmbeddedEditorActions(viewer, workbench);
+		}
+
+	}
+
+	public CodetemplatesEmbeddedEditorActions(ISourceViewer viewer, IWorkbench workbench) {
+		super(viewer, workbench);
+	}
+
+	@Override
+	protected void createFocusAndDisposeListeners() {
+		final List<IHandlerActivation> handlerActivations = Lists.newArrayListWithExpectedSize(3);
+		final IHandlerService handlerService = workbench.getAdapter(IHandlerService.class);
+		final IContextService contextService = workbench.getAdapter(IContextService.class);
+		Shell shell = viewer.getTextWidget().getShell();
+		final ActiveShellExpression expression = new ActiveShellExpression(shell);
+		AtomicReference<IContextActivation> contextActivationHolder = new AtomicReference<>();
+
+		shell.addDisposeListener(new DisposeListener() {
+			@Override
+			public void widgetDisposed(DisposeEvent e) {
+				handlerService.deactivateHandlers(handlerActivations);
+			}
+		});
+
+		viewer.getTextWidget().addFocusListener(new FocusListener() {
+			@Override
+			public void focusLost(FocusEvent e) {
+				IContextActivation contextActivation = contextActivationHolder.get();
+				if (contextActivation != null) {
+					contextService.deactivateContext(contextActivation);
+				}
+				handlerService.deactivateHandlers(handlerActivations);
+				handlerActivations.clear();
+			}
+
+			@Override
+			public void focusGained(FocusEvent e) {
+				final IContextActivation contextActivation = contextService.activateContext(EMBEDDED_TEXT_EDITOR_SCOPE, expression);
+				contextActivationHolder.set(contextActivation);
+				for (final IAction action : allActions.values()) {
+					handlerActivations.add(
+							handlerService.activateHandler(action.getActionDefinitionId(), new ActionHandler(action), expression, true));
+				}
+			}
+
+		});
+	}
+
+}

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorActions.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/embedded/EmbeddedEditorActions.java
@@ -121,6 +121,31 @@ public class EmbeddedEditorActions {
 	}
 	
 	protected void initialize() {
+		createFocusAndDisposeListeners();
+
+		createActions();
+
+		// create context menu
+		MenuManager manager = new MenuManager(null, null);
+		manager.setRemoveAllWhenShown(true);
+		manager.addMenuListener(new IMenuListener() {
+			@Override
+			public void menuAboutToShow(IMenuManager mgr) {
+				fillContextMenu(mgr);
+			}
+		});
+
+		StyledText text = viewer.getTextWidget();
+		Menu menu = manager.createContextMenu(text);
+		text.setMenu(menu);
+		
+		List<ActionActivationCode> activationCodes = Lists.newArrayList();
+		setActionActivationCode(activationCodes, ITextEditorActionConstants.SHIFT_RIGHT_TAB,'\t', -1, SWT.NONE);
+		setActionActivationCode(activationCodes, ITextEditorActionConstants.SHIFT_LEFT, '\t', -1, SWT.SHIFT);
+		viewer.getTextWidget().addVerifyKeyListener(new ActivationCodeTrigger(allActions, activationCodes));
+	}
+
+	protected void createFocusAndDisposeListeners() {
 		final List<IHandlerActivation> handlerActivations = Lists.newArrayListWithExpectedSize(3);
 		final IHandlerService handlerService = workbench.getAdapter(IHandlerService.class);
 		final IContextService contextService = workbench.getAdapter(IContextService.class);
@@ -151,27 +176,6 @@ public class EmbeddedEditorActions {
 			}
 			
 		});
-
-		createActions();
-
-		// create context menu
-		MenuManager manager = new MenuManager(null, null);
-		manager.setRemoveAllWhenShown(true);
-		manager.addMenuListener(new IMenuListener() {
-			@Override
-			public void menuAboutToShow(IMenuManager mgr) {
-				fillContextMenu(mgr);
-			}
-		});
-
-		StyledText text = viewer.getTextWidget();
-		Menu menu = manager.createContextMenu(text);
-		text.setMenu(menu);
-		
-		List<ActionActivationCode> activationCodes = Lists.newArrayList();
-		setActionActivationCode(activationCodes, ITextEditorActionConstants.SHIFT_RIGHT_TAB,'\t', -1, SWT.NONE);
-		setActionActivationCode(activationCodes, ITextEditorActionConstants.SHIFT_LEFT, '\t', -1, SWT.SHIFT);
-		viewer.getTextWidget().addVerifyKeyListener(new ActivationCodeTrigger(allActions, activationCodes));
 	}
 	
 	protected void fillContextMenu(IMenuManager menu) {


### PR DESCRIPTION
[eclipse/xtext-eclipse#1361] fixed embedded editor context activation in templates editor in preference pages

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>