### PR TITLE
Formatting org.eclipse.xtext.xtext.ui.tests plugin.xml files.

### DIFF
--- a/org.eclipse.xtext.xtext.ui.tests/plugin.xml
+++ b/org.eclipse.xtext.xtext.ui.tests/plugin.xml
@@ -1,126 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
-
 <plugin>
-
-
-    <extension
-            point="org.eclipse.ui.editors">
-        <editor
-            class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.XtextEditor"
-            contributorClass="org.eclipse.ui.editors.text.TextEditorActionContributor"
-            default="true"
-            extensions="ecore2xtexttest"
-            id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest"
-            name="Ecore2XtextTest Editor">
-        </editor>
-    </extension>
-    <extension
-        point="org.eclipse.ui.handlers">
-        <handler
-            class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.hyperlinking.OpenDeclarationHandler"
-            commandId="org.eclipse.xtext.ui.editor.hyperlinking.OpenDeclaration">
-            <activeWhen>
-                <reference
-                    definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
-                </reference>
-            </activeWhen>
-        </handler>
-        <handler
-            class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.handler.ValidateActionHandler"
-            commandId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate">
-         <activeWhen>
-            <reference
-                    definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
-            </reference>
-         </activeWhen>
-      </handler>
-    </extension>
-    <extension point="org.eclipse.core.expressions.definitions">
-        <definition id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
-            <and>
-                <reference definitionId="isActiveEditorAnInstanceOfXtextEditor"/>
-                <with variable="activeEditor">
-                    <test property="org.eclipse.xtext.ui.editor.XtextEditor.languageName" 
-                        value="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest" 
-                        forcePluginActivation="true"/>
-                </with>        
-            </and>
-        </definition>
-    </extension>
-    <extension
-            point="org.eclipse.ui.preferencePages">
-        <page
-            class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
-            id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest"
-            name="Ecore2XtextTest">
-            <keywordReference id="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.keyword_Ecore2XtextTest"/>
-        </page>
-        <page
-            category="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest"
-            class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.syntaxcoloring.SyntaxColoringPreferencePage"
-            id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.coloring"
-            name="Syntax Coloring">
-            <keywordReference id="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.keyword_Ecore2XtextTest"/>
-        </page>
-        <page
-            category="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest"
-            class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.templates.XtextTemplatePreferencePage"
-            id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.templates"
-            name="Templates">
-            <keywordReference id="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.keyword_Ecore2XtextTest"/>
-        </page>
-    </extension>
-    <extension
-        point="org.eclipse.ui.keywords">
-        <keyword
-            id="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.keyword_Ecore2XtextTest"
-            label="Ecore2XtextTest"/>
-    </extension>
-    <extension
-         point="org.eclipse.ui.commands">
-      <command
-            description="Trigger expensive validation"
-            id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate"
-            name="Validate">
-      </command>
-    </extension>
-    <extension point="org.eclipse.ui.menus">
-        <menuContribution
-            locationURI="popup:#TextEditorContext?after=group.edit">
-             <command
-                 commandId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate"
-                 style="push"
-                 tooltip="Trigger expensive validation">
-            <visibleWhen checkEnabled="false">
-                <reference
-                    definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
-                </reference>
-            </visibleWhen>
-         </command>  
-         </menuContribution>
-    </extension>
-    <extension point="org.eclipse.ui.menus">
+	<extension
+		point="org.eclipse.ui.editors">
+		<editor
+			class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.XtextEditor"
+			contributorClass="org.eclipse.ui.editors.text.TextEditorActionContributor"
+			default="true"
+			extensions="ecore2xtexttest"
+			id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest"
+			name="Ecore2XtextTest Editor">
+		</editor>
+	</extension>
+	<extension
+		point="org.eclipse.ui.handlers">
+		<handler
+			class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.hyperlinking.OpenDeclarationHandler"
+			commandId="org.eclipse.xtext.ui.editor.hyperlinking.OpenDeclaration">
+			<activeWhen>
+				<reference
+					definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
+				</reference>
+			</activeWhen>
+		</handler>
+		<handler
+			class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.handler.ValidateActionHandler"
+			commandId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate">
+			<activeWhen>
+				<reference
+					definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
+				</reference>
+			</activeWhen>
+		</handler>
+	</extension>
+	<extension point="org.eclipse.core.expressions.definitions">
+		<definition id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
+			<and>
+				<reference definitionId="isActiveEditorAnInstanceOfXtextEditor"/>
+				<with variable="activeEditor">
+					<test property="org.eclipse.xtext.ui.editor.XtextEditor.languageName"
+						value="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest"
+						forcePluginActivation="true"/>
+				</with>
+			</and>
+		</definition>
+	</extension>
+	<extension
+			point="org.eclipse.ui.preferencePages">
+		<page
+			class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage"
+			id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest"
+			name="Ecore2XtextTest">
+			<keywordReference id="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.keyword_Ecore2XtextTest"/>
+		</page>
+		<page
+			category="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest"
+			class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.syntaxcoloring.SyntaxColoringPreferencePage"
+			id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.coloring"
+			name="Syntax Coloring">
+			<keywordReference id="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.keyword_Ecore2XtextTest"/>
+		</page>
+		<page
+			category="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest"
+			class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.templates.XtextTemplatePreferencePage"
+			id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.templates"
+			name="Templates">
+			<keywordReference id="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.keyword_Ecore2XtextTest"/>
+		</page>
+	</extension>
+	<extension
+		point="org.eclipse.ui.keywords">
+		<keyword
+			id="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.keyword_Ecore2XtextTest"
+			label="Ecore2XtextTest"/>
+	</extension>
+	<extension
+		point="org.eclipse.ui.commands">
+		<command
+			description="Trigger expensive validation"
+			id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate"
+			name="Validate">
+		</command>
+	</extension>
+	<extension point="org.eclipse.ui.menus">
+		<menuContribution
+			locationURI="popup:#TextEditorContext?after=group.edit">
+			<command
+				commandId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate"
+				style="push"
+				tooltip="Trigger expensive validation">
+				<visibleWhen checkEnabled="false">
+					<reference
+						definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
+					</reference>
+				</visibleWhen>
+			</command>
+		</menuContribution>
+	</extension>
+	<extension point="org.eclipse.ui.menus">
 		<menuContribution locationURI="popup:#TextEditorContext?endof=group.find">
 			<command commandId="org.eclipse.xtext.ui.editor.FindReferences">
 				<visibleWhen checkEnabled="false">
