### PR TITLE
[bugzilla 564578] Fix wrong colors on colors preference page

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/fields/AbstractDetailsPart.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/editor/preferences/fields/AbstractDetailsPart.java
@@ -104,8 +104,11 @@ public abstract class AbstractDetailsPart extends FieldEditorPreferencePage {
 		if (event.getSource() instanceof FieldEditor) {
 			FieldEditor fe = (FieldEditor) event.getSource();
 			internalStore.setValue(fe.getPreferenceName(), fe.getPreferenceStore().getDefaultString(fe.getPreferenceName()));
+			// store changed value in internalStore
 			fe.setPreferenceStore(internalStore);
 			fe.store();
+			// reset preference store of fieldEditor to chained store, so it also works for other token styles.
+			fe.setPreferenceStore(getPreferenceStore());
 		}
 		super.propertyChange(event);
 	}


### PR DESCRIPTION
This fixes an issue on the syntax coloring preference page:
when one color is changed, all other colors were shown as black

The preference store of field editors should not be replaced when
when a color is changed. The preference store is already a chained
preference store that contains the internal store.

This fixes bugzilla 564578