### PR TITLE
Refactoring the org.eclipse.xtext.xtext.ui test cases.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/editor/autoedit/XtextAutoEditStrategyTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/editor/autoedit/XtextAutoEditStrategyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -14,24 +14,32 @@ import java.util.Collections;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swt.SWT;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.testing.AbstractCStyleLanguageAutoEditTest;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.util.JREContainerProvider;
 import org.eclipse.xtext.ui.util.PluginProjectFactory;
-import org.eclipse.xtext.xtext.ui.internal.Activator;
+import org.eclipse.xtext.xtext.ui.XtextUiInjectorProvider;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import com.google.inject.Injector;
+import com.google.inject.Inject;
 
 /**
  * @author Michael Clay - Initial contribution and API
  */
+@RunWith(XtextRunner.class)
+@InjectWith(XtextUiInjectorProvider.class)
 public class XtextAutoEditStrategyTest extends AbstractCStyleLanguageAutoEditTest {
+
+	@Inject
+	private PluginProjectFactory projectFactory;
+
 	private static final String SAMPLE_HEADER = "grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals\ngenerate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"\n";
 	private static final String TESTPROJECT_NAME = "autoedit";
 	private IProject autoEditTestProject;
@@ -39,11 +47,6 @@ public class XtextAutoEditStrategyTest extends AbstractCStyleLanguageAutoEditTes
 	@Override
 	protected String getFileExtension() {
 		return "xtext";
-	}
-
-	@Override
-	protected String getEditorId() {
-		return "org.eclipse.xtext.Xtext";
 	}
 	
 	@Override
@@ -311,9 +314,7 @@ public class XtextAutoEditStrategyTest extends AbstractCStyleLanguageAutoEditTes
 			createPluginProject(TESTPROJECT_NAME);
 	}
 
