### PR TITLE
[https://github.com/eclipse/xtext-core/issues/1506] Add reproducible

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/src/org/eclipse/xtext/example/arithmetics/tests/ArithmeticsFormatterTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/src/org/eclipse/xtext/example/arithmetics/tests/ArithmeticsFormatterTest.xtend
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.example.arithmetics.tests
+
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.testing.formatter.FormatterTestHelper
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(XtextRunner)
+@InjectWith(ArithmeticsInjectorProvider)
+class ArithmeticsFormatterTest {
+
+	@Inject extension FormatterTestHelper
+
+	@Ignore("See https://github.com/eclipse/xtext-core/issues/1506")
+	@Test def testFormatter() {
+		assertFormatted[
+			toBeFormatted = '''
+			module test
+			5 * 3 + 4;
+			'''
+			expectation = '''
+			module test
+			5 * 3 + 4;
+			'''
+		]
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/tests/ArithmeticsFormatterTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/tests/ArithmeticsFormatterTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.xtext.example.arithmetics.tests;
+
+import com.google.inject.Inject;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.arithmetics.tests.ArithmeticsInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.formatter.FormatterTestHelper;
+import org.eclipse.xtext.testing.formatter.FormatterTestRequest;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(XtextRunner.class)
+@InjectWith(ArithmeticsInjectorProvider.class)
+@SuppressWarnings("all")
+public class ArithmeticsFormatterTest {
+  @Inject
+  @Extension
+  private FormatterTestHelper _formatterTestHelper;
+  
+  @Ignore("See https://github.com/eclipse/xtext-core/issues/1506")
+  @Test
+  public void testFormatter() {
+    final Procedure1<FormatterTestRequest> _function = (FormatterTestRequest it) -> {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("module test");
+      _builder.newLine();
+      _builder.append("5 * 3 + 4;");
+      _builder.newLine();
+      it.setToBeFormatted(_builder);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("module test");
+      _builder_1.newLine();
+      _builder_1.append("5 * 3 + 4;");
+      _builder_1.newLine();
+      it.setExpectation(_builder_1);
+    };
+    this._formatterTestHelper.assertFormatted(_function);
+  }
+}


### PR DESCRIPTION
test case to the Xtext SimpleArithmetics Example (currently ignored).

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>