### PR TITLE
org.eclipse.xtext.ui.tests.editor.quickfix refactoring.

### DIFF
--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/quickfix/SpellingQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/quickfix/SpellingQuickfixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,6 +13,7 @@ import static com.google.common.collect.Iterables.*;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.quickassist.IQuickAssistProcessor;
@@ -33,7 +34,7 @@ import com.google.common.base.Predicate;
 public class SpellingQuickfixTest extends AbstractQuickfixTest {
 
 	private static final String PROJECT_NAME = "spellingquickfixtest";
-	private static final String MODEL_FILE = "spelling.quickfixcrossreftestlanguage";
+	private static final String MODEL_FILE = "spelling";
 
 	private static final String MODEL_WITH_SPELLING_QUICKFIX_IN_SL_COLMMENT = "Foo {  } \n // Single Line Komment Spelling Error";
 	private static final String MODEL_WITH_SPELLING_QUICKFIX_IN_ML_COLMMENT = "Foo {  } \n /* Multi Line \n Komment Spelling Error */";
@@ -44,7 +45,8 @@ public class SpellingQuickfixTest extends AbstractQuickfixTest {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		xtextEditor = newXtextEditor(PROJECT_NAME, MODEL_FILE, MODEL_WITH_SPELLING_QUICKFIX_IN_SL_COLMMENT);
+		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_SPELLING_QUICKFIX_IN_SL_COLMMENT);
+		xtextEditor = openEditor(dslFile);
 	}
 
 	@Test

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractQuickfixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,40 +8,34 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.tests.editor.quickfix;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.quickassist.IQuickAssistProcessor;
 import org.eclipse.jface.text.quickassist.QuickAssistAssistant;
 import org.eclipse.jface.text.source.TextInvocationContext;
 import org.eclipse.ui.IMarkerResolution;
 import org.eclipse.ui.IMarkerResolutionGenerator2;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.views.markers.WorkbenchMarkerResolution;
+import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.MarkerTypes;
-import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.eclipse.xtext.ui.editor.XtextEditorInfo;
 import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.quickfix.MarkerResolutionGenerator;
-import org.eclipse.xtext.ui.testing.AbstractWorkbenchTest;
+import org.eclipse.xtext.ui.testing.AbstractEditorTest;
 import org.eclipse.xtext.ui.testing.util.AnnotatedTextToString;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
-import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
-import org.eclipse.xtext.util.StringInputStream;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.validation.CheckMode;
@@ -57,7 +51,7 @@ import com.google.inject.Injector;
 /**
  * @author Jan Koehnlein - Initial contribution and API
  */
