### PR TITLE
Provide quickfixes for illegal rule references (WIP)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,6 +141,7 @@ spec:
   post {
     always {
       junit testResults: '**/target/surefire-reports/*.xml'
+      archiveArtifacts artifacts: '**/target/work/data/.metadata/.log, **/hs_err_pid*.log'
     }
     success {
       archiveArtifacts artifacts: 'build/**'
@@ -155,9 +156,6 @@ spec:
           }
         }
       }
-    }
-    failure {
-      archiveArtifacts artifacts: '**/target/work/data/.metadata/.log, **/hs_err_pid*.log'
     }
     cleanup {
       script {

--- a/org.eclipse.xtext.builder.tests/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.builder.tests/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,4 +1,0 @@
-#Tue Mar 31 22:20:17 CEST 2009
-eclipse.preferences.version=1
-metamodelContributor=org.eclipse.xtend.shared.ui.core.metamodel.jdt.javabean.JavaBeanMetamodelContributor
-project.specific.metamodel=true

--- a/org.eclipse.xtext.builder/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.builder/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,4 +1,0 @@
-#Tue Mar 31 22:20:17 CEST 2009
-eclipse.preferences.version=1
-metamodelContributor=org.eclipse.xtend.shared.ui.core.metamodel.jdt.javabean.JavaBeanMetamodelContributor
-project.specific.metamodel=true

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/builderState/AbstractBuilderState.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/builderState/AbstractBuilderState.java
@@ -71,7 +71,7 @@ public abstract class AbstractBuilderState extends AbstractResourceDescriptionCh
 
 	private volatile boolean isLoaded = false;
 	
-	final ILock loadLock = Job.getJobManager().newLock();
+	private final ILock loadLock = Job.getJobManager().newLock();
 
 	public void load() {
 		if (!isLoaded) {

--- a/org.eclipse.xtext.common.types.eclipse.tests/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.common.types.eclipse.tests/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,4 +1,0 @@
-#Tue Mar 31 22:20:17 CEST 2009
-eclipse.preferences.version=1
-metamodelContributor=org.eclipse.xtend.shared.ui.core.metamodel.jdt.javabean.JavaBeanMetamodelContributor
-project.specific.metamodel=true

--- a/org.eclipse.xtext.common.types.ui/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.common.types.ui/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,4 +1,0 @@
-#Tue Mar 31 22:20:17 CEST 2009
-eclipse.preferences.version=1
-metamodelContributor=org.eclipse.xtend.shared.ui.core.metamodel.jdt.javabean.JavaBeanMetamodelContributor
-project.specific.metamodel=true

--- a/org.eclipse.xtext.doc/contents/310_eclipse_support.html
+++ b/org.eclipse.xtext.doc/contents/310_eclipse_support.html
@@ -887,11 +887,13 @@ final class HelloWorldFile {
 
 <ul>
   <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractAutoEditTest.java">AbstractAutoEditTest</a>: base class for testing the auto editing functionality</li>
+  <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractCodeMiningTest.java">AbstractCodeMiningTest</a>: base class for testing the code mining capabilities</li>
   <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractContentAssistTest.java">AbstractContentAssistTest</a>: base class for testing the content assistant and template proposals</li>
   <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractFoldingTest.java">AbstractFoldingTest</a>: base class for testing the folding capabilities</li>
   <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHighlightingTest.java">AbstractHighlightingTest</a>: base class for testing the syntactical and semantic coloring</li>
   <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHoverTest.java">AbstractHoverTest</a>: base class for testing the hovering functionality</li>
   <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractHyperlinkingTest.java">AbstractHyperlinkingTest</a>: base class for testing the hyperlinking functionality</li>
+  <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractMultiQuickfixTest.java">AbstractMultiQuickfixTest</a>: base class for testing the multi quick fixes</li>
   <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractOutlineTest.java">AbstractOutlineTest</a>: base class for testing the structure of the outline view</li>
   <li><a href="https://github.com/eclipse/xtext-eclipse/blob/master/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractQuickfixTest.java">AbstractQuickfixTest</a>: base class for testing the quick fixes</li>
   <li>…</li>

--- a/org.eclipse.xtext.eclipse.tests/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.eclipse.tests/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,3 +1,0 @@
-#Tue Apr 06 14:38:13 CEST 2010
-eclipse.preferences.version=1
-project.specific.metamodel=true

--- a/org.eclipse.xtext.ui.codetemplates.ui/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.ui.codetemplates.ui/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,4 +1,0 @@
-#Tue Feb 16 15:24:59 CET 2010
-eclipse.preferences.version=1
-metamodelContributor=org.eclipse.xtend.shared.ui.core.metamodel.jdt.javabean.JavaBeanMetamodelContributor,org.eclipse.xtend.typesystem.emf.ui.EmfMetamodelContributor
-project.specific.metamodel=true

--- a/org.eclipse.xtext.ui.codetemplates/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.ui.codetemplates/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,4 +1,0 @@
-#Tue Feb 16 15:24:59 CET 2010
-eclipse.preferences.version=1
-metamodelContributor=org.eclipse.xtend.shared.ui.core.metamodel.jdt.javabean.JavaBeanMetamodelContributor,org.eclipse.xtend.typesystem.emf.ui.EmfMetamodelContributor
-project.specific.metamodel=true

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractCodeMiningTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractCodeMiningTest.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ui.testing;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.codemining.ICodeMiningProvider;
+import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.xtext.resource.FileExtensionProvider;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+
+/**
+ * @author miklossy - Initial contribution and API
+ * @since 2.23
+ */
+@Beta
+public class AbstractCodeMiningTest extends AbstractEditorTest {
+
+	@Inject
+	protected FileExtensionProvider fileExtensionProvider;
+
+	@Inject
+	protected ICodeMiningProvider codeMiningProvider;
+
+	/**
+	 * Test that the expected code minings are present on a given DSL text.
+	 *
+	 * @param initialText
+	 *            The initial DSL text.
+	 * @param expected
+	 *            The DSL text where the expected code minings are inserted on the right position.
+	 */
+	public void testCodeMining(CharSequence initialText, String expected) {
+		// Given
+		IFile dslFile = dslFile(initialText);
+		// When
+		XtextEditor editor = openEditor(dslFile);
+		// Then
+		codeMiningsArePresent(editor, expected);
+	}
+
+	@Override
+	protected XtextEditor openEditor(IFile dslFile) {
+		try {
+			XtextEditor editor = super.openEditor(dslFile);
+			assertNotNull(editor);
+			return editor;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected void codeMiningsArePresent(XtextEditor editor, String expected) {
+		String actual = insertCodeMinings(editor);
+		assertEquals(expected, actual);
+	}
+
+	protected String insertCodeMinings(XtextEditor editor) {
+		ISourceViewer viewer = editor.getInternalSourceViewer();
+
+		String text = editor.getDocument().get();
+		StringBuilder sb = new StringBuilder();
+
+		List<? extends ICodeMining> codeMinings;
+		try {
+			codeMinings = codeMiningProvider.provideCodeMinings(viewer, new NullProgressMonitor()).get();
+		} catch (InterruptedException | ExecutionException e) {
+			throw new RuntimeException(e);
+		}
+
+		for (ICodeMining codeMining : codeMinings) {
+			try {
+				codeMining.resolve(viewer, new NullProgressMonitor()).get();
+			} catch (InterruptedException | ExecutionException e) {
+				throw new RuntimeException(e);
+			}
+			assertTrue("CodeMining is not resolved!", codeMining.isResolved());
+		}
+
+		codeMinings.sort((ICodeMining cm1, ICodeMining cm2) -> cm1.getPosition().getOffset() - cm2.getPosition().getOffset());
+
+		int currentOffset = 0;
+		for (int i = 0; i < codeMinings.size(); i++) {
+
+			ICodeMining codeMining = codeMinings.get(i);
+
+			int codeMiningOffset = codeMining.getPosition().getOffset();
+
+			List<ICodeMining> codeMiningsOnTheSameOffset = getCodeMiningsByOffset(codeMinings, codeMiningOffset);
+
+			String codeMiningsText = getCodeMiningsText(codeMiningsOnTheSameOffset);
+
+			sb.append(text.substring(currentOffset, codeMiningOffset) + codeMiningsText);
+
+			currentOffset = codeMiningOffset;
+			if (containsLineHeaderCodeMining(codeMiningsOnTheSameOffset)) {
+				sb.append(System.lineSeparator());
+				currentOffset--;
+			}
+
+			i = getLastCodeMiningOnOffset(codeMinings, codeMiningOffset);
+		}
+
+		sb.append(text.substring(currentOffset));
+		return sb.toString();
+	}
+
+	protected List<ICodeMining> getCodeMiningsByOffset(List<? extends ICodeMining> codeMinings, int offset) {
+		List<ICodeMining> result = new ArrayList<ICodeMining>();
+		for (ICodeMining codeMining : codeMinings) {
+			int codeMiningOffset = codeMining.getPosition().getOffset();
+			if (codeMiningOffset == offset) {
+				result.add(codeMining);
+			}
+		}
+		return result;
+	}
+
+	protected String getCodeMiningsText(List<? extends ICodeMining> codeMinings) {
+		StringBuilder result = new StringBuilder();
+
+		int count = 0;
+		for (ICodeMining codeMining : codeMinings) {
+			String codeMiningLabel = codeMining.getLabel();
+			if (codeMiningLabel != null) {
+				if (count != 0) {
+					result.append(" | ");
+				}
+				result.append(codeMiningLabel);
+			}
+			count++;
+		}
+		return result.toString();
+	}
+
+	protected boolean containsLineHeaderCodeMining(List<ICodeMining> codeMinings) {
+		for (ICodeMining codeMining : codeMinings) {
+			if (codeMining instanceof LineHeaderCodeMining) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	protected int getLastCodeMiningOnOffset(List<? extends ICodeMining> codeMinings, int offset) {
+		int i = 0;
+		for (; i < codeMinings.size(); i++) {
+			ICodeMining codeMining = codeMinings.get(i);
+			if (codeMining.getPosition().getOffset() > offset) {
+				return i - 1;
+			}
+		}
+		return codeMinings.size();
+	}
+
+	protected IFile dslFile(CharSequence content) {
+		return dslFile(getProjectName(), getFileName(), getFileExtension(), content);
+	}
+
+	protected String getProjectName() {
+		return "CodeMiningTestProject";
+	}
+
+	protected String getFileName() {
+		return "codeMining";
+	}
+
+	protected String getFileExtension() {
+		return fileExtensionProvider.getPrimaryFileExtension();
+	}
+
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.arithmetics.ui.tests;x-internal=true,
  org.eclipse.xtext.example.arithmetics.ui.tests.autoedit;x-internal:=true,
+ org.eclipse.xtext.example.arithmetics.ui.tests.codemining;x-internal:=true,
  org.eclipse.xtext.example.arithmetics.ui.tests.folding;x-internal:=true,
  org.eclipse.xtext.example.arithmetics.ui.tests.hover;x-internal:=true,
  org.eclipse.xtext.example.arithmetics.ui.tests.hyperlinking;x-internal:=true,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/codemining/CodeMiningTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/codemining/CodeMiningTest.xtend
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.example.arithmetics.ui.tests.codemining
+
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractCodeMiningTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(ArithmeticsUiInjectorProvider)
+class CodeMiningTest extends AbstractCodeMiningTest {
+
+	@Test def evaluation_value_is_presented_as_code_mining() {
+		'''
+			module volume
+
+			def cubeVolume(l): boxVolume(l,l,l);
+			def boxVolume(l,w,h): l*w*h;
+
+			cubeVolume(10);
+			cubeVolume(2);
+			boxVolume(1,3,5);
+		'''.testCodeMining('''
+			module volume
+
+			def cubeVolume(l): boxVolume(l,l,l);
+			def boxVolume(l,w,h): l*w*h;
+
+			cubeVolume(10) = 1000;
+			cubeVolume(2) = 8;
+			boxVolume(1,3,5) = 15;
+		''')
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/codemining/CodeMiningTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/codemining/CodeMiningTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.xtext.example.arithmetics.ui.tests.codemining;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractCodeMiningTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(ArithmeticsUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class CodeMiningTest extends AbstractCodeMiningTest {
+  @Test
+  public void evaluation_value_is_presented_as_code_mining() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("module volume");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("def cubeVolume(l): boxVolume(l,l,l);");
+    _builder.newLine();
+    _builder.append("def boxVolume(l,w,h): l*w*h;");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("cubeVolume(10);");
+    _builder.newLine();
+    _builder.append("cubeVolume(2);");
+    _builder.newLine();
+    _builder.append("boxVolume(1,3,5);");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("module volume");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("def cubeVolume(l): boxVolume(l,l,l);");
+    _builder_1.newLine();
+    _builder_1.append("def boxVolume(l,w,h): l*w*h;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("cubeVolume(10) = 1000;");
+    _builder_1.newLine();
+    _builder_1.append("cubeVolume(2) = 8;");
+    _builder_1.newLine();
+    _builder_1.append("boxVolume(1,3,5) = 15;");
+    _builder_1.newLine();
+    this.testCodeMining(_builder, _builder_1.toString());
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/META-INF/MANIFEST.MF
@@ -22,6 +22,7 @@ Import-Package: org.apache.log4j,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.example.arithmetics.ui;x-internal:=true,
  org.eclipse.xtext.example.arithmetics.ui.autoedit;x-internal:=true,
+ org.eclipse.xtext.example.arithmetics.ui.codemining;x-internal:=true,
  org.eclipse.xtext.example.arithmetics.ui.contentassist;x-internal:=true,
  org.eclipse.xtext.example.arithmetics.ui.editor.hierarchy;x-internal:=true,
  org.eclipse.xtext.example.arithmetics.ui.internal;x-internal:=true,

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.xtend
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.example.domainmodel.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractCodeMiningTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(DomainmodelUiInjectorProvider)
+class CodeMiningTest extends AbstractCodeMiningTest {
+
+	@Test def implicit_return_type_is_presented_as_code_mining() {
+		'''
+			entity E {
+				s: String
+				op getS() { s }
+			}
+		'''.testCodeMining('''
+			entity E {
+				s: String
+				op getS() : String { s }
+			}
+		''')
+	}
+
+	@Test def explicit_return_type_is_not_presented_as_code_mining() {
+		'''
+			entity E {
+				s: String
+				op getS() : String { s }
+			}
+		'''.testCodeMining('''
+			entity E {
+				s: String
+				op getS() : String { s }
+			}
+		''')
+	}
+
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.xtext.example.domainmodel.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.domainmodel.ui.tests.DomainmodelUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractCodeMiningTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(DomainmodelUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class CodeMiningTest extends AbstractCodeMiningTest {
+  @Test
+  public void implicit_return_type_is_presented_as_code_mining() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("s: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op getS() { s }");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity E {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("s: String");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("op getS() : String { s }");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.testCodeMining(_builder, _builder_1.toString());
+  }
+  
+  @Test
+  public void explicit_return_type_is_not_presented_as_code_mining() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("s: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op getS() : String { s }");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity E {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("s: String");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("op getS() : String { s }");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.testCodeMining(_builder, _builder_1.toString());
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,4 +1,0 @@
-#Wed Feb 03 14:00:45 CET 2010
-eclipse.preferences.version=1
-metamodelContributor=org.eclipse.xtend.shared.ui.core.metamodel.jdt.javabean.JavaBeanMetamodelContributor
-project.specific.metamodel=true

--- a/org.eclipse.xtext.xtext.ui/.settings/org.eclipse.xtend.shared.ui.prefs
+++ b/org.eclipse.xtext.xtext.ui/.settings/org.eclipse.xtend.shared.ui.prefs
@@ -1,4 +1,0 @@
-#Fri Dec 18 14:03:49 CET 2009
-eclipse.preferences.version=1
-metamodelContributor=org.eclipse.xtend.shared.ui.core.metamodel.jdt.javabean.JavaBeanMetamodelContributor,org.eclipse.xtend.typesystem.emf.ui.EmfMetamodelContributor
-project.specific.metamodel=true

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -71,19 +71,19 @@
 		<repository location="https://download.eclipse.org/eclipse/updates/4.17-I-builds"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/releases/2020-09"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/nightly/latest"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
 		<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.11.3/"/>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-oxygen.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-oxygen.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/oxygen/201804111000"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.20"/>
 	</location>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-photon.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-photon.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/photon"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.20"/>
 	</location>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201809.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201809.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/2018-09"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.20"/>
 	</location>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201812.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201812.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/2018-12"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.20"/>
 	</location>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201903.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201903.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/2019-03"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.20"/>
 	</location>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201906.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201906.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/2019-06"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.20"/>
 	</location>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201909.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201909.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/2019-09"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.20"/>
 	</location>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201912.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201912.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/2019-12"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.20"/>
 	</location>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202003.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202003.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/2020-03"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.21"/>
 	</location>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202006.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202006.target
@@ -63,7 +63,7 @@
 		<repository location="https://ci.eclipse.org/xtext/job/xtext-extras/job/master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
@@ -76,7 +76,7 @@
 		<repository location="https://download.eclipse.org/releases/2020-06"/>
 	</location>
 
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.21"/>
 	</location>

--- a/releng/org.eclipse.xtext.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtext.tycho.parent/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<tycho-version>1.7.0</tycho-version>
 		<!-- version of the "bootstrap" plugin; used to compile xtend sources in xtend -->
-		<xtend-maven-plugin-version>2.23.0.M1</xtend-maven-plugin-version>
+		<xtend-maven-plugin-version>2.23.0.M2</xtend-maven-plugin-version>
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
- Enhanced the quick-fix to handle case where a terminal-fragment is referenced as a hidden token in a Parser rule definition
- Added method `createChangeToIssueResolution()` to avoid duplicate 'Change to' quick-fix if there are multiple/different fixes for an issue
- Added quick-fix method `fixUnresolvedEnumRule()`.

Signed-off-by: nbhusare <neerajbhusare@gmail.com>