### PR TITLE
[eclipse/xtext-core#1418] removed redundant superinterface from generated ca parsers

### DIFF
--- a/org.eclipse.xtext.builder.tests/src-gen/org/eclipse/xtext/builder/tests/ide/contentassist/antlr/PartialBuilderTestLanguageContentAssistParser.java
+++ b/org.eclipse.xtext.builder.tests/src-gen/org/eclipse/xtext/builder/tests/ide/contentassist/antlr/PartialBuilderTestLanguageContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialBuilderTestLanguageContentAssistParser extends BuilderTestLanguageParser implements IPartialEditingContentAssistParser {
+public class PartialBuilderTestLanguageContentAssistParser extends BuilderTestLanguageParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.ui.codetemplates.ide/src-gen/org/eclipse/xtext/ui/codetemplates/ide/contentassist/antlr/PartialCodetemplatesContentAssistParser.java
+++ b/org.eclipse.xtext.ui.codetemplates.ide/src-gen/org/eclipse/xtext/ui/codetemplates/ide/contentassist/antlr/PartialCodetemplatesContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialCodetemplatesContentAssistParser extends CodetemplatesParser implements IPartialEditingContentAssistParser {
+public class PartialCodetemplatesContentAssistParser extends CodetemplatesParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/xmleditor/ide/contentassist/antlr/PartialXmlContentAssistParser.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/xmleditor/ide/contentassist/antlr/PartialXmlContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialXmlContentAssistParser extends XmlParser implements IPartialEditingContentAssistParser {
+public class PartialXmlContentAssistParser extends XmlParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/src-gen/org/eclipse/xtext/example/arithmetics/ide/contentassist/antlr/PartialArithmeticsContentAssistParser.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ide/src-gen/org/eclipse/xtext/example/arithmetics/ide/contentassist/antlr/PartialArithmeticsContentAssistParser.java
@@ -13,10 +13,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialArithmeticsContentAssistParser extends ArithmeticsParser implements IPartialEditingContentAssistParser {
+public class PartialArithmeticsContentAssistParser extends ArithmeticsParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ide/src-gen/org/eclipse/xtext/example/domainmodel/ide/contentassist/antlr/PartialDomainmodelContentAssistParser.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ide/src-gen/org/eclipse/xtext/example/domainmodel/ide/contentassist/antlr/PartialDomainmodelContentAssistParser.java
@@ -13,10 +13,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialDomainmodelContentAssistParser extends DomainmodelParser implements IPartialEditingContentAssistParser {
+public class PartialDomainmodelContentAssistParser extends DomainmodelParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ide/src-gen/org/eclipse/xtext/example/fowlerdsl/ide/contentassist/antlr/PartialStatemachineContentAssistParser.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ide/src-gen/org/eclipse/xtext/example/fowlerdsl/ide/contentassist/antlr/PartialStatemachineContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialStatemachineContentAssistParser extends StatemachineParser implements IPartialEditingContentAssistParser {
+public class PartialStatemachineContentAssistParser extends StatemachineParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ide/src-gen/org/eclipse/xtext/example/homeautomation/ide/contentassist/antlr/PartialRuleEngineContentAssistParser.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ide/src-gen/org/eclipse/xtext/example/homeautomation/ide/contentassist/antlr/PartialRuleEngineContentAssistParser.java
@@ -7,10 +7,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialRuleEngineContentAssistParser extends RuleEngineParser implements IPartialEditingContentAssistParser {
+public class PartialRuleEngineContentAssistParser extends RuleEngineParser {
 
 	private AbstractRule rule;
 

--- a/org.eclipse.xtext.xtext.ui.tests/src-gen/org/eclipse/xtext/xtext/ui/ecore2xtext/ide/contentassist/antlr/PartialEcore2XtextTestContentAssistParser.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src-gen/org/eclipse/xtext/xtext/ui/ecore2xtext/ide/contentassist/antlr/PartialEcore2XtextTestContentAssistParser.java
@@ -8,10 +8,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialEcore2XtextTestContentAssistParser extends Ecore2XtextTestParser implements IPartialEditingContentAssistParser {
+public class PartialEcore2XtextTestContentAssistParser extends Ecore2XtextTestParser {
 
 	private AbstractRule rule;
 


### PR DESCRIPTION
[eclipse/xtext-core#1418] removed redundant superinterface from generated ca parsers

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>