### PR TITLE
[eclipse/xtext-xtend#1198] adapt message for KeepLocalHistory with hint on new global flag

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/preferences/messages.properties
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/preferences/messages.properties
@@ -17,6 +17,6 @@ OutputConfigurationPage_Directory=Directory:
 OutputConfigurationPage_IgnoreSourceFolder=Ignore?
 OutputConfigurationPage_OutputDirectory=Output directory
 OutputConfigurationPage_OverrideExistingResources=Overwrite existing files
-OutputConfigurationPage_KeepLocalHistory=Keep local history for generated files
+OutputConfigurationPage_KeepLocalHistory=Keep local history for generated files. Please note: From Eclipse 2021-06\nthis preference is overruled by the global "History for derived files" preference.
 OutputConfigurationPage_SourceFolder=Source folder
 OutputConfigurationPage_UseOutputPerSourceFolder=Allow output directory per source folder


### PR DESCRIPTION
[eclipse/xtext-xtend#1198] adapt message for KeepLocalHistory with hint on new global flag

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>