### PR TITLE
[eclipse/xtext#1738] use java.text.BreakIterator instead of com.ibm.icu.BreakIterator

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/doubleClicking/AbstractWordAwareDoubleClickStrategy.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/doubleClicking/AbstractWordAwareDoubleClickStrategy.java
@@ -9,6 +9,7 @@
 package org.eclipse.xtext.ui.editor.doubleClicking;
 
 
+import java.text.BreakIterator;
 import java.text.CharacterIterator;
 
 import org.eclipse.jface.text.BadLocationException;
@@ -19,11 +20,9 @@ import org.eclipse.jface.text.Region;
 import org.eclipse.xtext.ui.editor.model.CommonBreakIterator;
 import org.eclipse.xtext.ui.editor.model.DocumentCharacterIterator;
 
-import com.ibm.icu.text.BreakIterator;
-
 /**
  * <p>Customized {@link DefaultTextDoubleClickStrategy} that uses a word iterator instead
- * of a plain {@link com.ibm.icu.text.BreakIterator break iterator} to tokenize the document
+ * of a plain {@link java.text.BreakIterator break iterator} to tokenize the document
  * content. It is based on the plain text content of the document, e.g. terminal tokens are
  * not taken into account.</p>
  *  
@@ -39,7 +38,7 @@ public class AbstractWordAwareDoubleClickStrategy extends DefaultTextDoubleClick
 			if (offset == line.getOffset() + line.getLength())
 				return null;
 
-			com.ibm.icu.text.BreakIterator breakIter = createBreakIterator();
+			BreakIterator breakIter = createBreakIterator();
 			CharacterIterator characterIterator = new DocumentCharacterIterator(document);
 			breakIter.setText(characterIterator);
 			int start = breakIter.preceding(offset);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/CommonBreakIterator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/CommonBreakIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,11 +8,10 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.editor.model;
 
+import java.text.BreakIterator;
 import java.text.CharacterIterator;
 
 import org.eclipse.core.runtime.Assert;
-
-import com.ibm.icu.text.BreakIterator;
 
 /**
  * This class was copied from <code>org.eclipse.jdt.internal.ui.text.JavaBreakIterator</code>.

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/CommonWordIterator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/model/CommonWordIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,11 +8,10 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.editor.model;
 
+import java.text.BreakIterator;
 import java.text.CharacterIterator;
 
 import org.eclipse.core.runtime.Assert;
-
-import com.ibm.icu.text.BreakIterator;
 
 /**
  * Copied from <code>org.eclipse.jdt.internal.ui.text.JavaWordIterator</code>.


### PR DESCRIPTION
[eclipse/xtext#1738] use java.text.BreakIterator instead of com.ibm.icu.BreakIterator

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>