### PR TITLE
update to latest m2e to avoid dowload source and javadoc infinite loop

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -1381,7 +1381,7 @@
           <repository
               url="${p2.antlr-gen}"/>
           <repository
-              url="${p2.m2e}/1.18.1"/>
+              url="${p2.m2e}/1.18.2"/>
           <repository
               url="${p2.swtbot}"/>
           <repository


### PR DESCRIPTION
update to latest m2e to avoid dowload source and javadoc infinite loop
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>