### PR TITLE
[#1505] Improve AbstractMultiQuickfixTest separator.

### DIFF
--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/AnnotatedTextToString.java
@@ -11,7 +11,6 @@ package org.eclipse.xtext.ui.testing.util;
 import java.io.IOException;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
@@ -155,14 +154,12 @@ public class AnnotatedTextToString {
 		}
 
 		result.append(contents.substring(lastOffset, contents.length()));
-		String[] resultsArray = result.toString().replace("\t", "    ").split("\r?\n");
-		int maxLineLength = Arrays.stream(resultsArray).map(r -> r.length()).reduce(Integer::max).get();
 
 		if (!result.substring(result.length() - 1, result.length()).equals("\n")) {
 			result.append("\n");
 		}
 
-		result.append(Strings.repeat("-", maxLineLength));
+		result.append(Strings.repeat("-", 5));
 
 		if (sorted.isEmpty()) {
 			for (String message : emptyMessages) {

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.xtend
@@ -39,7 +39,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 			Foo { ref Bor }
 			<1<"bad doc">1>
 			Bor { }
-			---------------
+			-----
 			0: message=multiFixableIssue2
 			1: message=multiFixableIssue2
 		''')
@@ -50,7 +50,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 			Foo { ref Bor }
 			"not bad doc"
 			Bor { }
-			---------------
+			-----
 			(no markers found)
 		''')
 	}
@@ -69,7 +69,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 			Foo { ref Bor }
 			<1<"bad doc">1>
 			Bor { }
-			---------------
+			-----
 			0: message=multiFixableIssue2
 			1: message=multiFixableIssue2
 		''')
@@ -80,7 +80,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 			Foo { ref Bor }
 			<0<"bad doc">0>
 			Bor { }
-			---------------
+			-----
 			0: message=multiFixableIssue2
 		''')
 	}
@@ -117,7 +117,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 			<0<c>0> {	badname { foo {} } }
 			<1<a>1> {	badname { bar {} } }
 			<2<b>2> {	badname { baz {} } }
-			---------------------------------
+			-----
 			0: message=badNameInSubelements
 			1: message=badNameInSubelements
 			2: message=badNameInSubelements
@@ -128,7 +128,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 			newElement { } c {	goodname { foo {} } }
 			newElement { } a {	goodname { bar {} } }
 			newElement { } b {	goodname { baz {} } }
-			-------------------------------------------
+			-----
 			(no markers found)
 		''')
 	}
@@ -143,7 +143,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 		assertContentsAndMarkers(resource, markers, '''
 			<0<c>0> {	badname { foo {} } }
 			<1<a>1> {	badname { bar {} } }
-			---------------------------------
+			-----
 			0: message=badNameInSubelements
 			1: message=badNameInSubelements
 		''')
@@ -152,7 +152,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 		assertContentsAndMarkers(resource, '''
 			newElement { } c {	goodname { foo {} } }
 			<0<a>0> {	badname { bar {} } }
-			-------------------------------------------
+			-----
 			0: message=badNameInSubelements
 		''')
 	}
@@ -211,7 +211,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 			<3<lowercase_d>3> {}
 			<4<lowercase_e>4> {}
 			<5<lowercase_f>5> {}
-			--------------------
+			-----
 			0: message=lowercase
 			1: message=lowercase
 			2: message=lowercase
@@ -229,7 +229,7 @@ class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
 			LOWERCASE_D_LOWERCASE_D {}
 			LOWERCASE_E_LOWERCASE_E {}
 			LOWERCASE_F_LOWERCASE_F {}
-			--------------------------
+			-----
 			(no markers found)
 		''')
 	}

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.xtend
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.xtend
@@ -35,7 +35,7 @@ class MultiQuickFixTest extends AbstractMultiQuickfixTest {
 			<0<"no doc">0>
 			Foo { ref Bor }
 			<1<"no doc">1> Bor { }
-			----------------------
+			-----
 			0: message=multiFixableIssue
 			1: message=multiFixableIssue
 		''')
@@ -45,7 +45,7 @@ class MultiQuickFixTest extends AbstractMultiQuickfixTest {
 			"Better documentation"
 			Foo { ref Bor }
 			"Better documentation" Bor { }
-			------------------------------
+			-----
 			(no markers found)
 		''')
 	}
@@ -62,7 +62,7 @@ class MultiQuickFixTest extends AbstractMultiQuickfixTest {
 			<0<"no doc">0>
 			Foo { ref Bor }
 			<1<"no doc">1> Bor { }
-			----------------------
+			-----
 			0: message=multiFixableIssue
 			1: message=multiFixableIssue
 		''')
@@ -72,7 +72,7 @@ class MultiQuickFixTest extends AbstractMultiQuickfixTest {
 			"Better documentation"
 			Foo { ref Bor }
 			<0<"no doc">0> Bor { }
-			----------------------
+			-----
 			0: message=multiFixableIssue
 		''')
 	}

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/CompositeQuickfixTest.java
@@ -59,7 +59,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_1.newLine();
     _builder_1.append("Bor { }");
     _builder_1.newLine();
-    _builder_1.append("---------------");
+    _builder_1.append("-----");
     _builder_1.newLine();
     _builder_1.append("0: message=multiFixableIssue2");
     _builder_1.newLine();
