### PR TITLE
Make sure all images are disposed

### DIFF
--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/PluginImageHelper.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/PluginImageHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -109,9 +109,9 @@ public class PluginImageHelper implements IImageHelper, IImageDescriptorHelper, 
 
 	@Override
 	public Image getImage(String imageName) {
-		final ImageDescriptor descriptor = findImage(imageName);
+		ImageDescriptor descriptor = findImage(imageName);
 		if (descriptor != null) {
-			return descriptor.createImage();
+			return getImage(descriptor);
 		}
 		String imgname = imageName == null ? defaultImage : imageName;
 		if (imgname != null) {


### PR DESCRIPTION
When an image descriptor can be found through its name, it's not always registered for disposal. It should be.