### PR TITLE
Avoid the quickfix to create a terminal fragment where the fragment usage would be illegal

### DIFF
--- a/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.tests/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.xtend
@@ -162,18 +162,6 @@ class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
 				terminal Greeting:
 					
 				;
-			'''),
-			new Quickfix("Create terminal fragment 'Greeting'", "Create terminal fragment 'Greeting'", '''
-				grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals
-				
-				generate myDsl "http://www.xtext.org/example/mydsl/MyDsl"
-				
-				Model:
-					greetings+=Greeting*;
-				
-				terminal fragment Greeting:
-					
-				;
 			''')
 		);
 	}

--- a/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.java
+++ b/org.eclipse.xtext.xtext.ui.tests/xtend-gen/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixTest.java
@@ -246,28 +246,8 @@ public class XtextGrammarQuickfixTest extends AbstractQuickfixTest {
     _builder_3.append(";");
     _builder_3.newLine();
     AbstractQuickfixTest.Quickfix _quickfix_2 = new AbstractQuickfixTest.Quickfix("Create terminal \'Greeting\'", "Create terminal \'Greeting\'", _builder_3.toString());
-    StringConcatenation _builder_4 = new StringConcatenation();
-    _builder_4.append("grammar org.xtext.example.mydsl.MyDsl with org.eclipse.xtext.common.Terminals");
-    _builder_4.newLine();
-    _builder_4.newLine();
-    _builder_4.append("generate myDsl \"http://www.xtext.org/example/mydsl/MyDsl\"");
-    _builder_4.newLine();
-    _builder_4.newLine();
-    _builder_4.append("Model:");
-    _builder_4.newLine();
-    _builder_4.append("\t");
-    _builder_4.append("greetings+=Greeting*;");
-    _builder_4.newLine();
-    _builder_4.newLine();
-    _builder_4.append("terminal fragment Greeting:");
-    _builder_4.newLine();
-    _builder_4.append("\t");
-    _builder_4.newLine();
-    _builder_4.append(";");
-    _builder_4.newLine();
-    AbstractQuickfixTest.Quickfix _quickfix_3 = new AbstractQuickfixTest.Quickfix("Create terminal fragment \'Greeting\'", "Create terminal fragment \'Greeting\'", _builder_4.toString());
     this.testQuickfixesOn(_builder, 
-      "org.eclipse.xtext.grammar.UnresolvedRule", _quickfix, _quickfix_1, _quickfix_2, _quickfix_3);
+      "org.eclipse.xtext.grammar.UnresolvedRule", _quickfix, _quickfix_1, _quickfix_2);
   }
   
   @Test

--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProvider.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/editor/quickfix/XtextGrammarQuickfixProvider.java
@@ -171,7 +171,6 @@ public class XtextGrammarQuickfixProvider extends DefaultQuickfixProvider {
 				createNewRule(ruleName, ruleType));
 	}
 
-	@Fix(XtextLinkingDiagnosticMessageProvider.UNRESOLVED_RULE)
 	@Fix(XtextLinkingDiagnosticMessageProvider.UNRESOLVED_TERMINAL_RULE)
 	public void fixUnresolvedTerminalFragmentRule(final Issue issue, IssueResolutionAcceptor acceptor) {
 		String ruleName = issue.getData()[0];


### PR DESCRIPTION
Removed invalid terminal-fragment quick-fix proposal and the corresponding unit-test

Signed-off-by: nbhusare <neerajbhusare@gmail.com>