-                	<reference definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
-                	</reference>
-            	</visibleWhen>
+					<reference definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
+					</reference>
+				</visibleWhen>
 			</command>
 		</menuContribution>
 	</extension>
 	<extension point="org.eclipse.ui.handlers">
-	    <handler
-            class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.findrefs.FindReferencesHandler"
-            commandId="org.eclipse.xtext.ui.editor.FindReferences">
-            <activeWhen>
-                <reference
-                    definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
-                </reference>
-            </activeWhen>
-        </handler>
-    </extension>   
+		<handler
+			class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.findrefs.FindReferencesHandler"
+			commandId="org.eclipse.xtext.ui.editor.FindReferences">
+			<activeWhen>
+				<reference
+					definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
+				</reference>
+			</activeWhen>
+		</handler>
+	</extension>
 
 <!-- adding resource factories -->
 
@@ -132,11 +129,9 @@
 		</parser>
 	</extension>
 	<extension point="org.eclipse.xtext.extension_resourceServiceProvider">
-        <resourceServiceProvider
-            class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.resource.IResourceUIServiceProvider"
-            uriExtension="ecore2xtexttest">
-        </resourceServiceProvider>
-    </extension>
-
-
+		<resourceServiceProvider
+			class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.resource.IResourceUIServiceProvider"
+			uriExtension="ecore2xtexttest">
+		</resourceServiceProvider>
+	</extension>
 </plugin>

--- a/org.eclipse.xtext.xtext.ui.tests/plugin.xml_gen
+++ b/org.eclipse.xtext.xtext.ui.tests/plugin.xml_gen
@@ -26,11 +26,11 @@
 		<handler
 			class="org.eclipse.xtext.xtext.ui.ecore2xtext.ui.Ecore2XtextTestExecutableExtensionFactory:org.eclipse.xtext.ui.editor.handler.ValidateActionHandler"
 			commandId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate">
-		<activeWhen>
-			<reference
+			<activeWhen>
+				<reference
 					definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
-			</reference>
-		</activeWhen>
+				</reference>
+			</activeWhen>
 		</handler>
 		<!-- copy qualified name -->
 		<handler
@@ -119,38 +119,38 @@
 	</extension>
 	<extension
 		point="org.eclipse.ui.commands">
-	<command
+		<command
 			description="Trigger expensive validation"
 			id="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate"
 			name="Validate">
-	</command>
-	<!-- copy qualified name -->
-	<command
+		</command>
+		<!-- copy qualified name -->
+		<command
 			id="org.eclipse.xtext.ui.editor.copyqualifiedname.EditorCopyQualifiedName"
 			categoryId="org.eclipse.ui.category.edit"
 			description="Copy the qualified name for the selected element"
 			name="Copy Qualified Name">
-	</command>
-	<command
+		</command>
+		<command
 			id="org.eclipse.xtext.ui.editor.copyqualifiedname.OutlineCopyQualifiedName"
 			categoryId="org.eclipse.ui.category.edit"
 			description="Copy the qualified name for the selected element"
 			name="Copy Qualified Name">
-	</command>
+		</command>
 	</extension>
 	<extension point="org.eclipse.ui.menus">
 		<menuContribution
 			locationURI="popup:#TextEditorContext?after=group.edit">
-			 <command
-				 commandId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate"
-				 style="push"
-				 tooltip="Trigger expensive validation">
-			<visibleWhen checkEnabled="false">
-				<reference
-					definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
-				</reference>
-			</visibleWhen>
-		</command>
+			<command
+				commandId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.validate"
+				style="push"
+				tooltip="Trigger expensive validation">
+				<visibleWhen checkEnabled="false">
+					<reference
+						definitionId="org.eclipse.xtext.xtext.ui.ecore2xtext.Ecore2XtextTest.Editor.opened">
+					</reference>
+				</visibleWhen>
+			</command>
 		</menuContribution>
 		<!-- copy qualified name -->
 		<menuContribution locationURI="popup:#TextEditorContext?after=copy">


### PR DESCRIPTION
- Add changes to the plugin.xml_gen resulting from the regeneration of
the Xtext languages.
- Align formatting of the plugin.xml to the plugin.xml_gen to get a
readable, meaningful diff when comparing the two files.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>