### PR TITLE
[#1391] Use System.lineSeparator in XtextGrammarQuickfixProvider.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 RCP Vision s.r.l. (http://www.rcp-vision.com) and others.
+ * Copyright (c) 2019, 2020 RCP Vision s.r.l. (http://www.rcp-vision.com) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -25,7 +25,31 @@ import static org.eclipse.xtext.xtext.XtextConfigurableIssueCodes.SPACES_IN_KEYW
 @RunWith(XtextRunner)
 @InjectWith(XtextGrammarQuickfixTest.InjectorProvider)
 class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
-	
+
+	@Test def test_fix_missing_rule() {
+		'''
+			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+			
+			generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+			
+			Model:
+				greetings+=Greeting*;
+		'''
+		.testQuickfixesOn("org.eclipse.xtext.grammar.UnresolvedRule", new Quickfix("Create rule 'Greeting'", "Create rule 'Greeting'", '''
+			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+			
+			generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+			
+			Model:
+				greetings+=Greeting*;
+			
+			Greeting:
+				
+			;
+			''')
+		);
+	}
+
 	@Test def test_fix_empty_keyword() {
 		'''
 			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
@@ -76,11 +100,11 @@ class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
 			Model: 'model' a=ID;
 		''')
 	}
-	
+
 	private def removeEmptyKeywordQuickfix(String result) {
 		new Quickfix("Remove empty keyword", "Remove empty keyword", result)
 	}
-	
+
 	private def replaceEmptyKeywordWithRuleNameQuickfix(String result) {
 		new Quickfix("Replace empty keyword with rule name", "Replace empty keyword with rule name", result)
 	}

--- a/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 RCP Vision s.r.l. (http://www.rcp-vision.com) and others.
+ * Copyright (c) 2019, 2020 RCP Vision s.r.l. (http://www.rcp-vision.com) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -31,6 +31,43 @@ public class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
     public Injector getInjector() {
       return Activator.getDefault().getInjector(Activator.ORG_ECLIPSE_XTEXT_XTEXT);
     }
+  }
+  
+  @Test
+  public void test_fix_missing_rule() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Model:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("greetings+=Greeting*;");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("Model:");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("greetings+=Greeting*;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("Greeting:");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append(";");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Create rule \'Greeting\'", "Create rule \'Greeting\'", _builder_1.toString());
+    this.testQuickfixesOn(_builder, "org.eclipse.xtext.grammar.UnresolvedRule", _quickfix);
   }
   
   @Test

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProvider.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 Michael Clay and others.
+ * Copyright (c) 2010, 2020 Michael Clay and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -144,10 +144,11 @@ public class XtextGrammarQuickfixProvider extends DefaultQuickfixProvider {
 						AbstractRule abstractRule = EcoreUtil2.getContainerOfType(element, ParserRule.class);
 						ICompositeNode node = NodeModelUtils.getNode(abstractRule);
 						int offset = node.getEndOffset();
-						StringBuilder builder = new StringBuilder("\n\n");
+						String nl = System.lineSeparator();
+						StringBuilder builder = new StringBuilder(nl+nl);
 						if (abstractRule instanceof TerminalRule)
 							builder.append("terminal ");
-						String newRule = builder.append(ruleName).append(":\n\t\n;").toString();
+						String newRule = builder.append(ruleName).append(":" + nl + "\t" + nl + ";").toString();
 						context.getXtextDocument().replace(offset, 0, newRule);
 					}
 				});


### PR DESCRIPTION
- Modify the XtextGrammarQuickfixProvider to use system specific line
separators instead of the hard-coded '\n' symbol.
- Implement corresponding XtextGrammarQuickfixTest test case.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>