### PR TITLE
Refactoring the org.eclipse.xtext.ui.tests.editor.quickfix test cases.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.java
@@ -35,6 +35,7 @@ import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.StringInputStream;
 import org.eclipse.xtext.util.Strings;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
 import org.eclipse.xtext.validation.Issue;
@@ -225,6 +226,18 @@ public abstract class AbstractQuickfixTest extends AbstractEditorTest {
 				.collect(Collectors.toList());
 		assertEquals("There should be one '" + issueCode + "' validation issue!", 1, issueCandidates.size());
 		return issueCandidates.get(0);
+	}
+
+	/**
+	 * @since 2.22
+	 */
+	protected List<Issue> getAllValidationIssues(IXtextDocument document) {
+		return document.readOnly(new IUnitOfWork<List<Issue>, XtextResource>() {
+			@Override
+			public List<Issue> exec(XtextResource state) throws Exception {
+				return resourceValidator.validate(state, CheckMode.ALL, null);
+			}
+		});
 	}
 
 	protected void assertIssueResolutionResult(String expectedResult, IssueResolution actualIssueResolution, String originalText) {

--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/quickfix/SpellingQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/quickfix/SpellingQuickfixTest.java
@@ -21,20 +21,23 @@ import org.eclipse.jface.text.quickassist.QuickAssistAssistant;
 import org.eclipse.jface.text.reconciler.IReconciler;
 import org.eclipse.jface.text.reconciler.IReconcilingStrategyExtension;
 import org.eclipse.jface.text.source.TextInvocationContext;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 import org.eclipse.xtext.ui.editor.reconciler.XtextReconciler;
+import org.eclipse.xtext.ui.tests.quickfix.ui.tests.QuickfixCrossrefTestLanguageUiInjectorProvider;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.google.common.base.Predicate;
 
 /**
  * @author Michael Clay - Initial contribution and API
  */
+@RunWith(XtextRunner.class)
+@InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider.class)
 public class SpellingQuickfixTest extends AbstractQuickfixTest {
-
-	private static final String PROJECT_NAME = "spellingquickfixtest";
-	private static final String MODEL_FILE = "spelling";
 
 	private static final String MODEL_WITH_SPELLING_QUICKFIX_IN_SL_COLMMENT = "Foo {  } \n // Single Line Komment Spelling Error";
 	private static final String MODEL_WITH_SPELLING_QUICKFIX_IN_ML_COLMMENT = "Foo {  } \n /* Multi Line \n Komment Spelling Error */";
@@ -45,7 +48,7 @@ public class SpellingQuickfixTest extends AbstractQuickfixTest {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
-		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_SPELLING_QUICKFIX_IN_SL_COLMMENT);
+		IFile dslFile = dslFile(MODEL_WITH_SPELLING_QUICKFIX_IN_SL_COLMMENT);
 		xtextEditor = openEditor(dslFile);
 	}
 

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
@@ -10,17 +10,23 @@ package org.eclipse.xtext.ui.tests.editor.quickfix
 
 import org.eclipse.core.resources.IMarker
 import org.eclipse.ui.ide.IDE
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.ui.editor.XtextEditor
+import org.eclipse.xtext.ui.tests.quickfix.ui.tests.QuickfixCrossrefTestLanguageUiInjectorProvider
 import org.junit.Test
+import org.junit.runner.RunWith
 
 /**
  * @author Moritz Eysholdt - Initial contribution and API
  */
