### PR TITLE
[releng] Update Orbit URL to https://download.eclipse.org/tools/orbit/downloads/2020-12

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -27,7 +27,7 @@
       <unit id="org.apache.commons.cli" version="1.2.0.v201404270220"/>
       <unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
       <unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201606061308"/>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
@@ -110,7 +110,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-oxygen.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-oxygen.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-photon.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-photon.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201809.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201809.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201812.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201812.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201903.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201903.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201906.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201906.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201909.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201909.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201912.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r201912.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202003.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202003.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202006.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202006.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202009.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202009.target
@@ -102,7 +102,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>


### PR DESCRIPTION
This change was brought to you by your friendly Xtext Genie.