### PR TITLE
make SourceAttachmentPackageFragmentRootWalker accessible from Storage2UriMapperJavaImpl subclasses

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/SourceAttachmentPackageFragmentRootWalker.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/SourceAttachmentPackageFragmentRootWalker.java
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2012,2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package org.eclipse.xtext.ui.resource;
 
 import java.io.File;
@@ -31,7 +39,7 @@ import com.google.common.collect.Sets;
 /**
  * @since 2.4
  */
-abstract class SourceAttachmentPackageFragmentRootWalker<T> extends PackageFragmentRootWalker<T> {
+public abstract class SourceAttachmentPackageFragmentRootWalker<T> extends PackageFragmentRootWalker<T> {
 
 	private final static Logger LOG = Logger.getLogger(SourceAttachmentPackageFragmentRootWalker.class);
 


### PR DESCRIPTION
make SourceAttachmentPackageFragmentRootWalker accessible from Storage2UriMapperJavaImpl subclasses

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>