### PR TITLE
[eclipse/xtext#2002] bootstrap against Xtext 2.26.0.M2

### DIFF
--- a/releng/org.eclipse.xtext.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtext.tycho.parent/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<tycho-version>1.7.0</tycho-version>
 		<!-- version of the "bootstrap" plugin; used to compile xtend sources in xtend -->
-		<xtend-maven-plugin-version>2.26.0.M1</xtend-maven-plugin-version>
+		<xtend-maven-plugin-version>2.26.0.M2</xtend-maven-plugin-version>
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
[eclipse/xtext#2002] bootstrap against Xtext 2.26.0.M2
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>