### PR TITLE
[eclipse/xtext#1812] Use centos-7 pod template & config. JDK

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
             def downstreamUrl = new URL("${env.JENKINS_URL}/job/$it/job/${env.BRANCH_NAME}")
             def boolean downstreamJobExists = sh(script: "curl -L -s -o /dev/null -I -w '%{http_code}' ${downstreamUrl}", returnStdout: true) == "200"
             if (downstreamJobExists) {
-              build job: "$it/${env.BRANCH_NAME}", wait: false, parameters: [booleanParam(name: 'TRIGGER_DOWNSTREAM_BUILD', value: "${params.TRIGGER_DOWNSTREAM_BUILD}")]
+              build job: "$it/${env.BRANCH_NAME}", wait: false, parameters: [booleanParam(name: 'TRIGGER_DOWNSTREAM_BUILD', value: "${params.TRIGGER_DOWNSTREAM_BUILD}"), string(name: 'JDK_VERSION', value: "${JDK_VERSION}")]
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,20 +135,20 @@ pipeline {
 
 def eclipseVersion(String targetPlatform) {
   if (targetPlatform == 'latest') {
-    return "4.17"
+    return "Eclipse4.17"
   } else if (targetPlatform == 'photon') {
-    return "4.8"
+    return "Eclipse4.8"
   } else if (targetPlatform == 'oxygen') {
-    return "4.7"
+    return "Eclipse4.7"
   } else {
     def baseDate = java.time.LocalDate.parse("2018-06-01") // 4.8 Photon
     def df = java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd")
     def targetDate = java.time.LocalDate.parse(targetPlatform.substring(1)+"01", df)
     long monthsBetween = java.time.temporal.ChronoUnit.MONTHS.between(baseDate, targetDate);
-    return "4."+ (8+(monthsBetween/3))
+    return "Eclipse4."+ (8+(monthsBetween/3))
   } 
 }
 
 def javaVersion(String version) {
-  return version.replaceAll(".*-(jdk\\d+).*", "\$1")
+  return version.replaceAll(".*-(jdk\\d+).*", "\$1").toUpperCase()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,9 +150,5 @@ def eclipseVersion(String targetPlatform) {
 }
 
 def javaVersion(String version) {
-  if (!version.contains('-jdk')) {
-    return 'jdk15'
-  } else {
-    return version.replaceAll(".*-(jdk\\d+).*", "\$1")
-  }
+  return version.replaceAll(".*-(jdk\\d+).*", "\$1")
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
   }
 
   tools {
-     maven "apache-maven-latest"
+     maven "apache-maven-3.6.3"
      jdk "${params.JDK_VERSION}"
   }
 


### PR DESCRIPTION
The centos-7 pod template provides a configuration suitable for most
builds. This makes the configuration of the custom container obsolete.

Additionally JDK versions are now selectable by parameter.

The nightly build uses 'latest' target and JDK 11.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>