### PR TITLE
expose org.eclipse.xtext.ui.wizard.template as API

### DIFF
--- a/org.eclipse.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.ui/META-INF/MANIFEST.MF
@@ -146,7 +146,7 @@ Export-Package: org.eclipse.xtext.common.ui.contentassist,
  org.eclipse.xtext.ui.validation,
  org.eclipse.xtext.ui.views,
  org.eclipse.xtext.ui.wizard,
- org.eclipse.xtext.ui.wizard.template;x-friends:="org.eclipse.xtext.example.fowlerdsl.ui",
+ org.eclipse.xtext.ui.wizard.template,
  org.eclipse.xtext.ui.workspace;
   x-friends:="org.eclipse.xtext.ui.tests,
    org.eclipse.xtext.xbase.ui,

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/AbstractFileTemplate.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/AbstractFileTemplate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -7,8 +7,6 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package org.eclipse.xtext.ui.wizard.template;
-
-import com.google.common.annotations.Beta;
 
 /**
  * A template definition for a file, used by the new file wizard. Defines the UI (label, description, icon, variables) on how to present the
@@ -19,7 +17,6 @@ import com.google.common.annotations.Beta;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public abstract class AbstractFileTemplate extends AbstractTemplate {
 
 	private TemplateFileInfo info;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/AbstractProjectTemplate.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/AbstractProjectTemplate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -12,8 +12,6 @@ import org.eclipse.xtext.ui.util.ProjectFactory;
 import org.eclipse.xtext.ui.util.TextFileContributor;
 import org.eclipse.xtext.ui.wizard.IExtendedProjectInfo;
 
-import com.google.common.annotations.Beta;
-
 /**
  * A template definition for a project, used by the new project wizard. Defines the UI (label, description, icon, variables) on how to
  * present the template to the user. The {@link TemplateVariable}'s can be used to configure the {@link ProjectFactory}'s added inside
@@ -24,7 +22,6 @@ import com.google.common.annotations.Beta;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public abstract class AbstractProjectTemplate extends AbstractTemplate {
 
 	private IExtendedProjectInfo projectInfo;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/AbstractTemplate.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/AbstractTemplate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -18,8 +18,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.xtext.xbase.lib.Pair;
 
-import com.google.common.annotations.Beta;
-
 /**
  * A template definition used by the new wizards. Defines the UI (label, description, icon, variables) on how to present the template to the
  * user.
@@ -27,7 +25,6 @@ import com.google.common.annotations.Beta;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public abstract class AbstractTemplate {
 
 	private static final Logger logger = Logger.getLogger(AbstractTemplate.class);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/DefaultTemplateProjectCreator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/DefaultTemplateProjectCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -25,15 +25,12 @@ import org.eclipse.xtext.ui.util.ProjectFactory;
 import org.eclipse.xtext.ui.wizard.IProjectCreator;
 import org.eclipse.xtext.ui.wizard.IProjectInfo;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Project creator that creates all projects as configured through a selected template.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class DefaultTemplateProjectCreator extends WorkspaceModifyOperation implements IProjectCreator, IProjectGenerator {
 
 	private IProjectInfo projectInfo;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/FileTemplate.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/FileTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2020 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,8 +15,6 @@ import java.lang.annotation.Target;
 
 import org.eclipse.xtend.lib.macro.Active;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Annotation to define a file templates that is used in the new file wizard and declared in a language specific FileTemplateProvider.
  * 
@@ -26,7 +24,6 @@ import com.google.common.annotations.Beta;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Active(FileTemplateProcessor.class)
-@Beta
 public @interface FileTemplate {
 	/**
 	 * Label of the file template presented to the user in the list of templates. The label is written to a file "messages.properties" and

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/FileTemplateProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/FileTemplateProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2020 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,8 +13,6 @@ import org.eclipse.xtend.lib.macro.TransformationContext;
 import org.eclipse.xtend.lib.macro.declaration.ClassDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration;
 import org.eclipse.xtext.xbase.lib.Extension;
-
-import com.google.common.annotations.Beta;
 
 /**
  * Generate some code to simplify implementation of project templates.
@@ -31,7 +29,6 @@ import com.google.common.annotations.Beta;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class FileTemplateProcessor extends TemplateProcessor {
 	@Override
 	public void doTransform(MutableClassDeclaration annotatedClass, @Extension TransformationContext context) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IFileGenerator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IFileGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,15 +8,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.wizard.template;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Instances will be handled to {@link AbstractFileTemplate#generateFiles(IFileGenerator)} to collect the files the wizard will create.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public interface IFileGenerator {
 
 	/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IFileTemplateProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IFileTemplateProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,15 +8,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.wizard.template;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Provide the templates to be shown in the new file wizard.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public interface IFileTemplateProvider {
 
 	/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IParameterPage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IParameterPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,15 +10,12 @@ package org.eclipse.xtext.ui.wizard.template;
 
 import org.eclipse.core.runtime.IStatus;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Interface to avoid passing concrete implementation of parameter page to {@link TemplateVariable}.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public interface IParameterPage {
 
 	/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IProjectGenerator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IProjectGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -11,15 +11,12 @@ package org.eclipse.xtext.ui.wizard.template;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.xtext.ui.util.ProjectFactory;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Generate {@link IProject}'s by providing {@link ProjectFactory} instances.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public interface IProjectGenerator {
 
 	/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IProjectTemplateProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/IProjectTemplateProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,15 +8,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.wizard.template;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Provide the templates to be shown in the new project wizard.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public interface IProjectTemplateProvider {
 
 	/**

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/NewFileWizardPrimaryPage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/NewFileWizardPrimaryPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -41,8 +41,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.dialogs.ContainerSelectionDialog;
 
-import com.google.common.annotations.Beta;
-
 /**
  * The first page shown in the {@link TemplateNewFileWizard}. Allows selection of a path, a name and optionally of any parameters provided
  * by a template. In case multiple templates are available a combo box is shown to select the template. In that case the configuration of
@@ -51,7 +49,6 @@ import com.google.common.annotations.Beta;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class NewFileWizardPrimaryPage extends WizardPage implements IParameterPage {
 
 	private final AbstractFileTemplate[] templates;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/NewProjectWizardTemplateSelectionPage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/NewProjectWizardTemplateSelectionPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -34,8 +34,6 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.forms.widgets.FormText;
 import org.eclipse.xtext.xbase.lib.Pair;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Page of the new project wizard to present a list of templates to the user. The user can select a template and press finish. If the
  * template is configurable the variables can be configured in the following page, the {@link TemplateParameterPage}.
@@ -43,7 +41,6 @@ import com.google.common.annotations.Beta;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class NewProjectWizardTemplateSelectionPage extends WizardPage {
 
 	private static final String PROJECT_TEMPLATE_PROVIDER_EXTENSION_POINT_ID = "org.eclipse.xtext.ui.projectTemplate"; //$NON-NLS-1$

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/ParameterComposite.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/ParameterComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -16,15 +16,12 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Composite to be used inside a wizard to select the parameters for a template. These might be parameters for a project or a file template.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class ParameterComposite extends Composite {
 
 	private final AbstractTemplate template;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/ProjectTemplate.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/ProjectTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2020 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,8 +15,6 @@ import java.lang.annotation.Target;
 
 import org.eclipse.xtend.lib.macro.Active;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Annotation to define a project template that is selected by the user in the new project wizard and declared in a language specific
  * ProjectTemplateProvider.
@@ -27,7 +25,6 @@ import com.google.common.annotations.Beta;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Active(ProjectTemplateProcessor.class)
-@Beta
 public @interface ProjectTemplate {
 	/**
 	 * Label of the project template presented to the user in the list of templates. The label is written to a file "messages.properties"

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/ProjectTemplateProcessor.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/ProjectTemplateProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2020 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,7 +8,6 @@
  */
 package org.eclipse.xtext.ui.wizard.template;
 
