### PR TITLE
use 'unsuccessful' to catch all failure cases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
         }
       }
     }
-    failure {
+    unsuccessful {
       archiveArtifacts artifacts: '**/target/work/data/.metadata/.log, **/hs_err_pid*.log'
     }
     cleanup {


### PR DESCRIPTION
use 'unsuccessful' to catch all failure cases

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>