### PR TITLE
[eclipse/xtext-xtend#1034] restored old default (Object) case

### DIFF
--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/labeling/XbaseLabelProvider.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/labeling/XbaseLabelProvider.java
@@ -101,9 +101,12 @@ public class XbaseLabelProvider extends DefaultEObjectLabelProvider {
 			return _imageDescriptor((XImportSection) obj);
 		} else if (obj instanceof IResolvedField) {
 			return _imageDescriptor((IResolvedField) obj);
-		} else {
-			return null;
 		}
+		return _imageDescriptor(obj);
+	}
+
+	protected ImageDescriptor _imageDescriptor(Object element) {
+		return null;
 	}
 
 	protected ImageDescriptor _imageDescriptor(XImportSection importSection) {


### PR DESCRIPTION
[eclipse/xtext-xtend#1034] restored old default (Object) case
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>