-import com.google.common.annotations.Beta;
 import org.eclipse.xtend.lib.macro.CodeGenerationContext;
 import org.eclipse.xtend.lib.macro.TransformationContext;
 import org.eclipse.xtend.lib.macro.declaration.ClassDeclaration;
@@ -30,7 +29,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class ProjectTemplateProcessor extends TemplateProcessor {
 	@Override
 	public void doTransform(MutableClassDeclaration annotatedClass, @Extension TransformationContext context) {

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateFileInfo.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateFileInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,15 +8,12 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.wizard.template;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Information about the file to create.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class TemplateFileInfo {
 	private final String folder;
 	private final String name;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateLabelProvider.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,15 +10,12 @@ package org.eclipse.xtext.ui.wizard.template;
 
 import org.eclipse.xtext.ui.label.AbstractLabelProvider;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Simple label provider used by the new wizards in the template selection page.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class TemplateLabelProvider extends AbstractLabelProvider {
 
 	@Override

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateNewFileWizard.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateNewFileWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -29,7 +29,6 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.xtext.IGrammarAccess;
 import org.eclipse.xtext.ui.util.FileOpener;
 
-import com.google.common.annotations.Beta;
 import com.google.inject.Inject;
 
 /**
@@ -38,7 +37,6 @@ import com.google.inject.Inject;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class TemplateNewFileWizard extends Wizard implements INewWizard {
 
 	private static final String FILE_TEMPLATE_PROVIDER_EXTENSION_POINT_ID = "org.eclipse.xtext.ui.fileTemplate"; //$NON-NLS-1$

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateNewProjectWizard.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateNewProjectWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -28,7 +28,6 @@ import org.eclipse.xtext.ui.wizard.IExtendedProjectInfo;
 import org.eclipse.xtext.ui.wizard.IProjectCreator;
 import org.eclipse.xtext.ui.wizard.IProjectInfo;
 
-import com.google.common.annotations.Beta;
 import com.google.inject.Inject;
 
 /**
@@ -37,7 +36,6 @@ import com.google.inject.Inject;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class TemplateNewProjectWizard extends Wizard implements INewWizard {
 
 	private static final Logger logger = Logger.getLogger(TemplateNewProjectWizard.class);

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateParameterPage.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateParameterPage.java
@@ -15,8 +15,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Page in the new project wizard to display a list with project templates. User get some description text and can select a template. In a
  * later page he can eventually configure the project template further.
@@ -24,7 +22,6 @@ import com.google.common.annotations.Beta;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class TemplateParameterPage extends WizardPage implements IParameterPage {
 
 	private final AbstractTemplate template;

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateProcessor.xtend
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateProcessor.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,7 +8,6 @@
  *******************************************************************************/
 package org.eclipse.xtext.ui.wizard.template
 
-import com.google.common.annotations.Beta
 import java.util.HashMap
 import java.util.List
 import java.util.Map
@@ -32,7 +31,6 @@ import org.eclipse.xtend.lib.macro.file.Path
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 abstract class TemplateProcessor extends AbstractClassProcessor {
 
 	// the annotation processors run in parallel but write the same file ... we synchronize to avoid race conditions 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateProjectInfo.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateProjectInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,15 +10,12 @@ package org.eclipse.xtext.ui.wizard.template;
 
 import org.eclipse.xtext.ui.wizard.DefaultProjectInfo;
 
-import com.google.common.annotations.Beta;
-
 /**
  * IProjectInfo extended with a ProjectTemplate to be used by IProjectCreator to create a concreate project.
  * 
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public class TemplateProjectInfo extends DefaultProjectInfo {
 	private final AbstractProjectTemplate projectTemplate;
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateVariable.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/TemplateVariable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, 2020 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2017, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -11,8 +11,6 @@ package org.eclipse.xtext.ui.wizard.template;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Part of a template the variable defines the UI for the user to configure the generated files. A variable will be associated with a widget
  * to represent it inside the UI.
@@ -20,7 +18,6 @@ import com.google.common.annotations.Beta;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 public abstract class TemplateVariable {
 	private final String label;
 

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/WorkspaceFileGenerator.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/wizard/template/WorkspaceFileGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -27,8 +27,6 @@ import org.eclipse.ui.actions.WorkspaceModifyOperation;
 import org.eclipse.xtext.ui.internal.Activator;
 import org.eclipse.xtext.util.StringInputStream;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Implementation of {@link IFileGenerator} to create the files from the template inside the eclipse workspace.
  * 
@@ -36,7 +34,6 @@ import com.google.common.annotations.Beta;
  * @author Hannes Niederhausen - encoding fix in execute method
  * @since 2.14
  */
-@Beta
 public class WorkspaceFileGenerator extends WorkspaceModifyOperation implements IFileGenerator {
 
 	private final SortedMap<String, CharSequence> files = new TreeMap<>();

--- a/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/TemplateProcessor.java
+++ b/org.eclipse.xtext.ui/xtend-gen/org/eclipse/xtext/ui/wizard/template/TemplateProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2020 itemis AG (http://www.itemis.de) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.de) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,7 +8,6 @@
  */
 package org.eclipse.xtext.ui.wizard.template;
 
-import com.google.common.annotations.Beta;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,6 @@ import org.eclipse.xtext.xbase.lib.Extension;
  * @author Arne Deutsch - Initial contribution and API
  * @since 2.14
  */
-@Beta
 @SuppressWarnings("all")
 public abstract class TemplateProcessor extends AbstractClassProcessor {
   private static final Object LOCK = TemplateProcessor.class;


### PR DESCRIPTION
expose org.eclipse.xtext.ui.wizard.template as API
Fixes eclipse/xtext#1962

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>