### PR TITLE
[eclipse/xtext#1738] removed no longer needed icu dependency

### DIFF
--- a/org.eclipse.xtext.eclipse.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.eclipse.tests/META-INF/MANIFEST.MF
@@ -22,8 +22,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xtext.wizard
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
-Import-Package: com.ibm.icu.text;version="4.0.0",
- org.apache.log4j;version="1.2.15",
+Import-Package: org.apache.log4j;version="1.2.15",
  org.junit;version="4.5.0",
  org.junit.rules;version="4.7.0",
  org.junit.runner;version="4.5.0",

--- a/org.eclipse.xtext.ui.codetemplates/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui.codetemplates/META-INF/MANIFEST.MF
@@ -13,8 +13,7 @@ Require-Bundle: org.eclipse.xtext,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtend.lib
-Import-Package: com.ibm.icu.text;version="4.0.0";resolution:=optional,
- org.apache.commons.logging,
+Import-Package: org.apache.commons.logging,
  org.apache.log4j;version="1.2.15"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.ui.codetemplates;x-friends:="org.eclipse.xtext.ui.codetemplates.ide,org.eclipse.xtext.ui.codetemplates.ui",

--- a/org.eclipse.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui/META-INF/MANIFEST.MF
@@ -155,7 +155,6 @@ Export-Package: org.eclipse.xtext.common.ui.contentassist,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
-Import-Package: com.ibm.icu.text;version="4.0.0",
- org.apache.commons.lang,
+Import-Package: org.apache.commons.lang,
  org.apache.log4j;version="1.2.15"
 Automatic-Module-Name: org.eclipse.xtext.ui

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/build.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics/build.properties
@@ -14,5 +14,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/build.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/build.properties
@@ -16,5 +16,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/build.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl/build.properties
@@ -15,5 +15,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/build.properties
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation/build.properties
@@ -14,5 +14,4 @@ additional.bundles = org.eclipse.xtext.xbase,\
                      org.eclipse.emf.mwe2.lib,\
                      org.objectweb.asm,\
                      org.apache.commons.logging,\
-                     org.apache.log4j,\
-                     com.ibm.icu
+                     org.apache.log4j


### PR DESCRIPTION
[eclipse/xtext#1738] removed no longer needed icu dependency
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>