### PR TITLE
[https://github.com/eclipse/xtext/issues/1631] Add deprecation.

### DIFF
--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/util/ResourceLoadHelper.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/util/ResourceLoadHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -16,7 +16,9 @@ import org.eclipse.xtext.resource.XtextResource;
  * Abstraction for other test utilities that want to load a resource for a
  * textual model.
  * @author Sebastian Zarnekow - Initial contribution and API
+ * @deprecated Use org.eclipse.xtext.ui.testing.util.ResourceLoadHelper instead
  */
+@Deprecated
 public interface ResourceLoadHelper {
 
 	XtextResource getResourceFor(InputStream stream);


### PR DESCRIPTION
- Deprecate org.eclipse.xtext.junit4.util.ResourceLoadHelper in favor of
org.eclipse.xtext.ui.testing.util.ResourceLoadHelper

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>