### PR TITLE
Porting quickfixes for illegal rule references

### DIFF
--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.xtend
@@ -24,6 +24,98 @@ import static org.eclipse.xtext.xtext.XtextConfigurableIssueCodes.SPACES_IN_KEYW
 @RunWith(XtextRunner)
 @InjectWith(XtextUiInjectorProvider)
 class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
+	
+	@Test def test_convert_terminal_fragment_to_terminal_rule() {
+		'''
+			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+			
+			generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+			
+			Model hidden(ABC):
+				a = ID;
+			
+			terminal fragment ABC:
+				'a';
+		'''.testQuickfixesOn(
+			"org.eclipse.xtext.grammar.InvalidHiddenTokenFragment",
+			new Quickfix("Convert terminal fragment to terminal rule", "Convert terminal fragment to terminal rule", '''
+				grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+				
+				generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+				
+				Model hidden(ABC):
+					a = ID;
+				
+				terminal ABC:
+					'a';
+			'''),
+			new Quickfix("Remove hidden token definition", "Remove hidden token definition", '''
+				grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+				
+				generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+				
+				Model hidden():
+					a = ID;
+				
+				terminal fragment ABC:
+					'a';
+			''')
+		);
+	}
+	
+	@Test def test_convert_terminal_fragment_to_terminal_rule_01() {
+		'''
+			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+			
+			generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+			
+			Model:
+				a = ABC;
+			
+			terminal fragment ABC:
+				'a';
+		'''.testQuickfixesOn(
+			"org.eclipse.xtext.grammar.InvalidTerminalFragmentRuleReference",
+			new Quickfix("Convert terminal fragment to terminal rule", "Convert terminal fragment to terminal rule", '''
+				grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+				
+				generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+				
+				Model:
+					a = ABC;
+				
+				terminal ABC:
+					'a';
+			''')
+		);
+	}
+
+	@Test def test_fix_invalid_hidden_token() {
+		'''
+			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+			
+			generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+			
+			Model hidden(AnotherModel):
+				a = ID;
+			
+			AnotherModel:
+				b = ID;
+		'''.testQuickfixesOn(
+			"org.eclipse.xtext.grammar.InvalidHiddenToken",
+			new Quickfix("Remove hidden token definition", "Remove hidden token definition", '''
+				grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+				
+				generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+				
+				Model hidden():
+					a = ID;
+				
+				AnotherModel:
+					b = ID;
+			''')
+		);
+	}
 
 	@Test def test_fix_missing_rule() {
 		'''
@@ -33,18 +125,55 @@ class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
 			
 			Model:
 				greetings+=Greeting*;
-		'''
-		.testQuickfixesOn("org.eclipse.xtext.grammar.UnresolvedRule", new Quickfix("Create rule 'Greeting'", "Create rule 'Greeting'", '''
-			grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
-			
-			generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
-			
-			Model:
-				greetings+=Greeting*;
-			
-			Greeting:
+		'''.testQuickfixesOn(
+			"org.eclipse.xtext.grammar.UnresolvedRule",
+			new Quickfix("Create rule 'Greeting'", "Create rule 'Greeting'", '''
+				grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
 				
-			;
+				generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+				
+				Model:
+					greetings+=Greeting*;
+				
+				Greeting:
+					
+				;
+			'''),
+			new Quickfix("Create enum rule 'Greeting'", "Create enum rule 'Greeting'", '''
+				grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+				
+				generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+				
+				Model:
+					greetings+=Greeting*;
+				
+				enum Greeting:
+					
+				;
+			'''),
+			new Quickfix("Create terminal 'Greeting'", "Create terminal 'Greeting'", '''
+				grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+				
+				generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+				
+				Model:
+					greetings+=Greeting*;
+				
+				terminal Greeting:
+					
+				;
+			'''),
+			new Quickfix("Create terminal fragment 'Greeting'", "Create terminal fragment 'Greeting'", '''
+				grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
+				
+				generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
+				
+				Model:
+					greetings+=Greeting*;
+				
+				terminal fragment Greeting:
+					
+				;
 			''')
 		);
 	}

--- a/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.java
@@ -25,6 +25,154 @@ import org.junit.runner.RunWith;
 @SuppressWarnings("all")
 public class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
   @Test
+  public void test_convert_terminal_fragment_to_terminal_rule() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Model hidden(ABC):");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("a = ID;");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("terminal fragment ABC:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("\'a\';");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("Model hidden(ABC):");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("a = ID;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("terminal ABC:");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("\'a\';");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Convert terminal fragment to terminal rule", "Convert terminal fragment to terminal rule", _builder_1.toString());
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_2.newLine();
+    _builder_2.newLine();
+    _builder_2.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder_2.newLine();
+    _builder_2.newLine();
+    _builder_2.append("Model hidden():");
+    _builder_2.newLine();
+    _builder_2.append("\t");
+    _builder_2.append("a = ID;");
+    _builder_2.newLine();
+    _builder_2.newLine();
+    _builder_2.append("terminal fragment ABC:");
+    _builder_2.newLine();
+    _builder_2.append("\t");
+    _builder_2.append("\'a\';");
+    _builder_2.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix_1 = new AbstractQuickfixTest.Quickfix("Remove hidden token definition", "Remove hidden token definition", _builder_2.toString());
+    this.testQuickfixesOn(_builder, 
+      "org.eclipse.xtext.grammar.InvalidHiddenTokenFragment", _quickfix, _quickfix_1);
+  }
+  
+  @Test
+  public void test_convert_terminal_fragment_to_terminal_rule_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Model:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("a = ABC;");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("terminal fragment ABC:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("\'a\';");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("Model:");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("a = ABC;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("terminal ABC:");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("\'a\';");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Convert terminal fragment to terminal rule", "Convert terminal fragment to terminal rule", _builder_1.toString());
+    this.testQuickfixesOn(_builder, 
+      "org.eclipse.xtext.grammar.InvalidTerminalFragmentRuleReference", _quickfix);
+  }
+  
+  @Test
+  public void test_fix_invalid_hidden_token() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("Model hidden(AnotherModel):");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("a = ID;");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("AnotherModel:");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("b = ID;");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("Model hidden():");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("a = ID;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("AnotherModel:");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("b = ID;");
+    _builder_1.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Remove hidden token definition", "Remove hidden token definition", _builder_1.toString());
+    this.testQuickfixesOn(_builder, 
+      "org.eclipse.xtext.grammar.InvalidHiddenToken", _quickfix);
+  }
+  
+  @Test
   public void test_fix_missing_rule() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
@@ -58,7 +206,68 @@ public class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
     _builder_1.append(";");
     _builder_1.newLine();
     AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix("Create rule \'Greeting\'", "Create rule \'Greeting\'", _builder_1.toString());
-    this.testQuickfixesOn(_builder, "org.eclipse.xtext.grammar.UnresolvedRule", _quickfix);
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_2.newLine();
+    _builder_2.newLine();
+    _builder_2.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder_2.newLine();
+    _builder_2.newLine();
+    _builder_2.append("Model:");
+    _builder_2.newLine();
+    _builder_2.append("\t");
+    _builder_2.append("greetings+=Greeting*;");
+    _builder_2.newLine();
+    _builder_2.newLine();
+    _builder_2.append("enum Greeting:");
+    _builder_2.newLine();
+    _builder_2.append("\t");
+    _builder_2.newLine();
+    _builder_2.append(";");
+    _builder_2.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix_1 = new AbstractQuickfixTest.Quickfix("Create enum rule \'Greeting\'", "Create enum rule \'Greeting\'", _builder_2.toString());
+    StringConcatenation _builder_3 = new StringConcatenation();
+    _builder_3.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_3.newLine();
+    _builder_3.newLine();
+    _builder_3.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder_3.newLine();
+    _builder_3.newLine();
+    _builder_3.append("Model:");
+    _builder_3.newLine();
+    _builder_3.append("\t");
+    _builder_3.append("greetings+=Greeting*;");
+    _builder_3.newLine();
+    _builder_3.newLine();
+    _builder_3.append("terminal Greeting:");
+    _builder_3.newLine();
+    _builder_3.append("\t");
+    _builder_3.newLine();
+    _builder_3.append(";");
+    _builder_3.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix_2 = new AbstractQuickfixTest.Quickfix("Create terminal \'Greeting\'", "Create terminal \'Greeting\'", _builder_3.toString());
+    StringConcatenation _builder_4 = new StringConcatenation();
+    _builder_4.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
+    _builder_4.newLine();
+    _builder_4.newLine();
+    _builder_4.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
+    _builder_4.newLine();
+    _builder_4.newLine();
+    _builder_4.append("Model:");
+    _builder_4.newLine();
+    _builder_4.append("\t");
+    _builder_4.append("greetings+=Greeting*;");
+    _builder_4.newLine();
+    _builder_4.newLine();
+    _builder_4.append("terminal fragment Greeting:");
+    _builder_4.newLine();
+    _builder_4.append("\t");
+    _builder_4.newLine();
+    _builder_4.append(";");
+    _builder_4.newLine();
+    AbstractQuickfixTest.Quickfix _quickfix_3 = new AbstractQuickfixTest.Quickfix("Create terminal fragment \'Greeting\'", "Create terminal fragment \'Greeting\'", _builder_4.toString());
+    this.testQuickfixesOn(_builder, 
+      "org.eclipse.xtext.grammar.UnresolvedRule", _quickfix, _quickfix_1, _quickfix_2, _quickfix_3);
   }
   
   @Test


### PR DESCRIPTION
- Enhanced the quick-fix to handle the case where a terminal-fragment is referenced as a hidden token in a Parser rule definition
- Added method createChangeToIssueResolution() to avoid duplicate 'Change to' quick-fix if there are multiple/different fixes for an issue
- Added quick-fix method fixUnresolvedEnumRule()
- Added unit-tests.

Signed-off-by: nbhusare <neerajbhusare@gmail.com>