-public abstract class AbstractQuickfixTest extends AbstractWorkbenchTest {
+public abstract class AbstractQuickfixTest extends AbstractEditorTest {
 
 	private static boolean WAS_AUTOBUILD;
 
@@ -70,48 +64,27 @@ public abstract class AbstractQuickfixTest extends AbstractWorkbenchTest {
 	public static void afterClass() throws Exception {
 		IResourcesSetupUtil.setAutobuild(WAS_AUTOBUILD);
 	}
-
-	protected XtextEditor newXtextEditor(String projectName, String modelFile, String model) throws CoreException, PartInitException {
-		IJavaProject javaProject = JavaProjectSetupUtil.createJavaProject(projectName);
-		IFile file = createFile(javaProject.getProject(), modelFile, model);
-		XtextEditor xtextEditor = (XtextEditor) IDE.openEditor(getActivePage(), file);
-		return xtextEditor;
-	}
-
-	protected XtextEditor newXtextEditor(IProject project, String modelFile, String model) throws CoreException, PartInitException {
-		IFile file = createFile(project, modelFile, model);
-		XtextEditor xtextEditor = (XtextEditor) IDE.openEditor(getActivePage(), file);
-		return xtextEditor;
-	}
-
-	protected IFile createFile(IProject project, String modelFile, String model) throws CoreException {
-		IFile file = project.getFile(modelFile);
-		if (file.exists()) {
-			file.delete(true, null);
-		}
-		file.create(new StringInputStream(model), true, null);
-		file.refreshLocal(IResource.DEPTH_ONE, null);
-		return file;
-	}
-
-	protected IProject createGeneralXtextProject(String name) {
-		IProject project;
-		try {
-			project = IResourcesSetupUtil.createProject(name);
-			IResourcesSetupUtil.addNature(project, XtextProjectHelper.NATURE_ID);
-			IResourcesSetupUtil.addBuilder(project, XtextProjectHelper.BUILDER_ID);
-			return project;
-		} catch (InvocationTargetException | CoreException | InterruptedException e) {
-			Exceptions.sneakyThrow(e);
-			return null;
-		}
-	}
 	
+	protected IFile dslFile(String projectName, String fileName, CharSequence content) {
+		return dslFile(projectName, fileName, getFileExtension(), content);
+	}
+
+	@Override
+	protected String getEditorId() {
+		XtextEditorInfo editorInfo = getInjector().getInstance(XtextEditorInfo.class);
+		return editorInfo.getEditorId();
+	}
+
+	protected String getFileExtension() {
+		FileExtensionProvider fileExtensionProvider = getInjector().getInstance(FileExtensionProvider.class);
+		return fileExtensionProvider.getPrimaryFileExtension();
+	}
+
 	protected ICompletionProposal[] computeQuickAssistProposals(XtextEditor editor, String text) {
 		int idx = editor.getDocument().get().indexOf(text);
 		return computeQuickAssistProposals(editor, idx);
 	}
-	
+
 	protected ICompletionProposal[] computeQuickAssistProposals(XtextEditor editor, int offset) {
 		IResourcesSetupUtil.waitForBuild();
 		XtextSourceViewer sourceViewer = (XtextSourceViewer) editor.getInternalSourceViewer();

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2017, 2020 TypeFox GmbH (http://www.typefox.io) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,19 +8,19 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.tests.editor.quickfix
 
-import org.junit.Test
 import org.eclipse.core.resources.IMarker
-import org.eclipse.xtext.ui.editor.XtextEditor
 import org.eclipse.ui.ide.IDE
+import org.eclipse.xtext.ui.editor.XtextEditor
+import org.junit.Test
 
 /**
  * @author Moritz Eysholdt - Initial contribution and API
  */
 class CompositeQuickfixTest extends AbstractQuickfixTest {
-	
+
 	@Test
 	def void testSimpleFixMultipleMarkers() throws Exception {
-		val resource = createGeneralXtextProject("myProject").createFile("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			"bad doc"
 			Foo { ref Bor }
 			"bad doc"
@@ -47,10 +47,10 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 			(no markers found)
 		''')
 	}
-	
+
 	@Test
 	def void testSimpleSingleMarker() throws Exception {
-		val resource = createGeneralXtextProject("myProject").createFile("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			"bad doc"
 			Foo { ref Bor }
 			"bad doc"
@@ -77,15 +77,16 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 			0: message=multiFixableIssue2
 		''')
 	}
-	
+
 	@Test
 	def void testSimpleQuickAssist() throws Exception {
-		val editor = createGeneralXtextProject("myProject").newXtextEditor("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			"bad doc"
 			Foo { ref Bor }
 			"bad doc"
 			Bor { }
 		''')
+		val editor = resource.openEditor
 		val proposals = computeQuickAssistProposals(editor, 1)
 		assertEquals('''Multi fix 2'''.toString, proposals.map[displayString].join("\n"))
 		proposals.head.apply(editor.document)
@@ -96,11 +97,10 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 			Bor { }
 		'''.toString, editor.document.get)
 	}
-	
-	
+
 	@Test
 	def void testMultiFixMultipleMarkers() throws Exception {
-		val resource = createGeneralXtextProject("myProject").createFile("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			c {	badname { foo {} } }
 			a {	badname { bar {} } }
 			b {	badname { baz {} } }
@@ -128,7 +128,7 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testMultiFixSingleMarker() throws Exception {
-		val resource = createGeneralXtextProject("myProject").createFile("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			c {	badname { foo {} } }
 			a {	badname { bar {} } }
 		''')
@@ -149,13 +149,14 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 			0: message=badNameInSubelements
 		''')
 	}
-	
+
 	@Test
 	def void testMultiQuickAssist() throws Exception {
-		val editor = createGeneralXtextProject("myProject").newXtextEditor("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			c {	badname { foo {} } }
 			a {	badname { bar {} } }
 		''')
+		val editor = resource.openEditor
 		val proposals = computeQuickAssistProposals(editor, 1)
 		assertEquals('''Fix Bad Names'''.toString, proposals.map[displayString].join("\n"))
 		proposals.head.apply(editor.document)
@@ -164,13 +165,14 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 			a {	badname { bar {} } }
 		'''.toString, editor.document.get)
 	}
-	
+
 	@Test
 	def void testNoCrossRef() throws Exception {
-		val editor = createGeneralXtextProject("myProject").newXtextEditor("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			fixable_a {	ref fixable_b }
 			fixable_b {	ref fixable_a }
 		''')
+		val editor = resource.openEditor
 		val proposals = computeQuickAssistProposals(editor, 1)
 		assertEquals('''rename fixable'''.toString, proposals.map[displayString].join("\n"))
 		proposals.head.apply(editor.document)
@@ -179,13 +181,13 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 			fixable_b {	ref fixable_a }
 		'''.toString, editor.document.get)
 	}
-	
+
 	@Test
 	def void testTextualMultiModification() {
 		// we test two things here:
 		// - TextualMultiModifications actually work
 		// - TextualMultiModificationWorkbenchMarkerResolutionAdapter sorts correctly
-		val resource = createGeneralXtextProject("myProject").createFile("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			lowercase_a {}
 			lowercase_b {}
 			lowercase_c {}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/IssueDataTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/IssueDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -40,13 +41,13 @@ import com.google.common.collect.Lists;
 public class IssueDataTest extends AbstractQuickfixTest {
 
 	private static final String PROJECT_NAME = "quickfixtest";
-	private static final String MODEL_FILE = "test.quickfixcrossreftestlanguage";
+	private static final String MODEL_FILE = "test";
 	private static final String PREFIX = "//irrelevant\n\t\t";
 	private static final String MODEL_WITH_LINKING_ERROR = PREFIX + QuickfixCrossrefTestLanguageValidator.TRIGGER_VALIDATION_ISSUE + "{}";
 
-
 	@Test public void testIssueData() throws Exception {
-		XtextEditor xtextEditor = newXtextEditor(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
+		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
+		XtextEditor xtextEditor = openEditor(dslFile);
 		IXtextDocument document = xtextEditor.getDocument();
 		IResource file = xtextEditor.getResource();
 		List<Issue> issues = getIssues(document);

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/LinkingErrorTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/LinkingErrorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,6 +10,7 @@ package org.eclipse.xtext.ui.tests.editor.quickfix;
 
 import java.util.List;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.resource.XtextResource;
@@ -31,14 +32,13 @@ import org.junit.Test;
 public class LinkingErrorTest extends AbstractQuickfixTest {
 
 	private static final String PROJECT_NAME = "quickfixtest";
-	private static final String MODEL_FILE = "test.quickfixcrossreftestlanguage";
+	private static final String MODEL_FILE = "test";
 	private static final String MODEL_WITH_LINKING_ERROR = "Foo { ref Bor }\n" + "Bar { }\n Bar1{} Bar2{} Bar3{} Bar4{} Bar5{}";
 	private static final String MODEL_WITH_LINKING_ERROR_361509 = "^ref { ref raf }\n";
 	
-	private XtextEditor xtextEditor;
-
 	@Test public void testQuickfixTurnaround() throws Exception {
-		xtextEditor = newXtextEditor(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
+		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
+		XtextEditor xtextEditor = openEditor(dslFile);
 		IXtextDocument document = xtextEditor.getDocument();
 
 		List<Issue> issues = getIssues(document);
@@ -57,7 +57,8 @@ public class LinkingErrorTest extends AbstractQuickfixTest {
 	}
 	
 	@Test public void testBug361509() throws Exception {
-		xtextEditor = newXtextEditor(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR_361509);
+		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR_361509);
+		XtextEditor xtextEditor = openEditor(dslFile);
 		IXtextDocument document = xtextEditor.getDocument();
 
 		List<Issue> issues = getIssues(document);
@@ -77,7 +78,8 @@ public class LinkingErrorTest extends AbstractQuickfixTest {
 	}
 
 	@Test public void testSemanticIssueResolution() throws Exception {
-		xtextEditor = newXtextEditor(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
+		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
+		XtextEditor xtextEditor = openEditor(dslFile);
 		URI uriToProblem = xtextEditor.getDocument().readOnly(new IUnitOfWork<URI, XtextResource>() {
 			@Override
 			public URI exec(XtextResource state) throws Exception {
@@ -99,6 +101,4 @@ public class LinkingErrorTest extends AbstractQuickfixTest {
 		List<Issue> issues = getIssues(xtextEditor.getDocument());
 		assertTrue(issues.isEmpty());
 	}
-
-	
 }

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2017, 2020 TypeFox GmbH (http://www.typefox.io) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -18,7 +18,7 @@ class MultiQuickFixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testFixMultipleMarkers() throws Exception {
-		val resource = createGeneralXtextProject("myProject").createFile("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			"no doc"
 			Foo { ref Bor }
 			"no doc" Bor { }
@@ -45,7 +45,7 @@ class MultiQuickFixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testFixSingleMarker() throws Exception {
-		val resource = createGeneralXtextProject("myProject").createFile("test.quickfixcrossreftestlanguage", '''
+		val resource = dslFile("myProject", "test", '''
 			"no doc"
 			Foo { ref Bor }
 			"no doc" Bor { }
@@ -72,11 +72,12 @@ class MultiQuickFixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testQuickAssist() throws Exception {
-		val editor = createGeneralXtextProject("myProject").newXtextEditor("test.quickfixcrossreftestlanguage", '''
+		val dslFile = dslFile("myProject", "test", '''
 			"no doc"
 			Foo { ref Bor }
 			"no doc" Bor { }
 		''')
+		val editor = dslFile.openEditor
 		val proposals = computeQuickAssistProposals(editor, 1)
 		assertEquals('''Multi fix'''.toString, proposals.map[displayString].join("\n"))
 		proposals.head.apply(editor.document)

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2017, 2020 TypeFox GmbH (http://www.typefox.io) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -11,7 +11,6 @@ package org.eclipse.xtext.ui.tests.editor.quickfix;
 import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
@@ -34,7 +33,6 @@ import org.junit.Test;
 public class CompositeQuickfixTest extends AbstractQuickfixTest {
   @Test
   public void testSimpleFixMultipleMarkers() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("\"bad doc\"");
     _builder.newLine();
@@ -44,7 +42,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("Bor { }");
     _builder.newLine();
-    final IFile resource = this.createFile(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile resource = this.dslFile("myProject", "test", _builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<\"bad doc\">0>");
@@ -81,7 +79,6 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
   
   @Test
   public void testSimpleSingleMarker() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("\"bad doc\"");
     _builder.newLine();
@@ -91,7 +88,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("Bor { }");
     _builder.newLine();
-    final IFile resource = this.createFile(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile resource = this.dslFile("myProject", "test", _builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<\"bad doc\">0>");
@@ -137,7 +134,6 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
   
   @Test
   public void testSimpleQuickAssist() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("\"bad doc\"");
     _builder.newLine();
@@ -147,7 +143,8 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("Bor { }");
     _builder.newLine();
-    final XtextEditor editor = this.newXtextEditor(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final XtextEditor editor = this.openEditor(resource);
     final ICompletionProposal[] proposals = this.computeQuickAssistProposals(editor, 1);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("Multi fix 2");
@@ -170,7 +167,6 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
   
   @Test
   public void testMultiFixMultipleMarkers() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("c {\tbadname { foo {} } }");
     _builder.newLine();
@@ -178,7 +174,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("b {\tbadname { baz {} } }");
     _builder.newLine();
-    final IFile resource = this.createFile(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile resource = this.dslFile("myProject", "test", _builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<c>0> {\tbadname { foo {} } }");
@@ -213,13 +209,12 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
   
   @Test
   public void testMultiFixSingleMarker() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("c {\tbadname { foo {} } }");
     _builder.newLine();
     _builder.append("a {\tbadname { bar {} } }");
     _builder.newLine();
-    final IFile resource = this.createFile(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile resource = this.dslFile("myProject", "test", _builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<c>0> {\tbadname { foo {} } }");
@@ -257,13 +252,13 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
   
   @Test
   public void testMultiQuickAssist() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("c {\tbadname { foo {} } }");
     _builder.newLine();
     _builder.append("a {\tbadname { bar {} } }");
     _builder.newLine();
-    final XtextEditor editor = this.newXtextEditor(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final XtextEditor editor = this.openEditor(resource);
     final ICompletionProposal[] proposals = this.computeQuickAssistProposals(editor, 1);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("Fix Bad Names");
@@ -282,13 +277,13 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
   
   @Test
   public void testNoCrossRef() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("fixable_a {\tref fixable_b }");
     _builder.newLine();
     _builder.append("fixable_b {\tref fixable_a }");
     _builder.newLine();
-    final XtextEditor editor = this.newXtextEditor(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final XtextEditor editor = this.openEditor(resource);
     final ICompletionProposal[] proposals = this.computeQuickAssistProposals(editor, 1);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("rename fixable");
@@ -308,7 +303,6 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
   @Test
   public void testTextualMultiModification() {
     try {
-      IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("lowercase_a {}");
       _builder.newLine();
@@ -322,7 +316,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
       _builder.newLine();
       _builder.append("lowercase_f {}");
       _builder.newLine();
-      final IFile resource = this.createFile(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+      final IFile resource = this.dslFile("myProject", "test", _builder);
       IEditorPart _openEditor = IDE.openEditor(AbstractWorkbenchTest.getActivePage(), resource);
       final XtextEditor xtextEditor = ((XtextEditor) _openEditor);
       final IMarker[] markers = this.getMarkers(resource);

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2017, 2020 TypeFox GmbH (http://www.typefox.io) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -11,7 +11,6 @@ package org.eclipse.xtext.ui.tests.editor.quickfix;
 import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ui.editor.XtextEditor;
@@ -31,7 +30,6 @@ import org.junit.Test;
 public class MultiQuickFixTest extends AbstractQuickfixTest {
   @Test
   public void testFixMultipleMarkers() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("\"no doc\"");
     _builder.newLine();
@@ -39,7 +37,7 @@ public class MultiQuickFixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("\"no doc\" Bor { }");
     _builder.newLine();
-    final IFile resource = this.createFile(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile resource = this.dslFile("myProject", "test", _builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<\"no doc\">0>");
@@ -72,7 +70,6 @@ public class MultiQuickFixTest extends AbstractQuickfixTest {
   
   @Test
   public void testFixSingleMarker() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("\"no doc\"");
     _builder.newLine();
@@ -80,7 +77,7 @@ public class MultiQuickFixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("\"no doc\" Bor { }");
     _builder.newLine();
-    final IFile resource = this.createFile(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile resource = this.dslFile("myProject", "test", _builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<\"no doc\">0>");
@@ -122,7 +119,6 @@ public class MultiQuickFixTest extends AbstractQuickfixTest {
   
   @Test
   public void testQuickAssist() throws Exception {
-    IProject _createGeneralXtextProject = this.createGeneralXtextProject("myProject");
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("\"no doc\"");
     _builder.newLine();
@@ -130,7 +126,8 @@ public class MultiQuickFixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("\"no doc\" Bor { }");
     _builder.newLine();
-    final XtextEditor editor = this.newXtextEditor(_createGeneralXtextProject, "test.quickfixcrossreftestlanguage", _builder.toString());
+    final IFile dslFile = this.dslFile("myProject", "test", _builder);
+    final XtextEditor editor = this.openEditor(dslFile);
     final ICompletionProposal[] proposals = this.computeQuickAssistProposals(editor, 1);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("Multi fix");


### PR DESCRIPTION
- Eliminating duplicated code by inheriting the AbstractQuickfixTest
class from the AbstractEditorTest class instead of the
AbstractWorkbenchTest class.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>