### PR TITLE
Bug 568152 - Use FrameworkUtil#getBundle instead of Platform#getBundle

### DIFF
--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/BeeLangTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/BeeLangTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.backtracking.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class BeeLangTestLanguageExecutableExtensionFactory extends AbstractGuice
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/ExBeeLangTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/ExBeeLangTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.backtracking.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ExBeeLangTestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/SimpleBeeLangTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/SimpleBeeLangTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.backtracking.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class SimpleBeeLangTestLanguageExecutableExtensionFactory extends Abstrac
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/fileAware/ui/FileAwareTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/fileAware/ui/FileAwareTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.fileAware.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class FileAwareTestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/nestedRefs/ui/NestedRefsTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/nestedRefs/ui/NestedRefsTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.nestedRefs.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class NestedRefsTestLanguageExecutableExtensionFactory extends AbstractGu
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/noJdt/ui/NoJdtTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/noJdt/ui/NoJdtTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.noJdt.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class NoJdtTestLanguageExecutableExtensionFactory extends AbstractGuiceAw
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/xtextgrammar/ui/XtextGrammarTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/xtextgrammar/ui/XtextGrammarTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.xtextgrammar.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class XtextGrammarTestLanguageExecutableExtensionFactory extends Abstract
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override


### PR DESCRIPTION
Regenerated test languages.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>