### PR TITLE
[eclipse/xtext#1885] update latest tp to 4.19-I-builds

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -1272,7 +1272,7 @@
           <repository
               url="${p2.draw2d}"/>
           <repository
-              url="https://download.eclipse.org/eclipse/updates/4.18-I-builds"/>
+              url="https://download.eclipse.org/eclipse/updates/4.19-I-builds"/>
           <repository
               url="${p2.xpand}"/>
           <repository

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
@@ -68,7 +68,7 @@
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.api.tools.ee.feature.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/eclipse/updates/4.18-I-builds"/>
+		<repository location="https://download.eclipse.org/eclipse/updates/4.19-I-builds"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1885] update latest tp to 4.19-I-builds
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>

DO NOT merge (yet) as 4.19-I-builds is not available yet