### PR TITLE
Bug 568152 - Use FrameworkUtil#getBundle instead of Platform#getBundle

### DIFF
--- a/org.eclipse.xtext.builder.tests/src-gen/org/eclipse/xtext/builder/tests/ui/BuilderTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.builder.tests/src-gen/org/eclipse/xtext/builder/tests/ui/BuilderTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.builder.tests.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.builder.tests.internal.TestsActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class BuilderTestLanguageExecutableExtensionFactory extends AbstractGuice
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.common.types.eclipse.tests/src-gen/org/eclipse/xtext/common/types/xtext/ui/ui/ContentAssistTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src-gen/org/eclipse/xtext/common/types/xtext/ui/ui/ContentAssistTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.common.types.xtext.ui.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.common.types.eclipse.tests.internal.TestsActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ContentAssistTestLanguageExecutableExtensionFactory extends Abstrac
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.common.types.eclipse.tests/src-gen/org/eclipse/xtext/common/types/xtext/ui/ui/RefactoringTestLanguage1ExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src-gen/org/eclipse/xtext/common/types/xtext/ui/ui/RefactoringTestLanguage1ExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.common.types.xtext.ui.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.common.types.eclipse.tests.internal.TestsActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class RefactoringTestLanguage1ExecutableExtensionFactory extends Abstract
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.common.types.eclipse.tests/src-gen/org/eclipse/xtext/common/types/xtext/ui/ui/RefactoringTestLanguage2ExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src-gen/org/eclipse/xtext/common/types/xtext/ui/ui/RefactoringTestLanguage2ExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.common.types.xtext.ui.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.common.types.eclipse.tests.internal.TestsActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class RefactoringTestLanguage2ExecutableExtensionFactory extends Abstract
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.common.types.eclipse.tests/src-gen/org/eclipse/xtext/common/types/xtext/ui/ui/RefactoringTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/src-gen/org/eclipse/xtext/common/types/xtext/ui/ui/RefactoringTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.common.types.xtext.ui.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.common.types.eclipse.tests.internal.TestsActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class RefactoringTestLanguageExecutableExtensionFactory extends AbstractG
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.purexbase.ui/src-gen/org/eclipse/xtext/purexbase/ui/PureXbaseExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.purexbase.ui/src-gen/org/eclipse/xtext/purexbase/ui/PureXbaseExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.purexbase.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.purexbase.ui.internal.PurexbaseActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class PureXbaseExecutableExtensionFactory extends AbstractGuiceAwareExecu
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(PurexbaseActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(PurexbaseActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/BeeLangTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/BeeLangTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.backtracking.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class BeeLangTestLanguageExecutableExtensionFactory extends AbstractGuice
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/ExBeeLangTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/ExBeeLangTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.backtracking.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ExBeeLangTestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/SimpleBeeLangTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/backtracking/ui/SimpleBeeLangTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.backtracking.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class SimpleBeeLangTestLanguageExecutableExtensionFactory extends Abstrac
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/fileAware/ui/FileAwareTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/fileAware/ui/FileAwareTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.fileAware.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class FileAwareTestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/nestedRefs/ui/NestedRefsTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/nestedRefs/ui/NestedRefsTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.nestedRefs.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class NestedRefsTestLanguageExecutableExtensionFactory extends AbstractGu
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/noJdt/ui/NoJdtTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/noJdt/ui/NoJdtTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.noJdt.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class NoJdtTestLanguageExecutableExtensionFactory extends AbstractGuiceAw
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/xtextgrammar/ui/XtextGrammarTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.testlanguages.ui/src-gen/org/eclipse/xtext/testlanguages/xtextgrammar/ui/XtextGrammarTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.testlanguages.xtextgrammar.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.testlanguages.ui.internal.TestlanguagesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class XtextGrammarTestLanguageExecutableExtensionFactory extends Abstract
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.codetemplates.ui/src-gen/org/eclipse/xtext/ui/codetemplates/ui/CodetemplatesExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src-gen/org/eclipse/xtext/ui/codetemplates/ui/CodetemplatesExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.codetemplates.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.codetemplates.ui.internal.CodetemplatesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class CodetemplatesExecutableExtensionFactory extends AbstractGuiceAwareE
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(CodetemplatesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(CodetemplatesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.codetemplates.ui/src-gen/org/eclipse/xtext/ui/codetemplates/ui/SingleCodetemplateExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.codetemplates.ui/src-gen/org/eclipse/xtext/ui/codetemplates/ui/SingleCodetemplateExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.codetemplates.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.codetemplates.ui.internal.CodetemplatesActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class SingleCodetemplateExecutableExtensionFactory extends AbstractGuiceA
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(CodetemplatesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(CodetemplatesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/ExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/ExecutableExtensionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,9 +8,9 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.shared.internal;
 
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 import com.google.inject.Injector;
 
@@ -18,7 +18,7 @@ public class ExecutableExtensionFactory extends AbstractGuiceAwareExecutableExte
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(Activator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(Activator.class);
 	}
 
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/bracketmatching/ui/BmTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/bracketmatching/ui/BmTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.bracketmatching.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class BmTestLanguageExecutableExtensionFactory extends AbstractGuiceAware
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/services/Bug332217TestLanguageGrammarAccess.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/services/Bug332217TestLanguageGrammarAccess.java
@@ -983,10 +983,7 @@ public class Bug332217TestLanguageGrammarAccess extends AbstractElementFinder.Ab
 		private final Keyword cSubtitleSubtitleKeyword_3_0 = (Keyword)cSubtitleEnumLiteralDeclaration_3.eContents().get(0);
 		
 		//enum CellType:
-		//	default='Default' |
-		//	value1='Value1' |
-		//	value2='Value2' |
-		//	subtitle='Subtitle';
+		//	default='Default' | value1='Value1' | value2='Value2' | subtitle='Subtitle';
 		public EnumRule getRule() { return rule; }
 		
 		//default='Default' | value1='Value1' | value2='Value2' | subtitle='Subtitle'
@@ -1362,10 +1359,7 @@ public class Bug332217TestLanguageGrammarAccess extends AbstractElementFinder.Ab
 	}
 	
 	//enum CellType:
-	//	default='Default' |
-	//	value1='Value1' |
-	//	value2='Value2' |
-	//	subtitle='Subtitle';
+	//	default='Default' | value1='Value1' | value2='Value2' | subtitle='Subtitle';
 	public CellTypeElements getCellTypeAccess() {
 		return eCellType;
 	}

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/services/ContentAssistNoTerminalExtensionTestLanguageGrammarAccess.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/services/ContentAssistNoTerminalExtensionTestLanguageGrammarAccess.java
@@ -83,9 +83,8 @@ public class ContentAssistNoTerminalExtensionTestLanguageGrammarAccess extends A
 		private final Keyword cRpromoterRpromoterKeyword_19_0 = (Keyword)cRpromoterEnumLiteralDeclaration_19.eContents().get(0);
 		
 		//enum PolygonBasedNodeShape:
-		//	octagon | oval |
-		//	parallelogram | pentagon | plain | plaintext | point | polygon | primersite | promoter | proteasesite | proteinstab |
-		//	rarrow | record | rect | rectangle | restrictionsite | ribosite | rnastab | rpromoter;
+		//	octagon | oval | parallelogram | pentagon | plain | plaintext | point | polygon | primersite | promoter | proteasesite
+		//	| proteinstab | rarrow | record | rect | rectangle | restrictionsite | ribosite | rnastab | rpromoter;
 		public EnumRule getRule() { return rule; }
 		
 		//octagon | oval | parallelogram | pentagon | plain | plaintext | point | polygon | primersite | promoter | proteasesite |
@@ -261,9 +260,8 @@ public class ContentAssistNoTerminalExtensionTestLanguageGrammarAccess extends A
 	}
 	
 	//enum PolygonBasedNodeShape:
-	//	octagon | oval |
-	//	parallelogram | pentagon | plain | plaintext | point | polygon | primersite | promoter | proteasesite | proteinstab |
-	//	rarrow | record | rect | rectangle | restrictionsite | ribosite | rnastab | rpromoter;
+	//	octagon | oval | parallelogram | pentagon | plain | plaintext | point | polygon | primersite | promoter | proteasesite
+	//	| proteinstab | rarrow | record | rect | rectangle | restrictionsite | ribosite | rnastab | rpromoter;
 	public PolygonBasedNodeShapeElements getPolygonBasedNodeShapeAccess() {
 		return ePolygonBasedNodeShape;
 	}

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/BacktrackingContentAssistTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/BacktrackingContentAssistTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class BacktrackingContentAssistTestLanguageExecutableExtensionFactory ext
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug286935TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug286935TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug286935TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug287941TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug287941TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug287941TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug288734TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug288734TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug288734TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug288760TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug288760TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug288760TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug289187TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug289187TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug289187TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug291022TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug291022TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug291022TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug303200TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug303200TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug303200TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug304681TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug304681TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug304681TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug307519TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug307519TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug307519TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug309949TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug309949TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug309949TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug332217TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug332217TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug332217TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug347012TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug347012TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug347012TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug348199TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug348199TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug348199TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug348427TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug348427TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug348427TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug360834TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug360834TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug360834TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug377311TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug377311TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug377311TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug381381TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/Bug381381TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug381381TestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ContentAssistContextTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ContentAssistContextTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ContentAssistContextTestLanguageExecutableExtensionFactory extends 
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ContentAssistCustomizingTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ContentAssistCustomizingTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ContentAssistCustomizingTestLanguageExecutableExtensionFactory exte
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ContentAssistNoTerminalExtensionTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ContentAssistNoTerminalExtensionTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ContentAssistNoTerminalExtensionTestLanguageExecutableExtensionFact
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/CrossReferenceProposalTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/CrossReferenceProposalTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class CrossReferenceProposalTestLanguageExecutableExtensionFactory extend
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/DatatypeRuleTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/DatatypeRuleTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class DatatypeRuleTestLanguageExecutableExtensionFactory extends Abstract
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/DomainModelTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/DomainModelTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class DomainModelTestLanguageExecutableExtensionFactory extends AbstractG
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/GH341TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/GH341TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class GH341TestLanguageExecutableExtensionFactory extends AbstractGuiceAw
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/LookAheadContentAssistTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/LookAheadContentAssistTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class LookAheadContentAssistTestLanguageExecutableExtensionFactory extend
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ParameterizedExpressionsTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ParameterizedExpressionsTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ParameterizedExpressionsTestLanguageExecutableExtensionFactory exte
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ParametersTestLanguageExExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ParametersTestLanguageExExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ParametersTestLanguageExExecutableExtensionFactory extends Abstract
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ParametersTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/ParametersTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ParametersTestLanguageExecutableExtensionFactory extends AbstractGu
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/TwoContextsTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/TwoContextsTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class TwoContextsTestLanguageExecutableExtensionFactory extends AbstractG
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/TwoParametersTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/TwoParametersTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class TwoParametersTestLanguageExecutableExtensionFactory extends Abstrac
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/UnorderedGroupsTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/contentassist/ui/UnorderedGroupsTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.contentassist.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class UnorderedGroupsTestLanguageExecutableExtensionFactory extends Abstr
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/encoding/ui/EncodingUiTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/encoding/ui/EncodingUiTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.encoding.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class EncodingUiTestLanguageExecutableExtensionFactory extends AbstractGu
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/outline/ui/OutlineTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/editor/outline/ui/OutlineTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.editor.outline.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class OutlineTestLanguageExecutableExtensionFactory extends AbstractGuice
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/enumrules/ui/EnumRulesUiTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/enumrules/ui/EnumRulesUiTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.enumrules.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class EnumRulesUiTestLanguageExecutableExtensionFactory extends AbstractG
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/linking/ui/ImportUriUiTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/linking/ui/ImportUriUiTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.linking.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ImportUriUiTestLanguageExecutableExtensionFactory extends AbstractG
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/parser/keywords/ui/KeywordsUiTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/parser/keywords/ui/KeywordsUiTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.parser.keywords.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class KeywordsUiTestLanguageExecutableExtensionFactory extends AbstractGu
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/quickfix/ui/QuickfixCrossrefTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/quickfix/ui/QuickfixCrossrefTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.quickfix.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class QuickfixCrossrefTestLanguageExecutableExtensionFactory extends Abst
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/refactoring/ui/RefactoringTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/refactoring/ui/RefactoringTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.refactoring.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class RefactoringTestLanguageExecutableExtensionFactory extends AbstractG
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/refactoring/ui/ReferringTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/refactoring/ui/ReferringTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.refactoring.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ReferringTestLanguageExecutableExtensionFactory extends AbstractGui
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/testlanguages/ui/ContentAssistTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/testlanguages/ui/ContentAssistTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.testlanguages.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ContentAssistTestLanguageExecutableExtensionFactory extends Abstrac
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/testlanguages/ui/ReferenceGrammarUiTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/testlanguages/ui/ReferenceGrammarUiTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.testlanguages.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ReferenceGrammarUiTestLanguageExecutableExtensionFactory extends Ab
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/ui/FoldingTestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/ui/FoldingTestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class FoldingTestLanguageExecutableExtensionFactory extends AbstractGuice
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/ui/TestLanguageExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/ui/TestLanguageExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class TestLanguageExecutableExtensionFactory extends AbstractGuiceAwareEx
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/xmleditor/ui/XmlExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.ui.tests/src-gen/org/eclipse/xtext/ui/tests/xmleditor/ui/XmlExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.ui.tests.xmleditor.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class XmlExecutableExtensionFactory extends AbstractGuiceAwareExecutableE
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xbase.testlanguages.ui/src-gen/org/eclipse/xtext/xbase/testlanguages/bug462047/ui/Bug462047LangExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xbase.testlanguages.ui/src-gen/org/eclipse/xtext/xbase/testlanguages/bug462047/ui/Bug462047LangExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.xbase.testlanguages.bug462047.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.xbase.testlanguages.ui.internal.TestlanguagesActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class Bug462047LangExecutableExtensionFactory extends AbstractGuiceAwareE
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xbase.testlanguages.ui/src-gen/org/eclipse/xtext/xbase/testlanguages/ui/ContentAssistFragmentTestLangExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xbase.testlanguages.ui/src-gen/org/eclipse/xtext/xbase/testlanguages/ui/ContentAssistFragmentTestLangExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.xbase.testlanguages.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.xbase.testlanguages.ui.internal.TestlanguagesActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class ContentAssistFragmentTestLangExecutableExtensionFactory extends Abs
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xbase.testlanguages.ui/src-gen/org/eclipse/xtext/xbase/testlanguages/ui/XImportSectionTestLangExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xbase.testlanguages.ui/src-gen/org/eclipse/xtext/xbase/testlanguages/ui/XImportSectionTestLangExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.xbase.testlanguages.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.xbase.testlanguages.ui.internal.TestlanguagesActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class XImportSectionTestLangExecutableExtensionFactory extends AbstractGu
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestlanguagesActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestlanguagesActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xbase.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.xbase.ui.tests/META-INF/MANIFEST.MF
@@ -32,3 +32,5 @@ Import-Package: org.apache.log4j;version="1.2.15",
  org.junit.runner;version="4.5.0",
  org.junit.runners;version="4.5.0"
 Automatic-Module-Name: org.eclipse.xtext.xbase.ui.tests
+Export-Package: org.eclipse.xtext.xbase.testlanguages.ui.tests;x-internal=true,
+ org.eclipse.xtext.xbase.testlanguages.bug462047.ui.tests;x-internal=true

--- a/org.eclipse.xtext.xbase.ui/src-gen/org/eclipse/xtext/xbase/annotations/ui/XbaseWithAnnotationsExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xbase.ui/src-gen/org/eclipse/xtext/xbase/annotations/ui/XbaseWithAnnotationsExecutableExtensionFactory.java
@@ -8,11 +8,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.annotations.ui;
 
-import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.xbase.ui.internal.XbaseActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import com.google.inject.Injector;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -22,7 +23,7 @@ public class XbaseWithAnnotationsExecutableExtensionFactory extends AbstractGuic
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(XbaseActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(XbaseActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xbase.ui/src-gen/org/eclipse/xtext/xbase/ui/XbaseExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xbase.ui/src-gen/org/eclipse/xtext/xbase/ui/XbaseExecutableExtensionFactory.java
@@ -8,11 +8,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.ui;
 
-import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.xbase.ui.internal.XbaseActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import com.google.inject.Injector;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -22,7 +23,7 @@ public class XbaseExecutableExtensionFactory extends AbstractGuiceAwareExecutabl
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(XbaseActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(XbaseActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xbase.ui/src-gen/org/eclipse/xtext/xbase/ui/XtypeExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xbase.ui/src-gen/org/eclipse/xtext/xbase/ui/XtypeExecutableExtensionFactory.java
@@ -8,11 +8,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.xbase.ui;
 
-import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.xbase.ui.internal.XbaseActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import com.google.inject.Injector;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -22,7 +23,7 @@ public class XtypeExecutableExtensionFactory extends AbstractGuiceAwareExecutabl
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(XbaseActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(XbaseActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src-gen/org/eclipse/xtext/example/arithmetics/ui/ArithmeticsExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src-gen/org/eclipse/xtext/example/arithmetics/ui/ArithmeticsExecutableExtensionFactory.java
@@ -9,10 +9,10 @@
 package org.eclipse.xtext.example.arithmetics.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.example.arithmetics.ui.internal.ArithmeticsActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -22,7 +22,7 @@ public class ArithmeticsExecutableExtensionFactory extends AbstractGuiceAwareExe
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(ArithmeticsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(ArithmeticsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src-gen/org/eclipse/xtext/example/domainmodel/ui/DomainmodelExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src-gen/org/eclipse/xtext/example/domainmodel/ui/DomainmodelExecutableExtensionFactory.java
@@ -9,10 +9,10 @@
 package org.eclipse.xtext.example.domainmodel.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.example.domainmodel.ui.internal.DomainmodelActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -22,7 +22,7 @@ public class DomainmodelExecutableExtensionFactory extends AbstractGuiceAwareExe
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(DomainmodelActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(DomainmodelActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src-gen/org/eclipse/xtext/example/fowlerdsl/ui/StatemachineExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/fowlerdsl/org.eclipse.xtext.example.fowlerdsl.ui/src-gen/org/eclipse/xtext/example/fowlerdsl/ui/StatemachineExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.example.fowlerdsl.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.example.fowlerdsl.ui.internal.FowlerdslActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class StatemachineExecutableExtensionFactory extends AbstractGuiceAwareEx
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(FowlerdslActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(FowlerdslActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui/src-gen/org/eclipse/xtext/example/homeautomation/ui/RuleEngineExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/homeautomation/org.eclipse.xtext.example.homeautomation.ui/src-gen/org/eclipse/xtext/example/homeautomation/ui/RuleEngineExecutableExtensionFactory.java
@@ -3,10 +3,10 @@
 package org.eclipse.xtext.example.homeautomation.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.example.homeautomation.ui.internal.HomeautomationActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -16,7 +16,7 @@ public class RuleEngineExecutableExtensionFactory extends AbstractGuiceAwareExec
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(HomeautomationActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(HomeautomationActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xtext.ui.tests/src-gen/org/eclipse/xtext/xtext/ui/ecore2xtext/ui/Ecore2XtextTestExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xtext.ui.tests/src-gen/org/eclipse/xtext/xtext/ui/ecore2xtext/ui/Ecore2XtextTestExecutableExtensionFactory.java
@@ -3,11 +3,12 @@
  */
 package org.eclipse.xtext.xtext.ui.ecore2xtext.ui;
 
-import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.xtext.ui.tests.internal.TestsActivator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import com.google.inject.Injector;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +18,7 @@ public class Ecore2XtextTestExecutableExtensionFactory extends AbstractGuiceAwar
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(TestsActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(TestsActivator.class);
 	}
 	
 	@Override

--- a/org.eclipse.xtext.xtext.ui/src-gen/org/eclipse/xtext/xtext/ui/XtextExecutableExtensionFactory.java
+++ b/org.eclipse.xtext.xtext.ui/src-gen/org/eclipse/xtext/xtext/ui/XtextExecutableExtensionFactory.java
@@ -4,10 +4,10 @@
 package org.eclipse.xtext.xtext.ui;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.eclipse.xtext.xtext.ui.internal.Activator;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -17,7 +17,7 @@ public class XtextExecutableExtensionFactory extends AbstractGuiceAwareExecutabl
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(Activator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(Activator.class);
 	}
 	
 	@Override


### PR DESCRIPTION
Regenerated languages.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>