### PR TITLE
[eclipse/xtext#1997] update to Platform 2021-12 in domainmodel

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -8,7 +8,7 @@
       <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/releases/2021-09"/>
+      <repository location="https://download.eclipse.org/releases/2021-12/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
[eclipse/xtext#1997] update to Platform 2021-12 in domainmodel
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>