+@RunWith(XtextRunner)
+@InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider)
 class CompositeQuickfixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testSimpleFixMultipleMarkers() throws Exception {
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			"bad doc"
 			Foo { ref Bor }
 			"bad doc"
@@ -50,7 +56,7 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testSimpleSingleMarker() throws Exception {
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			"bad doc"
 			Foo { ref Bor }
 			"bad doc"
@@ -80,7 +86,7 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testSimpleQuickAssist() throws Exception {
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			"bad doc"
 			Foo { ref Bor }
 			"bad doc"
@@ -100,7 +106,7 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testMultiFixMultipleMarkers() throws Exception {
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			c {	badname { foo {} } }
 			a {	badname { bar {} } }
 			b {	badname { baz {} } }
@@ -128,7 +134,7 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testMultiFixSingleMarker() throws Exception {
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			c {	badname { foo {} } }
 			a {	badname { bar {} } }
 		''')
@@ -152,7 +158,7 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testMultiQuickAssist() throws Exception {
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			c {	badname { foo {} } }
 			a {	badname { bar {} } }
 		''')
@@ -168,7 +174,7 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testNoCrossRef() throws Exception {
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			fixable_a {	ref fixable_b }
 			fixable_b {	ref fixable_a }
 		''')
@@ -187,7 +193,7 @@ class CompositeQuickfixTest extends AbstractQuickfixTest {
 		// we test two things here:
 		// - TextualMultiModifications actually work
 		// - TextualMultiModificationWorkbenchMarkerResolutionAdapter sorts correctly
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			lowercase_a {}
 			lowercase_b {}
 			lowercase_c {}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/IssueDataTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/IssueDataTest.java
@@ -20,6 +20,8 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.MarkerTypes;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
@@ -27,30 +29,49 @@ import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionProvider;
 import org.eclipse.xtext.ui.editor.validation.AnnotationIssueProcessor;
 import org.eclipse.xtext.ui.editor.validation.MarkerCreator;
 import org.eclipse.xtext.ui.editor.validation.XtextAnnotation;
+import org.eclipse.xtext.ui.testing.AbstractQuickfixTest;
+import org.eclipse.xtext.ui.testing.util.AnnotatedTextToString;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.eclipse.xtext.ui.tests.quickfix.ui.tests.QuickfixCrossrefTestLanguageUiInjectorProvider;
 import org.eclipse.xtext.ui.tests.quickfix.validation.QuickfixCrossrefTestLanguageValidator;
 import org.eclipse.xtext.ui.util.IssueUtil;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.validation.Issue;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.google.common.collect.Lists;
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
  */
+@RunWith(XtextRunner.class)
+@InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider.class)
 public class IssueDataTest extends AbstractQuickfixTest {
 
-	private static final String PROJECT_NAME = "quickfixtest";
-	private static final String MODEL_FILE = "test";
 	private static final String PREFIX = "//irrelevant\n\t\t";
 	private static final String MODEL_WITH_LINKING_ERROR = PREFIX + QuickfixCrossrefTestLanguageValidator.TRIGGER_VALIDATION_ISSUE + "{}";
 
+	private static boolean WAS_AUTOBUILD;
+
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		WAS_AUTOBUILD = IResourcesSetupUtil.setAutobuild(false);
+	}
+
+	@AfterClass
+	public static void afterClass() throws Exception {
+		IResourcesSetupUtil.setAutobuild(WAS_AUTOBUILD);
+	}
+
 	@Test public void testIssueData() throws Exception {
-		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
+		IFile dslFile = dslFile(getProjectName(), getFileName(), getFileExtension(), MODEL_WITH_LINKING_ERROR);
 		XtextEditor xtextEditor = openEditor(dslFile);
 		IXtextDocument document = xtextEditor.getDocument();
 		IResource file = xtextEditor.getResource();
-		List<Issue> issues = getIssues(document);
+		List<Issue> issues = getAllValidationIssues(document);
 		assertEquals(1, issues.size());
 		Issue issue = issues.get(0);
 		assertEquals(2, issue.getLineNumber().intValue());
@@ -61,7 +82,7 @@ public class IssueDataTest extends AbstractQuickfixTest {
 			QuickfixCrossrefTestLanguageValidator.ISSUE_DATA_1};
 		assertTrue(Arrays.equals(expectedIssueData, issue.getData()));
 		Thread.sleep(1000);
-		
+
 		IAnnotationModel annotationModel = xtextEditor.getDocumentProvider().getAnnotationModel(
 				xtextEditor.getEditorInput());
 		AnnotationIssueProcessor annotationIssueProcessor = 
@@ -77,10 +98,11 @@ public class IssueDataTest extends AbstractQuickfixTest {
 		IssueUtil issueUtil = new IssueUtil();
 		Issue issueFromAnnotation = issueUtil.getIssueFromAnnotation(annotation);
 		assertTrue(Arrays.equals(expectedIssueData, issueFromAnnotation.getData()));
-		
+
 		new MarkerCreator().createMarker(issue, file, MarkerTypes.FAST_VALIDATION);
 		IMarker[] markers = file.findMarkers(MarkerTypes.FAST_VALIDATION, true, IResource.DEPTH_ZERO);
-		assertEquals(1, markers.length);
+		String errorMessage = new AnnotatedTextToString().withFile(dslFile).withMarkers(markers).toString().trim();
+		assertEquals(errorMessage, 1, markers.length);
 		String attribute = (String) markers[0].getAttribute(Issue.DATA_KEY);
 		assertNotNull(attribute);
 		assertTrue(Arrays.equals(expectedIssueData, Strings.unpack(attribute)));
@@ -91,7 +113,5 @@ public class IssueDataTest extends AbstractQuickfixTest {
 		assertEquals(issue.getOffset(), issueFromMarker.getOffset());
 		assertEquals(issue.getLength(), issueFromMarker.getLength());
 		assertTrue(Arrays.equals(expectedIssueData, issueFromMarker.getData()));
-		
 	}
-	
 }

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/LinkingErrorTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/LinkingErrorTest.java
@@ -14,71 +14,73 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolution;
-import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionProvider;
+import org.eclipse.xtext.ui.testing.AbstractQuickfixTest;
 import org.eclipse.xtext.ui.tests.quickfix.quickfixCrossref.Element;
 import org.eclipse.xtext.ui.tests.quickfix.quickfixCrossref.Main;
 import org.eclipse.xtext.ui.tests.quickfix.ui.quickfix.QuickfixCrossrefTestLanguageQuickfixProvider;
+import org.eclipse.xtext.ui.tests.quickfix.ui.tests.QuickfixCrossrefTestLanguageUiInjectorProvider;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.validation.Issue;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * @author Heiko Behrens - Initial contribution and API
  * @author Jan Koehnlein
  */
+@RunWith(XtextRunner.class)
+@InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider.class)
 public class LinkingErrorTest extends AbstractQuickfixTest {
 
-	private static final String PROJECT_NAME = "quickfixtest";
-	private static final String MODEL_FILE = "test";
 	private static final String MODEL_WITH_LINKING_ERROR = "Foo { ref Bor }\n" + "Bar { }\n Bar1{} Bar2{} Bar3{} Bar4{} Bar5{}";
 	private static final String MODEL_WITH_LINKING_ERROR_361509 = "^ref { ref raf }\n";
 	
 	@Test public void testQuickfixTurnaround() throws Exception {
-		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
+		IFile dslFile = dslFile(MODEL_WITH_LINKING_ERROR);
 		XtextEditor xtextEditor = openEditor(dslFile);
 		IXtextDocument document = xtextEditor.getDocument();
 
-		List<Issue> issues = getIssues(document);
+		List<Issue> issues = getAllValidationIssues(document);
 		assertFalse(issues.isEmpty());
 		Issue issue = issues.get(0);
 		assertNotNull(issue);
-		IssueResolutionProvider quickfixProvider = getInjector().getInstance(IssueResolutionProvider.class);
-		List<IssueResolution> resolutions = quickfixProvider.getResolutions(issue);
+		List<IssueResolution> resolutions = issueResolutionProvider.getResolutions(issue);
 
 		assertEquals(1, resolutions.size());
 		IssueResolution resolution = resolutions.get(0);
 		assertEquals("Change to 'Bar'", resolution.getLabel());
 		resolution.apply();
-		issues = getIssues(document);
+		issues = getAllValidationIssues(document);
 		assertTrue(issues.isEmpty());
 	}
 	
 	@Test public void testBug361509() throws Exception {
-		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR_361509);
+		IFile dslFile = dslFile(MODEL_WITH_LINKING_ERROR_361509);
 		XtextEditor xtextEditor = openEditor(dslFile);
 		IXtextDocument document = xtextEditor.getDocument();
 
-		List<Issue> issues = getIssues(document);
+		List<Issue> issues = getAllValidationIssues(document);
 		assertFalse(issues.isEmpty());
 		Issue issue = issues.get(0);
 		assertNotNull(issue);
-		IssueResolutionProvider quickfixProvider = getInjector().getInstance(IssueResolutionProvider.class);
-		List<IssueResolution> resolutions = quickfixProvider.getResolutions(issue);
+		List<IssueResolution> resolutions = issueResolutionProvider.getResolutions(issue);
 
 		assertEquals(1, resolutions.size());
 		IssueResolution resolution = resolutions.get(0);
 		assertEquals("Change to 'ref'", resolution.getLabel());
 		resolution.apply();
-		issues = getIssues(document);
+		issues = getAllValidationIssues(document);
 		assertTrue(issues.isEmpty());
 		assertEquals(MODEL_WITH_LINKING_ERROR_361509.replace("raf", "^ref"), document.get());
 	}
 
 	@Test public void testSemanticIssueResolution() throws Exception {
-		IFile dslFile = dslFile(PROJECT_NAME, MODEL_FILE, MODEL_WITH_LINKING_ERROR);
+		IFile dslFile = dslFile(MODEL_WITH_LINKING_ERROR);
 		XtextEditor xtextEditor = openEditor(dslFile);
 		URI uriToProblem = xtextEditor.getDocument().readOnly(new IUnitOfWork<URI, XtextResource>() {
 			@Override
@@ -92,13 +94,16 @@ public class LinkingErrorTest extends AbstractQuickfixTest {
 		issue.setUriToProblem(uriToProblem);
 		issue.setCode(QuickfixCrossrefTestLanguageQuickfixProvider.SEMANTIC_FIX_ID);
 
-		IssueResolutionProvider quickfixProvider = getInjector().getInstance(IssueResolutionProvider.class);
-		List<IssueResolution> resolutions = quickfixProvider.getResolutions(issue);
+		List<IssueResolution> resolutions = issueResolutionProvider.getResolutions(issue);
 		assertEquals(1, resolutions.size());
 		IssueResolution issueResolution = resolutions.get(0);
 		issueResolution.apply();
 		xtextEditor.doSave(null);
-		List<Issue> issues = getIssues(xtextEditor.getDocument());
+		List<Issue> issues = getAllValidationIssues(xtextEditor.getDocument());
 		assertTrue(issues.isEmpty());
+	}
+	
+	private IFile dslFile(CharSequence content) {
+		return dslFile(getProjectName(), getFileName(), getFileExtension(), content);
 	}
 }

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.xtend
@@ -9,16 +9,22 @@
 package org.eclipse.xtext.ui.tests.editor.quickfix
 
 import org.eclipse.core.resources.IMarker
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.tests.quickfix.ui.tests.QuickfixCrossrefTestLanguageUiInjectorProvider
 import org.junit.Test
+import org.junit.runner.RunWith
 
 /**
  * @author dhuebner - Initial contribution and API
  */
+@RunWith(XtextRunner)
+@InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider)
 class MultiQuickFixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testFixMultipleMarkers() throws Exception {
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			"no doc"
 			Foo { ref Bor }
 			"no doc" Bor { }
@@ -45,7 +51,7 @@ class MultiQuickFixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testFixSingleMarker() throws Exception {
-		val resource = dslFile("myProject", "test", '''
+		val resource = dslFile('''
 			"no doc"
 			Foo { ref Bor }
 			"no doc" Bor { }
@@ -72,7 +78,7 @@ class MultiQuickFixTest extends AbstractQuickfixTest {
 
 	@Test
 	def void testQuickAssist() throws Exception {
-		val dslFile = dslFile("myProject", "test", '''
+		val dslFile = dslFile('''
 			"no doc"
 			Foo { ref Bor }
 			"no doc" Bor { }

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
@@ -15,9 +15,12 @@ import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.testing.AbstractWorkbenchTest;
 import org.eclipse.xtext.ui.tests.editor.quickfix.AbstractQuickfixTest;
+import org.eclipse.xtext.ui.tests.quickfix.ui.tests.QuickfixCrossrefTestLanguageUiInjectorProvider;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -25,10 +28,13 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * @author Moritz Eysholdt - Initial contribution and API
  */
+@RunWith(XtextRunner.class)
+@InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider.class)
 @SuppressWarnings("all")
 public class CompositeQuickfixTest extends AbstractQuickfixTest {
   @Test
@@ -42,7 +48,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("Bor { }");
     _builder.newLine();
-    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final IFile resource = this.dslFile(_builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<\"bad doc\">0>");
@@ -88,7 +94,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("Bor { }");
     _builder.newLine();
-    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final IFile resource = this.dslFile(_builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<\"bad doc\">0>");
@@ -143,7 +149,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("Bor { }");
     _builder.newLine();
-    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final IFile resource = this.dslFile(_builder);
     final XtextEditor editor = this.openEditor(resource);
     final ICompletionProposal[] proposals = this.computeQuickAssistProposals(editor, 1);
     StringConcatenation _builder_1 = new StringConcatenation();
@@ -174,7 +180,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("b {\tbadname { baz {} } }");
     _builder.newLine();
-    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final IFile resource = this.dslFile(_builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<c>0> {\tbadname { foo {} } }");
@@ -214,7 +220,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("a {\tbadname { bar {} } }");
     _builder.newLine();
-    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final IFile resource = this.dslFile(_builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<c>0> {\tbadname { foo {} } }");
@@ -257,7 +263,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("a {\tbadname { bar {} } }");
     _builder.newLine();
-    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final IFile resource = this.dslFile(_builder);
     final XtextEditor editor = this.openEditor(resource);
     final ICompletionProposal[] proposals = this.computeQuickAssistProposals(editor, 1);
     StringConcatenation _builder_1 = new StringConcatenation();
@@ -282,7 +288,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("fixable_b {\tref fixable_a }");
     _builder.newLine();
-    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final IFile resource = this.dslFile(_builder);
     final XtextEditor editor = this.openEditor(resource);
     final ICompletionProposal[] proposals = this.computeQuickAssistProposals(editor, 1);
     StringConcatenation _builder_1 = new StringConcatenation();
@@ -316,7 +322,7 @@ public class CompositeQuickfixTest extends AbstractQuickfixTest {
       _builder.newLine();
       _builder.append("lowercase_f {}");
       _builder.newLine();
-      final IFile resource = this.dslFile("myProject", "test", _builder);
+      final IFile resource = this.dslFile(_builder);
       IEditorPart _openEditor = IDE.openEditor(AbstractWorkbenchTest.getActivePage(), resource);
       final XtextEditor xtextEditor = ((XtextEditor) _openEditor);
       final IMarker[] markers = this.getMarkers(resource);

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.java
@@ -13,8 +13,11 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.tests.editor.quickfix.AbstractQuickfixTest;
+import org.eclipse.xtext.ui.tests.quickfix.ui.tests.QuickfixCrossrefTestLanguageUiInjectorProvider;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -22,10 +25,13 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * @author dhuebner - Initial contribution and API
  */
+@RunWith(XtextRunner.class)
+@InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider.class)
 @SuppressWarnings("all")
 public class MultiQuickFixTest extends AbstractQuickfixTest {
   @Test
@@ -37,7 +43,7 @@ public class MultiQuickFixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("\"no doc\" Bor { }");
     _builder.newLine();
-    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final IFile resource = this.dslFile(_builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<\"no doc\">0>");
@@ -77,7 +83,7 @@ public class MultiQuickFixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("\"no doc\" Bor { }");
     _builder.newLine();
-    final IFile resource = this.dslFile("myProject", "test", _builder);
+    final IFile resource = this.dslFile(_builder);
     final IMarker[] markers = this.getMarkers(resource);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("<0<\"no doc\">0>");
@@ -126,7 +132,7 @@ public class MultiQuickFixTest extends AbstractQuickfixTest {
     _builder.newLine();
     _builder.append("\"no doc\" Bor { }");
     _builder.newLine();
-    final IFile dslFile = this.dslFile("myProject", "test", _builder);
+    final IFile dslFile = this.dslFile(_builder);
     final XtextEditor editor = this.openEditor(dslFile);
     final ICompletionProposal[] proposals = this.computeQuickAssistProposals(editor, 1);
     StringConcatenation _builder_1 = new StringConcatenation();


### PR DESCRIPTION
- Modify the IssueDataTest and the LinkingErrorTest test cases to use
the
org.eclipse.xtext.ui.testing.AbstractQuickfixTest API instead of the
org.eclipse.xtext.ui.tests.editor.quickfix.AbstractQuickfixTest internal
base class.
- Modify the CompositeQuickfixTest, MultiQuickFixTest and
SpellingQuickfixTest test cases to use the generated
QuickfixCrossrefTestLanguageUiInjectorProvider.
- Remove the obsolete getInjector() method from the AbstractQuickfixTest
base class.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>