@@ -76,7 +76,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_2.newLine();
     _builder_2.append("Bor { }");
     _builder_2.newLine();
-    _builder_2.append("---------------");
+    _builder_2.append("-----");
     _builder_2.newLine();
     _builder_2.append("(no markers found)");
     _builder_2.newLine();
@@ -105,7 +105,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_1.newLine();
     _builder_1.append("Bor { }");
     _builder_1.newLine();
-    _builder_1.append("---------------");
+    _builder_1.append("-----");
     _builder_1.newLine();
     _builder_1.append("0: message=multiFixableIssue2");
     _builder_1.newLine();
@@ -131,7 +131,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_2.newLine();
     _builder_2.append("Bor { }");
     _builder_2.newLine();
-    _builder_2.append("---------------");
+    _builder_2.append("-----");
     _builder_2.newLine();
     _builder_2.append("0: message=multiFixableIssue2");
     _builder_2.newLine();
@@ -189,7 +189,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_1.newLine();
     _builder_1.append("<2<b>2> {\tbadname { baz {} } }");
     _builder_1.newLine();
-    _builder_1.append("---------------------------------");
+    _builder_1.append("-----");
     _builder_1.newLine();
     _builder_1.append("0: message=badNameInSubelements");
     _builder_1.newLine();
@@ -206,7 +206,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_2.newLine();
     _builder_2.append("newElement { } b {\tgoodname { baz {} } }");
     _builder_2.newLine();
-    _builder_2.append("-------------------------------------------");
+    _builder_2.append("-----");
     _builder_2.newLine();
     _builder_2.append("(no markers found)");
     _builder_2.newLine();
@@ -227,7 +227,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_1.newLine();
     _builder_1.append("<1<a>1> {\tbadname { bar {} } }");
     _builder_1.newLine();
-    _builder_1.append("---------------------------------");
+    _builder_1.append("-----");
     _builder_1.newLine();
     _builder_1.append("0: message=badNameInSubelements");
     _builder_1.newLine();
@@ -249,7 +249,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_2.newLine();
     _builder_2.append("<0<a>0> {\tbadname { bar {} } }");
     _builder_2.newLine();
-    _builder_2.append("-------------------------------------------");
+    _builder_2.append("-----");
     _builder_2.newLine();
     _builder_2.append("0: message=badNameInSubelements");
     _builder_2.newLine();
@@ -338,7 +338,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_1.newLine();
     _builder_1.append("<5<lowercase_f>5> {}");
     _builder_1.newLine();
-    _builder_1.append("--------------------");
+    _builder_1.append("-----");
     _builder_1.newLine();
     _builder_1.append("0: message=lowercase");
     _builder_1.newLine();
@@ -368,7 +368,7 @@ public class CompositeQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_2.newLine();
     _builder_2.append("LOWERCASE_F_LOWERCASE_F {}");
     _builder_2.newLine();
-    _builder_2.append("--------------------------");
+    _builder_2.append("-----");
     _builder_2.newLine();
     _builder_2.append("(no markers found)");
     _builder_2.newLine();

--- a/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.java
+++ b/org.eclipse.xtext.ui.tests/xtend-gen/org/eclipse/xtext/ui/tests/editor/quickfix/MultiQuickFixTest.java
@@ -52,7 +52,7 @@ public class MultiQuickFixTest extends AbstractMultiQuickfixTest {
     _builder_1.newLine();
     _builder_1.append("<1<\"no doc\">1> Bor { }");
     _builder_1.newLine();
-    _builder_1.append("----------------------");
+    _builder_1.append("-----");
     _builder_1.newLine();
     _builder_1.append("0: message=multiFixableIssue");
     _builder_1.newLine();
@@ -67,7 +67,7 @@ public class MultiQuickFixTest extends AbstractMultiQuickfixTest {
     _builder_2.newLine();
     _builder_2.append("\"Better documentation\" Bor { }");
     _builder_2.newLine();
-    _builder_2.append("------------------------------");
+    _builder_2.append("-----");
     _builder_2.newLine();
     _builder_2.append("(no markers found)");
     _builder_2.newLine();
@@ -92,7 +92,7 @@ public class MultiQuickFixTest extends AbstractMultiQuickfixTest {
     _builder_1.newLine();
     _builder_1.append("<1<\"no doc\">1> Bor { }");
     _builder_1.newLine();
-    _builder_1.append("----------------------");
+    _builder_1.append("-----");
     _builder_1.newLine();
     _builder_1.append("0: message=multiFixableIssue");
     _builder_1.newLine();
@@ -116,7 +116,7 @@ public class MultiQuickFixTest extends AbstractMultiQuickfixTest {
     _builder_2.newLine();
     _builder_2.append("<0<\"no doc\">0> Bor { }");
     _builder_2.newLine();
-    _builder_2.append("----------------------");
+    _builder_2.append("-----");
     _builder_2.newLine();
     _builder_2.append("0: message=multiFixableIssue");
     _builder_2.newLine();


### PR DESCRIPTION
- Use fix number (5) of the - character as separator instead of
dynamically calculate it to match the same length as the longest line.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>