### PR TITLE
[eclipse/xtext#1784] use download.eclipse.org/releases/2020-09 in latest + domainmodel

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -8,7 +8,7 @@
       <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/releases/2020-06"/>
+      <repository location="https://download.eclipse.org/releases/2020-09"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
@@ -75,7 +75,7 @@
 		<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/releases/2020-06"/>
+		<repository location="https://download.eclipse.org/releases/2020-09"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1784] use download.eclipse.org/releases/2020-09 in latest + domainmodel

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>