### PR TITLE
[eclipse/xtext#1452] add common JavaRuntimeVersion utility to avoid code duplication between modules

### DIFF
--- a/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/xtext/ui/ContentAssistTest.java
+++ b/org.eclipse.xtext.common.types.eclipse.tests/tests/org/eclipse/xtext/common/types/xtext/ui/ContentAssistTest.java
@@ -81,10 +81,6 @@ public class ContentAssistTest extends AbstractXtextTests implements ResourceLoa
 		return true;
 	}
 	
-	protected boolean isJava6(){
-		return System.getProperty("java.version","1.6.0").startsWith("1.6");
-	}
-	
 	@Test
 	public void testDefaultArrayList_01() throws Exception {
 		//FIXME this does not consider JDT type filter, i.e. TypeFilter#isFiltered(char[],char[]) is not called.

--- a/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/AbstractXbaseContentAssistTest.java
+++ b/org.eclipse.xtext.xbase.ui.testing/src/org/eclipse/xtext/xbase/ui/testing/AbstractXbaseContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,8 +15,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.emf.common.util.URI;
@@ -31,11 +29,12 @@ import org.eclipse.xtext.Constants;
 import org.eclipse.xtext.common.types.access.IJvmTypeProvider;
 import org.eclipse.xtext.common.types.access.jdt.IJavaProjectProvider;
 import org.eclipse.xtext.common.types.access.jdt.JdtTypeProviderFactory;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.ui.testing.ContentAssistProcessorTestBuilder;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.ResourceLoadHelper;
-import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.resource.XtextResourceSet;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.util.StringInputStream;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.XExpression;
@@ -55,82 +54,6 @@ import com.google.inject.name.Named;
  * @since 2.12
  */
 public abstract class AbstractXbaseContentAssistTest extends Assert implements ResourceLoadHelper, IJavaProjectProvider {
-
-	private static final boolean isJava11OrLater = determineJava11OrLater();
-
-	/**
-	 * @since 2.20
-	 */
-	public static boolean isJava11OrLater() {
-		return isJava11OrLater;
-	}
-
-	private static final boolean isJava12OrLater = determineJava12OrLater();
-
-	/**
-	 * @since 2.20
-	 */
-	public static boolean isJava12OrLater() {
-		return isJava12OrLater;
-	}
-
-	private static final boolean isJava13OrLater = determineJava13OrLater();
-
-	/**
-	 * @since 2.20
-	 */
-	public static boolean isJava13OrLater() {
-		return isJava13OrLater;
-	}
-
-	private static boolean determineJava11OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 11;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-
-	private static boolean determineJava12OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 12;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-
-	private static boolean determineJava13OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 13;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-
 
 	@Inject
 	protected IWorkspace workspace;
@@ -326,7 +249,7 @@ public abstract class AbstractXbaseContentAssistTest extends Assert implements R
 		addMethods(stringType, features, staticFeatures, featuresOrTypes);
 		// compareTo(T) is actually overridden by compareTo(String) but contained twice in String.class#getMethods
 		features.remove("compareTo()");
-		if (isJava13OrLater()) {
+		if (JavaRuntimeVersion.isJava13OrLater()) {
 			features.remove("resolveConstantDesc()");
 		}
 		Set<String> featuresAsSet = Sets.newHashSet(features);
@@ -385,7 +308,7 @@ public abstract class AbstractXbaseContentAssistTest extends Assert implements R
 		List<String> features = Lists.newArrayList();
 		List<String> staticFeatures = Lists.newArrayList();
 		addMethods(classType, features, staticFeatures, featuresOrTypes);
-		if (isJava13OrLater()) {
+		if (JavaRuntimeVersion.isJava13OrLater()) {
 			features.remove("componentType");
 			features.remove("arrayType");
 			features.add("getComponentType");


### PR DESCRIPTION
[eclipse/xtext#1452] add common JavaRuntimeVersion utility to avoid code duplication between modules

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>