### PR TITLE
[#1447] Rename AbstractQuickfixTest to AbstractMultiQuickfixTest.

### DIFF
--- a/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/quickfix/SpellingQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/src-longrunning/org/eclipse/xtext/ui/tests/editor/quickfix/SpellingQuickfixTest.java
@@ -37,7 +37,7 @@ import com.google.common.base.Predicate;
  */
 @RunWith(XtextRunner.class)
 @InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider.class)
-public class SpellingQuickfixTest extends AbstractQuickfixTest {
+public class SpellingQuickfixTest extends AbstractMultiQuickfixTest {
 
 	private static final String MODEL_WITH_SPELLING_QUICKFIX_IN_SL_COLMMENT = "Foo {  } \n // Single Line Komment Spelling Error";
 	private static final String MODEL_WITH_SPELLING_QUICKFIX_IN_ML_COLMMENT = "Foo {  } \n /* Multi Line \n Komment Spelling Error */";

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractMultiQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/AbstractMultiQuickfixTest.java
@@ -43,7 +43,7 @@ import com.google.inject.Inject;
 /**
  * @author Jan Koehnlein - Initial contribution and API
  */
-public abstract class AbstractQuickfixTest extends AbstractEditorTest {
+public abstract class AbstractMultiQuickfixTest extends AbstractEditorTest {
 
 	@Inject
 	protected MarkerResolutionGenerator markerResolutionGenerator;
@@ -68,11 +68,11 @@ public abstract class AbstractQuickfixTest extends AbstractEditorTest {
 	}
 
 	protected String getProjectName() {
-		return "QuickfixTestProject";
+		return "MultiQuickfixTestProject";
 	}
 
 	protected String getFileName() {
-		return "quickfix";
+		return "multiquickfix";
 	}
 
 	protected String getFileExtension() {

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(XtextRunner)
 @InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider)
-class CompositeQuickfixTest extends AbstractQuickfixTest {
+class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 
 	@Test
 	def void testSimpleFixMultipleMarkers() throws Exception {

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.xtend
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(XtextRunner)
 @InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider)
-class MultiQuickFixTest extends AbstractQuickfixTest {
+class MultiQuickFixTest extends AbstractMultiQuickfixTest {
 
 	@Test
 	def void testFixMultipleMarkers() throws Exception {

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
@@ -19,7 +19,7 @@ import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.testing.AbstractWorkbenchTest;
-import org.eclipse.xtext.ui.tests.editor.quickfix.AbstractQuickfixTest;
+import org.eclipse.xtext.ui.tests.editor.quickfix.AbstractMultiQuickfixTest;
 import org.eclipse.xtext.ui.tests.quickfix.ui.tests.QuickfixCrossrefTestLanguageUiInjectorProvider;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -36,7 +36,7 @@ import org.junit.runner.RunWith;
 @RunWith(XtextRunner.class)
 @InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider.class)
 @SuppressWarnings("all")
-public class CompositeQuickfixTest extends AbstractQuickfixTest {
+public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
   @Test
   public void testSimpleFixMultipleMarkers() throws Exception {
     StringConcatenation _builder = new StringConcatenation();

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.java
@@ -16,7 +16,7 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.editor.XtextEditor;
-import org.eclipse.xtext.ui.tests.editor.quickfix.AbstractQuickfixTest;
+import org.eclipse.xtext.ui.tests.editor.quickfix.AbstractMultiQuickfixTest;
 import org.eclipse.xtext.ui.tests.quickfix.ui.tests.QuickfixCrossrefTestLanguageUiInjectorProvider;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith;
 @RunWith(XtextRunner.class)
 @InjectWith(QuickfixCrossrefTestLanguageUiInjectorProvider.class)
 @SuppressWarnings("all")
-public class MultiQuickFixTest extends AbstractQuickfixTest {
+public class MultiQuickFixTest extends AbstractMultiQuickfixTest {
   @Test
   public void testFixMultipleMarkers() throws Exception {
     StringConcatenation _builder = new StringConcatenation();


### PR DESCRIPTION
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>