### PR TITLE
[#1710] Don't touch the project again if it was already built

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/BuildManagerAccess.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/BuildManagerAccess.java
@@ -99,5 +99,20 @@ public class BuildManagerAccess {
 			throw new RuntimeException("Unexpected workspace implementation");
 		}
 	}
+	
+	/**
+	 * Schedule an auto build to be run.
+	 * 
+	 * @since 2.26
+	 */
+	public static void scheduleAutoBuild() {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		if (workspace instanceof Workspace) {
+			BuildManager buildManager = ((Workspace) workspace).getBuildManager();
+			buildManager.endTopLevel(true);
+		} else {
+			throw new RuntimeException("Unexpected workspace implementation");
+		}
+	}
 
 }

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/BuilderStateDiscarder.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/BuilderStateDiscarder.java
@@ -10,12 +10,8 @@ package org.eclipse.xtext.builder.impl;
 
 import java.util.Map;
 
-import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.Job;
 
 import com.google.common.annotations.Beta;
 
@@ -33,50 +29,42 @@ import com.google.common.annotations.Beta;
 @Beta
 public class BuilderStateDiscarder {
 
-	private static final Logger logger = Logger.getLogger(BuilderStateDiscarder.class);
-
 	/**
 	 * Returns true, if the given builderArguments indicate that we should discard the built state
 	 * for the given projects.
 	 */
 	public boolean forgetLastBuildState(Iterable<IProject> toUpdate, Map<String, String> builderArguments) {
+		/*
+		 * Implementation note:
+		 * This is an unsafe operation. There no guarantee that any lock is being acquired by the current thread
+		 * while performing this operation. It is very well possible that this is running concurrently with a build.
+		 * 
+		 * When we come here, we might, or might not
+		 * - hold the AbstractBuilderState.loadLock
+		 * - hold the org.eclipse.core.internal.resources.WorkManager.lock
+		 * - come from a build and see a situation with org.eclipse.core.internal.resources.Workspace.treeLocked being the case
+		 * - might or might not have a rule stack available on org.eclipse.core.internal.jobs.ThreadJob.ruleStack
+		 * 
+		 * It is desired that we only discard the build information of the XtextBuilder and not of all the builders
+		 * of a project. Therefore, we try to keep the interaction with the resource model to a minimum.
+		 * 
+		 * The strategy is coupled to the internals of the XtextBuilder where state is maintained
+		 * that allows to schedule an initial full build for a project.
+		 */
 		if (canHandleBuildFlag(builderArguments)) {
 			for (IProject project : toUpdate) {
-				XtextBuilder builder = BuildManagerAccess.findBuilder(project);
-				if (builder != null) {
-					builder.forgetLastBuiltState();
-					touchProject(project);
+				if (project.isAccessible()) {
+					XtextBuilder builder = BuildManagerAccess.findBuilder(project);
+					if (builder != null) {
+						builder.requestFullBuild(IBuildFlag.FORGET_BUILD_STATE_ONLY.isSet(builderArguments));
+					}
 				}
 			}
 			return true;
 		}
 		return false;
 	}
-
-	/**
-	 * Touch a given project such that the auto-build knows it should be rebuild.
-	 *
-	 * @since 2.26
-	 */
-	protected void touchProject(IProject project) {
-		Job touchJob = Job.create("Touch project " + project.getName(), progressMonitor -> {
-			try {
-				if (project.isAccessible()) {
-					project.touch(progressMonitor);
-				}
-				return Status.OK_STATUS;
-			} catch (CoreException e) {
-				logger.error("Failed to refresh project while forgetting its builder state", e);
-				return Status.CANCEL_STATUS;
-			}
-		});
-		touchJob.setRule(project);
-		touchJob.setUser(false);
-		touchJob.setSystem(true);
-		touchJob.schedule(0);
-
-	}
-
+	
 	protected boolean canHandleBuildFlag(Map<String, String> builderArguments) {
 		return IBuildFlag.FORGET_BUILD_STATE_ONLY.isSet(builderArguments)
 				|| IBuildFlag.RECOVERY_BUILD.isSet(builderArguments);

--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/ProjectOpenedOrClosedListener.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/ProjectOpenedOrClosedListener.java
@@ -214,11 +214,18 @@ public class ProjectOpenedOrClosedListener implements IResourceChangeListener {
 	}
 
 	protected void scheduleRemoveProjectJob(final IProject project) {
-		final ToBeBuilt toBeBuilt = getToBeBuiltComputer().removeProject(project, new NullProgressMonitor());
-		if (toBeBuilt.getToBeDeleted().isEmpty() && toBeBuilt.getToBeUpdated().isEmpty()) {
-			return;
+		try {
+			final ToBeBuilt toBeBuilt = getToBeBuiltComputer().removeProject(project, new NullProgressMonitor());
+			if (toBeBuilt.getToBeDeleted().isEmpty() && toBeBuilt.getToBeUpdated().isEmpty()) {
+				return;
+			}
+			scheduleJob(project.getName(), toBeBuilt);
+		} finally {
+			XtextBuilder builder = BuildManagerAccess.findBuilder(project);
+			if (builder != null) {
+				builder.forgetLastBuiltState();
+			}
 		}
-		scheduleJob(project.getName(), toBeBuilt);
 	}
 
 	/**


### PR DESCRIPTION
The window of opportunity for the autobuild is the time between
forgetting the last built state and the touch of the project in its own
job. Check if there is a known built state before touching the project
again.

Signed-off-by: Sebastian Zarnekow <sebastian.zarnekow@gmail.com>