### PR TITLE
Process UI events before & after setup & teardown

### DIFF
--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractWorkbenchTest.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/AbstractWorkbenchTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -31,27 +31,38 @@ public abstract class AbstractWorkbenchTest extends Assert {
 
 	@Before
 	public void setUp() throws Exception {
+		waitForEventProcessing();
 		closeWelcomePage();
 		closeEditors();
 		cleanWorkspace();
 		waitForBuild();
+		waitForEventProcessing();
 	}
 	
 	@After
 	public void tearDown() throws Exception {
+		waitForEventProcessing();
 		closeEditors();
 		cleanWorkspace();
 		waitForBuild();
+		waitForEventProcessing();
 	}
-	
+
+	/**
+	 * @since 2.24
+	 */
+	protected void waitForEventProcessing() {
+		while (Display.getDefault().readAndDispatch()) {
+		}
+	}
+
 	protected void closeEditors() {
 		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
 	}
 
 	protected void closeWelcomePage() throws InterruptedException {
 		if (PlatformUI.getWorkbench().getIntroManager().getIntro() != null) {
-			PlatformUI.getWorkbench().getIntroManager().closeIntro(
-					PlatformUI.getWorkbench().getIntroManager().getIntro());
+			PlatformUI.getWorkbench().getIntroManager().closeIntro(PlatformUI.getWorkbench().getIntroManager().getIntro());
 		}
 	}
 

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractWorkbenchTest.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/AbstractWorkbenchTest.java
@@ -44,12 +44,15 @@ public abstract class AbstractWorkbenchTest extends Assert {
 	
 	@Before @BeforeEach
 	public void setUp() throws Exception {
+		waitForEventProcessing();
 		cleanWorkspace();
 		waitForBuild();
+		waitForEventProcessing();
 	}
 	
 	@After @AfterEach
 	public void tearDown() throws Exception {
+		waitForEventProcessing();
 		closeEditors();
 		cleanWorkspace();
 		waitForBuild();


### PR DESCRIPTION
Process UI events before & after setup & teardown
to avoid problems with wrong active shell in tests

Fixes #1538

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>