### PR TITLE
[eclipse/xtext#1827] prepare oomph for Xtext 2.24 & Eclipse 2020-12

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -56,6 +56,9 @@
     <annotation
         source="http://www.eclipse.org/oomph/setup/GlobalVariable"/>
     <choice
+        value="2020-12"
+        label="Eclipse 2020-12 - 4.18"/>
+    <choice
         value="2020-09"
         label="Eclipse 2020-09 - 4.17"/>
     <choice
@@ -1186,7 +1189,40 @@
           <repository
               url="${p2.draw2d}"/>
           <repository
-              url="https://download.eclipse.org/eclipse/updates/4.17-I-builds"/>
+              url="${p2.xpand}"/>
+          <repository
+              url="${p2.buildship}"/>
+          <repository
+              url="${p2.webtools}"/>
+          <repository
+              url="${p2.lsp4j}"/>
+          <repository
+              url="${p2.cbi.analyzer}"/>
+          <repository
+              url="${p2.egit}"/>
+        </repositoryList>
+        <repositoryList
+            name="2020-12">
+          <repository
+              url="${p2.xtext}"/>
+          <repository
+              url="${p2.mwe2}"/>
+          <repository
+              url="${p2.antlr-gen}"/>
+          <repository
+              url="${p2.gef}"/>
+          <repository
+              url="${p2.m2e}/1.12"/>
+          <repository
+              url="${p2.swtbot}"/>
+          <repository
+              url="${p2.orbit}"/>
+          <repository
+              url="${p2.emf}"/>
+          <repository
+              url="${p2.draw2d}"/>
+          <repository
+              url="https://download.eclipse.org/eclipse/updates/4.18-I-builds"/>
           <repository
               url="${p2.xpand}"/>
           <repository


### PR DESCRIPTION
[eclipse/xtext#1827] prepare oomph for Xtext 2.24 & Eclipse 2020-12
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>