### PR TITLE
[eclipse/xtext-extras#695] fix jvm element removal in inferrer

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HoverTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/src/org/eclipse/xtext/example/domainmodel/ui/tests/HoverTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -98,5 +98,16 @@ class HoverTest extends AbstractHoverTest {
 				}
 			}
 		'''.hasHoverOver("getB", '''getB() : String''')
+	}
+
+	@Test def hover_over_operation2() {
+		'''
+			entity Foo {
+				b : String
+				op : setB(String b) : void {
+					this.b = b
+				}
+			}
+		'''.hasHoverOver("setB", '''setB(String b) : void''')
 	}
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HoverTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/ui/tests/HoverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -162,5 +162,29 @@ public class HoverTest extends AbstractHoverTest {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("getB() : String");
     this.hasHoverOver(_builder, "getB", _builder_1.toString());
+  }
+  
+  @Test
+  public void hover_over_operation2() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("entity Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("b : String");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("op : setB(String b) : void {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("this.b = b");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("setB(String b) : void");
+    this.hasHoverOver(_builder, "setB", _builder_1.toString());
   }
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/jvmmodel/DomainmodelJvmModelInferrer.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel/xtend-gen/org/eclipse/xtext/example/domainmodel/jvmmodel/DomainmodelJvmModelInferrer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2011, 2019 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -32,6 +32,7 @@ import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.xbase.jvmmodel.AbstractModelInferrer;
 import org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor;
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations;
+import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociator;
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -55,6 +56,10 @@ public class DomainmodelJvmModelInferrer extends AbstractModelInferrer {
   @Inject
   @Extension
   private IJvmModelAssociations _iJvmModelAssociations;
+  
+  @Inject
+  @Extension
+  private IJvmModelAssociator _iJvmModelAssociator;
   
   protected void _infer(final Entity entity, @Extension final IJvmDeclaredTypeAcceptor acceptor, final boolean prelinkingPhase) {
     final Procedure1<JvmGenericType> _function = (JvmGenericType it) -> {
@@ -147,6 +152,15 @@ public class DomainmodelJvmModelInferrer extends AbstractModelInferrer {
       };
       final JvmOperation getterOrSetter = IterableExtensions.<JvmOperation>head(IterableExtensions.<JvmOperation>filter(jvmOperations, _function_1));
       if ((getterOrSetter != null)) {
+        this._iJvmModelAssociator.removeAllAssociation(getterOrSetter.getReturnType());
+        EList<JvmFormalParameter> _parameters = getterOrSetter.getParameters();
+        for (final JvmFormalParameter p : _parameters) {
+          {
+            this._iJvmModelAssociator.removeAllAssociation(p.getParameterType());
+            this._iJvmModelAssociator.removeAllAssociation(p);
+          }
+        }
+        this._iJvmModelAssociator.removeAllAssociation(getterOrSetter);
         inferredType.getMembers().remove(getterOrSetter);
       }
     };


### PR DESCRIPTION
[eclipse/xtext-extras#695] fix jvm element removal in inferrer
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>