### PR TITLE
[eclipse/xtext#1995] switch from adoptopenjdk to termurin and provide java 17 jdk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     choice(name: 'TARGET_PLATFORM', choices: ['oxygen', 'photon', 'r201809', 'r201812', 'r201903', 'r201906', 'r201909', 'r201912', 'r202003', 'r202006', 'r202009', 'r202012', 'r202103', 'r202106', 'r202109', 'latest' ], description: 'Which Target Platform should be used?')
     // see https://wiki.eclipse.org/Jenkins#JDK
     choice(name: 'JDK_VERSION', description: 'Which JDK should be used?', choices: [
-       'adoptopenjdk-hotspot-jdk8-latest', 'adoptopenjdk-hotspot-jdk11-latest', 'adoptopenjdk-hotspot-jdk16-latest'
+       'temurin-jdk8-latest', 'temurin-jdk11-latest', 'temurin-jdk17-latest'
     ])
     booleanParam(
       name: 'TRIGGER_DOWNSTREAM_BUILD', 
@@ -23,7 +23,7 @@ pipeline {
   }
 
   triggers {
-    parameterizedCron(env.BRANCH_NAME == 'master' ? 'H H(0-1) * * * %TARGET_PLATFORM=latest;JDK_VERSION=adoptopenjdk-hotspot-jdk11-latest' : '')
+    parameterizedCron(env.BRANCH_NAME == 'master' ? 'H H(0-1) * * * %TARGET_PLATFORM=latest;JDK_VERSION=temurin-jdk11-latest' : '')
   }
 
   options {


### PR DESCRIPTION
[eclipse/xtext#1995] switch from adoptopenjdk to termurin and provide java 17 jdk

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>