### PR TITLE
Bug 568152 - Use FrameworkUtil#getBundle instead of Platform#getBundle

### DIFF
--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/ParallelBuildEnabledTest.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/ParallelBuildEnabledTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -11,13 +11,13 @@ package org.eclipse.xtext.builder.tests;
 import static org.junit.Assert.*;
 
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.eclipse.xtext.builder.impl.XtextBuilder;
 import org.eclipse.xtext.builder.impl.XtextBuilder.SchedulingOption;
 import org.eclipse.xtext.builder.internal.Activator;
 import org.junit.Test;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.Version;
 
 /**
@@ -27,7 +27,7 @@ public class ParallelBuildEnabledTest {
 	@Test
 	public void testIsParallelBuildEnabledInWorkspace() {
 		// preference and constant ResourcesPlugin#PREF_MAX_CONCURRENT_BUILDS only available on o.e.core.resources >= 3.13 
-		if (Platform.getBundle(ResourcesPlugin.PI_RESOURCES).getVersion().compareTo(new Version(3,13,0)) < 0) {
+		if (FrameworkUtil.getBundle(ResourcesPlugin.class).getVersion().compareTo(new Version(3,13,0)) < 0) {
 			return; // running on too old platform
 		}
 		int maxConcurrentProjectBuilds = new ScopedPreferenceStore(InstanceScope.INSTANCE, ResourcesPlugin.PI_RESOURCES).getInt("maxConcurrentBuilds");

--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/TargetPlatformUtil.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/TargetPlatformUtil.java
@@ -54,7 +54,7 @@ public class TargetPlatformUtil {
 		ITargetPlatformService tpService = TargetPlatformService.getDefault();
 		ITargetDefinition targetDef = tpService.newTarget();
 		targetDef.setName("Tycho platform");
-		Bundle[] bundles = Platform.getBundle("org.eclipse.core.runtime").getBundleContext().getBundles();
+		Bundle[] bundles = FrameworkUtil.getBundle(Platform.class).getBundleContext().getBundles();
 		List<ITargetLocation> bundleContainers = new ArrayList<ITargetLocation>();
 		Set<File> dirs = new HashSet<File>();
 		for (Bundle bundle : bundles) {

--- a/org.eclipse.xtext.logging/src/org/eclipse/xtext/logging/EclipseLogAppender.java
+++ b/org.eclipse.xtext.logging/src/org/eclipse/xtext/logging/EclipseLogAppender.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author Peter Friese - Initial contribution and API
@@ -39,7 +40,7 @@ public class EclipseLogAppender extends AppenderSkeleton {
 			if (!Platform.isRunning()) {
 				LOGGER.warn("You appear to be running outside Eclipse; you might want to remove the jar org.eclipse.xtext.logging*.jar from your classpath and supply your own log4j.properties.");
 			} else {
-				log = Platform.getLog(Platform.getBundle(LOG4J_BUNDLE_NAME));
+				log = Platform.getLog(FrameworkUtil.getBundle(Logger.class));
 			}
 			initialized = true;
 		}

--- a/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/Activator.java
+++ b/org.eclipse.xtext.ui.shared/src/org/eclipse/xtext/ui/shared/internal/Activator.java
@@ -26,11 +26,15 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.xtext.XtextRuntimeModule;
 import org.eclipse.xtext.common.types.ui.notification.TypeResourceUnloader;
+import org.eclipse.xtext.ide.DefaultIdeModule;
+import org.eclipse.xtext.ui.DefaultUiModule;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.Version;
 
 import com.google.common.collect.Lists;
@@ -108,10 +112,10 @@ public class Activator extends Plugin {
 	 * @since 2.13
 	 */
 	protected void handleGuiceInitializationError(Throwable t) throws CoreException {
-		Bundle bundleXtextRuntime = Platform.getBundle(PLUGIN_ID_XTEXT_RT);
-		Bundle bundleXtextIde = Platform.getBundle("org.eclipse.xtext.ide");
-		Bundle bundleXtextUi = Platform.getBundle(PLUGIN_ID_XTEXT_UI);
-		Bundle bundleXtextUiShared = Platform.getBundle(PLUGIN_ID);
+		Bundle bundleXtextRuntime = FrameworkUtil.getBundle(XtextRuntimeModule.class);
+		Bundle bundleXtextIde = FrameworkUtil.getBundle(DefaultIdeModule.class);
+		Bundle bundleXtextUi = FrameworkUtil.getBundle(DefaultUiModule.class);
+		Bundle bundleXtextUiShared = FrameworkUtil.getBundle(SharedModule.class);
 
 		StringBuilder msg = new StringBuilder();
 		msg.append("Xtext configuration error!\n");

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/TargetPlatformUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/TargetPlatformUtil.java
@@ -54,7 +54,7 @@ public class TargetPlatformUtil {
 		ITargetPlatformService tpService = TargetPlatformService.getDefault();
 		ITargetDefinition targetDef = tpService.newTarget();
 		targetDef.setName("Tycho platform");
-		Bundle[] bundles = Platform.getBundle("org.eclipse.core.runtime").getBundleContext().getBundles();
+		Bundle[] bundles = FrameworkUtil.getBundle(Platform.class).getBundleContext().getBundles();
 		List<ITargetLocation> bundleContainers = new ArrayList<ITargetLocation>();
 		Set<File> dirs = new HashSet<File>();
 		for (Bundle bundle : bundles) {

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/util/BundleClasspathUriResolverTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/util/BundleClasspathUriResolverTest.java
@@ -2,11 +2,13 @@ package org.eclipse.xtext.ui.tests.core.util;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.xtext.resource.IClasspathUriResolver;
 import org.eclipse.xtext.ui.tests.internal.TestsActivator;
 import org.eclipse.xtext.ui.util.BundleClasspathUriResolver;
 import org.junit.Before;
 import org.junit.Test;
+import org.osgi.framework.FrameworkUtil;
 
 public class BundleClasspathUriResolverTest extends AbstractClasspathUriResolverTest {
 
@@ -36,13 +38,13 @@ public class BundleClasspathUriResolverTest extends AbstractClasspathUriResolver
 
 	@Test public void testClasspathUriForEcore() {
 		URI classpathUri = URI.createURI("classpath:/model/Ecore.ecore");
-		URI normalizedUri = _resolver.resolve(Platform.getBundle("org.eclipse.emf.ecore"), classpathUri);
+		URI normalizedUri = _resolver.resolve(FrameworkUtil.getBundle(EPackage.class), classpathUri);
 		assertResourceLoadable(classpathUri, normalizedUri, null);
 	}
 
 	@Test public void testClasspathUriForEcoreWithFragment() {
 		URI classpathUri = URI.createURI("classpath:/model/Ecore.ecore#/");
-		URI normalizedUri = _resolver.resolve(Platform.getBundle("org.eclipse.emf.ecore"), classpathUri);
+		URI normalizedUri = _resolver.resolve(FrameworkUtil.getBundle(EPackage.class), classpathUri);
 		assertEquals("/", normalizedUri.fragment());
 		assertResourceLoadable(classpathUri, normalizedUri, null);
 	}


### PR DESCRIPTION
Refactor usages where a class can be referenced for the requested
bundle.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>