### PR TITLE
[#1497] Provide the AbstractCodeMiningTest abstract base class.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractCodeMiningTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractCodeMiningTest.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.ui.testing;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.codemining.ICodeMiningProvider;
+import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.xtext.resource.FileExtensionProvider;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+
+/**
+ * @author miklossy - Initial contribution and API
+ * @since 2.23
+ */
+@Beta
+public class AbstractCodeMiningTest extends AbstractEditorTest {
+
+	@Inject
+	protected FileExtensionProvider fileExtensionProvider;
+
+	@Inject
+	protected ICodeMiningProvider codeMiningProvider;
+
+	/**
+	 * Test that the expected code minings are present on a given DSL text.
+	 *
+	 * @param initialText
+	 *            The initial DSL text.
+	 * @param expected
+	 *            The DSL text where the expected code minings are inserted on the right position.
+	 */
+	public void testCodeMining(CharSequence initialText, String expected) {
+		// Given
+		IFile dslFile = dslFile(initialText);
+		// When
+		XtextEditor editor = openEditor(dslFile);
+		// Then
+		codeMiningsArePresent(editor, expected);
+	}
+
+	@Override
+	protected XtextEditor openEditor(IFile dslFile) {
+		try {
+			XtextEditor editor = super.openEditor(dslFile);
+			assertNotNull(editor);
+			return editor;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected void codeMiningsArePresent(XtextEditor editor, String expected) {
+		String actual = insertCodeMinings(editor);
+		assertEquals(expected, actual);
+	}
+
+	protected String insertCodeMinings(XtextEditor editor) {
+		ISourceViewer viewer = editor.getInternalSourceViewer();
+
+		String text = editor.getDocument().get();
+		StringBuilder sb = new StringBuilder();
+
+		List<? extends ICodeMining> codeMinings;
+		try {
+			codeMinings = codeMiningProvider.provideCodeMinings(viewer, new NullProgressMonitor()).get();
+		} catch (InterruptedException | ExecutionException e) {
+			throw new RuntimeException(e);
+		}
+
+		for (ICodeMining codeMining : codeMinings) {
+			try {
+				codeMining.resolve(viewer, new NullProgressMonitor()).get();
+			} catch (InterruptedException | ExecutionException e) {
+				throw new RuntimeException(e);
+			}
+			assertTrue("CodeMining is not resolved!", codeMining.isResolved());
+		}
+
+		codeMinings.sort((ICodeMining cm1, ICodeMining cm2) -> cm1.getPosition().getOffset() - cm2.getPosition().getOffset());
+
+		int currentOffset = 0;
+		for (int i = 0; i < codeMinings.size(); i++) {
+
+			ICodeMining codeMining = codeMinings.get(i);
+
+			int codeMiningOffset = codeMining.getPosition().getOffset();
+
+			List<ICodeMining> codeMiningsOnTheSameOffset = getCodeMiningsByOffset(codeMinings, codeMiningOffset);
+
+			String codeMiningsText = getCodeMiningsText(codeMiningsOnTheSameOffset);
+
+			sb.append(text.substring(currentOffset, codeMiningOffset) + codeMiningsText);
+
+			currentOffset = codeMiningOffset;
+			if (containsLineHeaderCodeMining(codeMiningsOnTheSameOffset)) {
+				sb.append(System.lineSeparator());
+				currentOffset--;
+			}
+
+			i = getLastCodeMiningOnOffset(codeMinings, codeMiningOffset);
+		}
+
+		sb.append(text.substring(currentOffset));
+		return sb.toString();
+	}
+
+	protected List<ICodeMining> getCodeMiningsByOffset(List<? extends ICodeMining> codeMinings, int offset) {
+		List<ICodeMining> result = new ArrayList<ICodeMining>();
+		for (ICodeMining codeMining : codeMinings) {
+			int codeMiningOffset = codeMining.getPosition().getOffset();
+			if (codeMiningOffset == offset) {
+				result.add(codeMining);
+			}
+		}
+		return result;
+	}
+
+	protected String getCodeMiningsText(List<? extends ICodeMining> codeMinings) {
+		StringBuilder result = new StringBuilder();
+
+		int count = 0;
+		for (ICodeMining codeMining : codeMinings) {
+			String codeMiningLabel = codeMining.getLabel();
+			if (codeMiningLabel != null) {
+				if (count != 0) {
+					result.append(" | ");
+				}
+				result.append(codeMiningLabel);
+			}
+			count++;
+		}
+		return result.toString();
+	}
+
+	protected boolean containsLineHeaderCodeMining(List<ICodeMining> codeMinings) {
+		for (ICodeMining codeMining : codeMinings) {
+			if (codeMining instanceof LineHeaderCodeMining) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	protected int getLastCodeMiningOnOffset(List<? extends ICodeMining> codeMinings, int offset) {
+		int i = 0;
+		for (; i < codeMinings.size(); i++) {
+			ICodeMining codeMining = codeMinings.get(i);
+			if (codeMining.getPosition().getOffset() > offset) {
+				return i - 1;
+			}
+		}
+		return codeMinings.size();
+	}
+
+	protected IFile dslFile(CharSequence content) {
+		return dslFile(getProjectName(), getFileName(), getFileExtension(), content);
+	}
+
+	protected String getProjectName() {
+		return "CodeMiningTestProject";
+	}
+
+	protected String getFileName() {
+		return "codeMining";
+	}
+
+	protected String getFileExtension() {
+		return fileExtensionProvider.getPrimaryFileExtension();
+	}
+
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/codemining/CodeMiningTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/src/org/eclipse/xtext/example/arithmetics/ui/tests/codemining/CodeMiningTest.xtend
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.example.arithmetics.ui.tests.codemining
+
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractCodeMiningTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(ArithmeticsUiInjectorProvider)
+class CodeMiningTest extends AbstractCodeMiningTest {
+
+	@Test def evaluation_value_is_presented_as_code_mining() {
+		'''
+			module volume
+
+			def cubeVolume(l): boxVolume(l,l,l);
+			def boxVolume(l,w,h): l*w*h;
+
+			cubeVolume(10);
+			cubeVolume(2);
+			boxVolume(1,3,5);
+		'''.testCodeMining('''
+			module volume
+
+			def cubeVolume(l): boxVolume(l,l,l);
+			def boxVolume(l,w,h): l*w*h;
+
+			cubeVolume(10) = 1000;
+			cubeVolume(2) = 8;
+			boxVolume(1,3,5) = 15;
+		''')
+	}
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/codemining/CodeMiningTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui.tests/xtend-gen/org/eclipse/xtext/example/arithmetics/ui/tests/codemining/CodeMiningTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.xtext.example.arithmetics.ui.tests.codemining;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.arithmetics.ui.tests.ArithmeticsUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractCodeMiningTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(ArithmeticsUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class CodeMiningTest extends AbstractCodeMiningTest {
+  @Test
+  public void evaluation_value_is_presented_as_code_mining() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("module volume");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("def cubeVolume(l): boxVolume(l,l,l);");
+    _builder.newLine();
+    _builder.append("def boxVolume(l,w,h): l*w*h;");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("cubeVolume(10);");
+    _builder.newLine();
+    _builder.append("cubeVolume(2);");
+    _builder.newLine();
+    _builder.append("boxVolume(1,3,5);");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("module volume");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("def cubeVolume(l): boxVolume(l,l,l);");
+    _builder_1.newLine();
+    _builder_1.append("def boxVolume(l,w,h): l*w*h;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("cubeVolume(10) = 1000;");
+    _builder_1.newLine();
+    _builder_1.append("cubeVolume(2) = 8;");
+    _builder_1.newLine();
+    _builder_1.append("boxVolume(1,3,5) = 15;");
+    _builder_1.newLine();
+    this.testCodeMining(_builder, _builder_1.toString());
+  }
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.xtend
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.example.domainmodel.ui.tests
+
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractCodeMiningTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner)
+@InjectWith(DomainmodelUiInjectorProvider)
+class CodeMiningTest extends AbstractCodeMiningTest {
+
+	@Test def implicit_return_type_is_presented_as_code_mining() {
+		'''
+			entity E {
+				s: String
+				op getS() { s }
+			}
+		'''.testCodeMining('''
+			entity E {
+				s: String
+				op getS() : String { s }
+			}
+		''')
+	}
+
+	@Test def explicit_return_type_is_not_presented_as_code_mining() {
+		'''
+			entity E {
+				s: String
+				op getS() : String { s }
+			}
+		'''.testCodeMining('''
+			entity E {
+				s: String
+				op getS() : String { s }
+			}
+		''')
+	}
+
+}

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.xtext.example.domainmodel.ui.tests;
+
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.example.domainmodel.ui.tests.DomainmodelUiInjectorProvider;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractCodeMiningTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(DomainmodelUiInjectorProvider.class)
+@SuppressWarnings("all")
+public class CodeMiningTest extends AbstractCodeMiningTest {
+  @Test
+  public void implicit_return_type_is_presented_as_code_mining() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("s: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op getS() { s }");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity E {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("s: String");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("op getS() : String { s }");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.testCodeMining(_builder, _builder_1.toString());
+  }
+  
+  @Test
+  public void explicit_return_type_is_not_presented_as_code_mining() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("s: String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op getS() : String { s }");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("entity E {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("s: String");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("op getS() : String { s }");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.testCodeMining(_builder, _builder_1.toString());
+  }
+}


### PR DESCRIPTION
- Extend the 'Xtext UI Testing' test infrastructure by the
AbstractCodeMiningTest abstract class to provide a base infrastructure
for testing the code mining capabilities.
- Extend the Xtext Examples by CodeMiningTest test cases to
demonstrate the usage of the AbstractCodeMiningTest class.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>