-	protected IProject createPluginProject(String name) throws CoreException {
-		Injector injector = Activator.getInstance().getInjector("org.eclipse.xtext.Xtext");
-		PluginProjectFactory projectFactory = injector.getInstance(PluginProjectFactory.class);
+	protected IProject createPluginProject(String name) {
 		projectFactory.setBreeToUse(JREContainerProvider.PREFERRED_BREE);
 		projectFactory.setProjectName(name);
 		projectFactory.addFolders(Collections.singletonList("src"));

--- a/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/refactoring/XtextGrammarRefactoringIntegrationTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src-longrunning/org/eclipse/xtext/xtext/ui/refactoring/XtextGrammarRefactoringIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -37,6 +37,8 @@ import org.eclipse.xtext.ParserRule;
 import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.XtextPackage;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.refactoring.ui.IRenameElementContext;
@@ -46,20 +48,22 @@ import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.TargetPlatformUtil;
 import org.eclipse.xtext.util.SimpleAttributeResolver;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
-import org.eclipse.xtext.xtext.ui.Activator;
+import org.eclipse.xtext.xtext.ui.XtextUiInjectorProvider;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
-import com.google.inject.Injector;
 import com.google.inject.Provider;
 
 /**
  * @author Holger Schill - Initial contribution and API
  */
 @SuppressWarnings("restriction")
+@RunWith(XtextRunner.class)
+@InjectWith(XtextUiInjectorProvider.class)
 public class XtextGrammarRefactoringIntegrationTest extends AbstractLinkedEditingIntegrationTest {
 
 	private static final String REFACTOREDCLASSIFIERNAME = "Greeting123";
@@ -88,7 +92,6 @@ public class XtextGrammarRefactoringIntegrationTest extends AbstractLinkedEditin
 	@Inject
 	private Provider<ResourceSet> resourceSetProvider;
 
-	@SuppressWarnings("static-access")
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
@@ -96,8 +99,6 @@ public class XtextGrammarRefactoringIntegrationTest extends AbstractLinkedEditin
 		project = createProject(TEST_PROJECT);
 		IJavaProject javaProject = makeJavaProject(project);
 		addNature(javaProject.getProject(), XtextProjectHelper.NATURE_ID);
-		Injector injector = Activator.getInstance().getInjector(getEditorId());
-		injector.injectMembers(this);
 		grammar = "grammar org.xtext.example.mydsl.MyDsl\n hidden(WS) generate myDsl\n 'http://testrefactoring'\n import 'http://www.eclipse.org/emf/2002/Ecore'\n as ecore \nModel: greetings+="
 				+ CLASSIFIERNAME
 				+ "*; \n"
@@ -311,10 +312,5 @@ public class XtextGrammarRefactoringIntegrationTest extends AbstractLinkedEditin
 	public void tearDown() throws Exception {
 		super.tearDown();
 		EcoreRefactoringParticipant.setDisableWarning(false);
-	}
-
-	@Override
-	protected String getEditorId() {
-		return "org.eclipse.xtext.Xtext";
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/hyperlinking/HyperlinkHelperTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/hyperlinking/HyperlinkHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2009, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,37 +15,30 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
 import org.eclipse.xtext.Grammar;
 import org.eclipse.xtext.GrammarUtil;
-import org.eclipse.xtext.ISetup;
-import org.eclipse.xtext.XtextRuntimeModule;
-import org.eclipse.xtext.XtextStandaloneSetup;
 import org.eclipse.xtext.junit4.AbstractXtextTests;
 import org.eclipse.xtext.resource.ClasspathUriUtil;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
 import org.eclipse.xtext.ui.editor.hyperlinking.XtextHyperlink;
-import org.eclipse.xtext.ui.shared.SharedStateModule;
-import org.eclipse.xtext.util.Modules2;
-import org.eclipse.xtext.xtext.ui.Activator;
+import org.eclipse.xtext.xtext.ui.XtextUiInjectorProvider;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import com.google.inject.Guice;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
  */
+@RunWith(XtextRunner.class)
+@InjectWith(XtextUiInjectorProvider.class)
 public class HyperlinkHelperTest extends AbstractXtextTests {
 
-	private ISetup getSetup() {
-		return new XtextStandaloneSetup() {
-			@Override
-			public Injector createInjector() {
-				return Guice.createInjector(Modules2.mixin(new XtextRuntimeModule(), new org.eclipse.xtext.xtext.ui.internal.XtextUIModuleInternal(Activator.getDefault()), new SharedStateModule()));
-			}
-		};
-	}
-
+	@Inject
 	private IHyperlinkHelper helper;
+
 	private XtextResource resource;
 	private Grammar grammar;
 	private Grammar terminalGrammar;
@@ -54,8 +47,6 @@ public class HyperlinkHelperTest extends AbstractXtextTests {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		with(getSetup());
-		helper = get(IHyperlinkHelper.class);
 		model = "grammar org.eclipse.xtext.ui.HyperlinkTest with org.eclipse.xtext.common.Terminals\n" +
 				"generate hyperlinkTest 'http://www.eclipse.org/Xtext/2008/HyperlinkTest'\n" +
 				"import '" + EcorePackage.eINSTANCE.getNsURI() + "' as ecore\n" +
@@ -197,4 +188,10 @@ public class HyperlinkHelperTest extends AbstractXtextTests {
 		assertEquals(terminalGrammar, obj);
 	}
 
+	@Inject
+	@Override
+	protected void setInjector(Injector injector) {
+		super.setInjector(injector);
+	}
+	
 }

--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/outline/XtextOutlineTreeProviderTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/outline/XtextOutlineTreeProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,37 +10,39 @@ package org.eclipse.xtext.xtext.ui.editor.outline;
 
 import java.util.List;
 
-import org.eclipse.xtext.ISetup;
 import org.eclipse.xtext.junit4.AbstractXtextTests;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.editor.model.XtextDocument;
 import org.eclipse.xtext.ui.editor.outline.IOutlineNode;
 import org.eclipse.xtext.ui.editor.outline.impl.OutlineMode;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.StringInputStream;
-import org.eclipse.xtext.xtext.ui.Activator;
+import org.eclipse.xtext.xtext.ui.XtextUiInjectorProvider;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.Provider;
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
  */
+@RunWith(XtextRunner.class)
+@InjectWith(XtextUiInjectorProvider.class)
 public class XtextOutlineTreeProviderTest extends AbstractXtextTests {
 
+	@Inject
 	private XtextOutlineTreeProvider treeProvider;
+
+	@Inject
+	private Provider<XtextDocument> documentProvider;
 
 	@Override
 	public void setUp() throws Exception {
-		final Injector injector = Activator.getDefault().getInjector("org.eclipse.xtext.Xtext");
 		super.setUp();
-		with(new ISetup() {
-			@Override
-			public Injector createInjectorAndDoEMFRegistration() {
-				return injector;
-			}
-		});
-		treeProvider = get(XtextOutlineTreeProvider.class);
 		setShowInherited(false);
 	}
 
@@ -49,7 +51,7 @@ public class XtextOutlineTreeProviderTest extends AbstractXtextTests {
 		assertNoException("grammar Foo generate foo 'Foo' terminal : ;");
 	}
 	
-	@Test public void testNonInheritMode() throws Exception{
+	@Test public void testNonInheritMode() throws Exception {
 		IOutlineNode node = assertNoException("grammar Foo with org.eclipse.xtext.common.Terminals " +
 				"generate foo 'Foo' " +
 				"Foo: 'foo'; " +
@@ -62,7 +64,7 @@ public class XtextOutlineTreeProviderTest extends AbstractXtextTests {
 		assertNode(grammar.getChildren().get(2), "Bar", 0);
 	}
 
-	@Test public void testInheritMode() throws Exception{
+	@Test public void testInheritMode() throws Exception {
 		setShowInherited(true);
 		String model = "grammar Foo with org.eclipse.xtext.common.Terminals " +
 				"generate foo 'Foo' " +
@@ -92,7 +94,7 @@ public class XtextOutlineTreeProviderTest extends AbstractXtextTests {
 		assertNode(grammar.getChildren().get(9), "ANY_OTHER (org.eclipse.xtext.common.Terminals)", 0);	
 	}
 	
-	@Test public void testInheritModeWithOverride() throws Exception{
+	@Test public void testInheritModeWithOverride() throws Exception {
 		setShowInherited(true);
 		String model = "grammar Foo with org.eclipse.xtext.common.Terminals " +
 				"generate foo 'Foo' " +
@@ -135,7 +137,7 @@ public class XtextOutlineTreeProviderTest extends AbstractXtextTests {
 	protected IOutlineNode assertNoException(String model) throws Exception {
 		try {
 			XtextResource resource = getResourceAndExpect(new StringInputStream(model), UNKNOWN_EXPECTATION);
-			XtextDocument document = get(XtextDocument.class);
+			XtextDocument document = documentProvider.get();
 			document.setInput(resource);
 			IOutlineNode root = treeProvider.createRoot(document);
 			traverseChildren(root);
@@ -152,6 +154,12 @@ public class XtextOutlineTreeProviderTest extends AbstractXtextTests {
 		for (IOutlineNode child : node.getChildren()) {
 			traverseChildren(child);
 		}
+	}
+	
+	@Inject
+	@Override
+	protected void setInjector(Injector injector) {
+		super.setInjector(injector);
 	}
 
 }


### PR DESCRIPTION
- Reusing the recently introduced XtextUiInjectorProvider class.
- Reusing the inherited code from the org.eclipse.xtext.ui.testing
infrastructure.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>