### PR TITLE
[eclipse/xtext-core#1561] Remove model listener when the railroad view is closed

### DIFF
--- a/org.eclipse.xtext.xtext.ui.graph/src/org/eclipse/xtext/xtext/ui/graph/RailroadSynchronizer.java
+++ b/org.eclipse.xtext.xtext.ui.graph/src/org/eclipse/xtext/xtext/ui/graph/RailroadSynchronizer.java
@@ -54,6 +54,9 @@ public class RailroadSynchronizer implements IPartListener, IXtextModelListener 
 
 	public void stop(IWorkbenchPartSite site) {
 		site.getWorkbenchWindow().getPartService().removePartListener(this);
+		if (lastActiveDocument != null) {
+			lastActiveDocument.removeModelListener(this);
+		}
 		lastActiveDocument = null;
 	}
 


### PR DESCRIPTION
see eclipse/xtext-core#1561