### PR TITLE
Fix wrong variable passing

### DIFF
--- a/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/refactoring/XbaseReferenceUpdater.java
+++ b/org.eclipse.xtext.xbase.ui/src/org/eclipse/xtext/xbase/ui/refactoring/XbaseReferenceUpdater.java
@@ -109,7 +109,7 @@ public class XbaseReferenceUpdater extends JvmModelReferenceUpdater {
 				JvmDeclaredType type = (JvmDeclaredType) newTargetElement;
 
 				ImportAwareUpdateAcceptor importAwareUpdateAcceptor = (ImportAwareUpdateAcceptor) updateAcceptor;
-				importAwareUpdateAcceptor.removeImport(type, isStatic, isExtension, memberName);
+				importAwareUpdateAcceptor.removeImport(importedType, isStatic, isExtension, memberName);
 				importAwareUpdateAcceptor.acceptImport(type, isStatic, isExtension, memberName);
 				return;
 			}


### PR DESCRIPTION
The reference update of ImportDeclaration passed the same variable for removeImport and acceptImport. The remove should be the importedType.