### PR TITLE
[eclipse/xtext#1652] update to lsp4j 0.11.0 

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -149,7 +149,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="p2.lsp4j"
-      value="https://download.eclipse.org/lsp4j/updates/releases/0.10.0"/>
+      value="https://download.eclipse.org/lsp4j/updates/releases/0.11.0"/>
   <setupTask
       xsi:type="setup:VariableTask"
       type="URI"


### PR DESCRIPTION
[eclipse/xtext#1652] update to lsp4j 0.11.0 

requires https://github.com/eclipse/xtext-eclipse/pull/1658