### PR TITLE
[eclipse/xtext#1738] use java.text.MessageFormat instead of com.ibm.icu.MessageFormat

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/XtextUIMessages.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/XtextUIMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,12 +9,11 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui;
 
+import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 import org.eclipse.osgi.util.NLS;
-
-import com.ibm.icu.text.MessageFormat;
 
 /**
  * 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/folding/FoldingMessages.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/folding/FoldingMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 Michael Clay and others.
+ * Copyright (c) 2010, 2020 Michael Clay and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,10 +9,9 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.editor.folding;
 
+import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-
-import com.ibm.icu.text.MessageFormat;
 
 /**
  * Class that gives access to the folding messages resource bundle.

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/html/DefaultEObjectHoverProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/hover/html/DefaultEObjectHoverProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 Christoph Kulla
+ * Copyright (c) 2010, 2020 Christoph Kulla
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -17,6 +17,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.text.MessageFormat;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
@@ -56,7 +57,6 @@ import org.eclipse.xtext.ui.internal.XtextPluginImages;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import com.ibm.icu.text.MessageFormat;
 
 /**
  * Returns a html string as documentation. Delegates to another IEObjectDocumentationProvider and adds
@@ -156,7 +156,6 @@ public class DefaultEObjectHoverProvider implements IEObjectHoverProvider {
 	private static String fgStyleSheet;
 
 	private IInformationControlCreator hoverControlCreator;
-
 	private IInformationControlCreator presenterControlCreator;
 
 	protected static final class BackAction extends Action {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/XtextDocumentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -20,6 +20,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.UnsupportedCharsetException;
+import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Map;
 
@@ -65,7 +66,6 @@ import org.eclipse.xtext.validation.IResourceValidator;
 import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.ibm.icu.text.MessageFormat;
 
 /**
  * @author Peter Friese - Initial contribution and API

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/StatusWrapper.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/refactoring/impl/StatusWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -11,6 +11,8 @@ package org.eclipse.xtext.ui.refactoring.impl;
 import static com.google.common.collect.Iterables.*;
 import static com.google.common.collect.Lists.*;
 import static org.eclipse.xtext.util.Strings.*;
+
+import java.text.MessageFormat;
 
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
@@ -31,7 +33,6 @@ import org.eclipse.xtext.util.SimpleAttributeResolver;
 
 import com.google.common.base.Function;
 import com.google.inject.Inject;
-import com.ibm.icu.text.MessageFormat;
 
 /**
  * Convenience class to create refactoring issues with an {@link RefactoringStatusContext}.


### PR DESCRIPTION
[eclipse/xtext#1738] use java.text.MessageFormat instead of com.ibm.icu.MessageFormat

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>