### PR TITLE
[#1563] Add Domainmodel Codemining test cases

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.xtend
@@ -28,6 +28,7 @@ class CodeMiningTest extends AbstractCodeMiningTest {
 				op getS() { s }
 			}
 		'''.testCodeMining('''
+			1 property | 1 operation
 			entity E {
 				s: String
 				op getS() : String { s }
@@ -42,6 +43,7 @@ class CodeMiningTest extends AbstractCodeMiningTest {
 				op getS() : String { s }
 			}
 		'''.testCodeMining('''
+			1 property | 1 operation
 			entity E {
 				s: String
 				op getS() : String { s }
@@ -49,4 +51,37 @@ class CodeMiningTest extends AbstractCodeMiningTest {
 		''')
 	}
 
+	@Test def several_entities_001() {
+		'''
+			entity E1 {
+			}
+			entity E2 {
+			}
+		'''.testCodeMining('''
+			0 properties | 0 operations
+			entity E1 {
+			}
+			0 properties | 0 operations
+			entity E2 {
+			}
+		''')
+	}
+
+	@Test def several_entities_002() {
+		'''
+			entity E1 {
+			}
+			
+			entity E2 {
+			}
+		'''.testCodeMining('''
+			0 properties | 0 operations
+			entity E1 {
+			}
+			
+			0 properties | 0 operations
+			entity E2 {
+			}
+		''')
+	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/CodeMiningTest.java
@@ -37,6 +37,8 @@ public class CodeMiningTest extends AbstractCodeMiningTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("1 property | 1 operation");
+    _builder_1.newLine();
     _builder_1.append("entity E {");
     _builder_1.newLine();
     _builder_1.append("\t");
@@ -64,6 +66,8 @@ public class CodeMiningTest extends AbstractCodeMiningTest {
     _builder.append("}");
     _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("1 property | 1 operation");
+    _builder_1.newLine();
     _builder_1.append("entity E {");
     _builder_1.newLine();
     _builder_1.append("\t");
@@ -71,6 +75,62 @@ public class CodeMiningTest extends AbstractCodeMiningTest {
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append("op getS() : String { s }");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.testCodeMining(_builder, _builder_1.toString());
+  }
+  
+  @Test
+  public void several_entities_001() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E1 {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("entity E2 {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("0 properties | 0 operations");
+    _builder_1.newLine();
+    _builder_1.append("entity E1 {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("0 properties | 0 operations");
+    _builder_1.newLine();
+    _builder_1.append("entity E2 {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.testCodeMining(_builder, _builder_1.toString());
+  }
+  
+  @Test
+  public void several_entities_002() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity E1 {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("entity E2 {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("0 properties | 0 operations");
+    _builder_1.newLine();
+    _builder_1.append("entity E1 {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("0 properties | 0 operations");
+    _builder_1.newLine();
+    _builder_1.append("entity E2 {");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/codemining/DomainmodelCodeMiningProvider.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src/org/eclipse/xtext/example/domainmodel/ui/codemining/DomainmodelCodeMiningProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -18,7 +18,9 @@ import org.eclipse.jface.text.codemining.ICodeMining;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.common.types.JvmOperation;
+import org.eclipse.xtext.example.domainmodel.domainmodel.Entity;
 import org.eclipse.xtext.example.domainmodel.domainmodel.Operation;
+import org.eclipse.xtext.example.domainmodel.domainmodel.Property;
 import org.eclipse.xtext.example.domainmodel.services.DomainmodelGrammarAccess;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.INode;
@@ -32,9 +34,10 @@ import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations;
 import com.google.inject.Inject;
 
 /**
- * Provide minings for inferred return types of operations.
+ * Provide code minings for the Domainmodel example.
  */
 public class DomainmodelCodeMiningProvider extends AbstractXtextCodeMiningProvider {
+
 	@Inject
 	private IJvmModelAssociations jvmModelAssociations;
 	@Inject
@@ -46,7 +49,24 @@ public class DomainmodelCodeMiningProvider extends AbstractXtextCodeMiningProvid
 		if (resource.getContents().isEmpty()) {
 			return;
 		}
-		// get all operations to open document
+		
+		// get all entities in the open document
+		List<Entity> allEntities = EcoreUtil2.eAllOfType(resource.getContents().get(0), Entity.class);
+		for (Entity e : allEntities) {
+			int propertiesCount = (int) e.getFeatures().stream().filter(f -> (f instanceof Property)).count();
+			String propertiesHeaderText = propertiesCount + " " + (propertiesCount == 1 ? "property" : "properties");
+			
+			int operationsCount = (int) e.getFeatures().stream().filter(f -> (f instanceof Operation)).count();
+			String operationsHeaderText = operationsCount + " operation" + (operationsCount == 1 ? "" : "s");
+			
+			ICompositeNode node = NodeModelUtils.getNode(e);
+			int beforeLineNumber = document.getLineOfOffset(node.getOffset());
+			// create two line header code minings before the entity: one for the properties, one for the operations
+			acceptor.accept(createNewLineHeaderCodeMining(beforeLineNumber, document, propertiesHeaderText));
+			acceptor.accept(createNewLineHeaderCodeMining(beforeLineNumber, document, operationsHeaderText));
+		}
+		
+		// get all operations in the open document
 		List<Operation> allOperations = EcoreUtil2.eAllOfType(resource.getContents().get(0), Operation.class);
 		// get keyword for ')'
 		Keyword rightParenthesisKeyword_4 = grammar.getOperationAccess().getRightParenthesisKeyword_4();


### PR DESCRIPTION
- Modify the DomainmodelCodeMiningProvider to display the number of
properties / operations as line header code minings before the entity
definition.
- Implement corresponding CodeMiningTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>