### PR TITLE
Make sure the auto build is triggered after a force kill

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/BuilderStateDiscarder.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/BuilderStateDiscarder.java
@@ -43,17 +43,25 @@ public class BuilderStateDiscarder {
 				XtextBuilder builder = BuildManagerAccess.findBuilder(project);
 				if (builder != null) {
 					builder.forgetLastBuiltState();
-					try {
-						// Touch the project such that the auto-build knows it should be rebuild
-						project.touch(null);
-					} catch (CoreException e) {
-						logger.error("Failed to refresh project while forgetting its builder state", e);
-					}
+					touchProject(project);
 				}
 			}
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Touch a given project such that the auto-build knows it should be rebuild.
+	 *
+	 * @since 2.26
+	 */
+	protected void touchProject(IProject project) {
+		try {
+			project.touch(null);
+		} catch (CoreException e) {
+			logger.error("Failed to refresh project while forgetting its builder state", e);
+		}
 	}
 
 	protected boolean canHandleBuildFlag(Map<String, String> builderArguments) {

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/BuilderStateDiscarder.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/BuilderStateDiscarder.java
@@ -10,8 +10,10 @@ package org.eclipse.xtext.builder.impl;
 
 import java.util.Map;
 
+import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.CoreException;
 
 import com.google.common.annotations.Beta;
 
@@ -29,6 +31,8 @@ import com.google.common.annotations.Beta;
 @Beta
 public class BuilderStateDiscarder {
 
+	private static final Logger logger = Logger.getLogger(BuilderStateDiscarder.class);
+
 	/**
 	 * Returns true, if the given builderArguments indicate that we should discard the built state
 	 * for the given projects.
@@ -39,6 +43,12 @@ public class BuilderStateDiscarder {
 				XtextBuilder builder = BuildManagerAccess.findBuilder(project);
 				if (builder != null) {
 					builder.forgetLastBuiltState();
+					try {
+						// Touch the project such that the auto-build knows it should be rebuild
+						project.touch(null);
+					} catch (CoreException e) {
+						logger.error("Failed to refresh project while forgetting its builder state", e);
+					}
 				}
 			}
 			return true;


### PR DESCRIPTION
When an Xtext application is force killed, the Xtext will not have been
written (as it's written on shutdown). The applications thus forgets
the last built state during the next startup. The idea is that
the auto-builder will then pick up that the projects need to be rebuild.

However, for the latter we need to first touch the relevant projects.