### PR TITLE
[eclipse/xtext#2017] repare 2021-12 target && use 4.23 I-Builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
   }
 
   parameters {
-    choice(name: 'TARGET_PLATFORM', choices: ['oxygen', 'photon', 'r201809', 'r201812', 'r201903', 'r201906', 'r201909', 'r201912', 'r202003', 'r202006', 'r202009', 'r202012', 'r202103', 'r202106', 'r202109', 'latest' ], description: 'Which Target Platform should be used?')
+    choice(name: 'TARGET_PLATFORM', choices: ['oxygen', 'photon', 'r201809', 'r201812', 'r201903', 'r201906', 'r201909', 'r201912', 'r202003', 'r202006', 'r202009', 'r202012', 'r202103', 'r202106', 'r202109', 'r202112', 'latest' ], description: 'Which Target Platform should be used?')
     // see https://wiki.eclipse.org/Jenkins#JDK
     choice(name: 'JDK_VERSION', description: 'Which JDK should be used?', choices: [
        'temurin-jdk8-latest', 'temurin-jdk11-latest', 'temurin-jdk17-latest'
@@ -154,7 +154,7 @@ def isTriggeredByUpstream() {
 def eclipseVersion() {
   def targetPlatform = selectedTargetPlatform()
   if (targetPlatform == 'latest') {
-    return "4.22"
+    return "4.23"
   } else if (targetPlatform == 'photon') {
     return "4.8"
   } else if (targetPlatform == 'oxygen') {

--- a/org.eclipse.xtext.buildship/pom.xml
+++ b/org.eclipse.xtext.buildship/pom.xml
@@ -47,6 +47,7 @@
 		<profile><id>r202103</id></profile>
 		<profile><id>r202106</id></profile>
 		<profile><id>r202109</id></profile>
+		<profile><id>r202112</id></profile>
 		<profile><id>latest</id></profile>
 	</profiles>
 </project>

--- a/org.eclipse.xtext.ui.codemining/pom.xml
+++ b/org.eclipse.xtext.ui.codemining/pom.xml
@@ -38,6 +38,7 @@
 		<profile><id>r202103</id></profile>
 		<profile><id>r202106</id></profile>
 		<profile><id>r202109</id></profile>
+		<profile><id>r202112</id></profile>
 		<profile><id>latest</id></profile>
 	</profiles>
 </project>

--- a/org.eclipse.xtext.ui.testing/pom.xml
+++ b/org.eclipse.xtext.ui.testing/pom.xml
@@ -36,6 +36,7 @@
 		<profile><id>r202103</id></profile>
 		<profile><id>r202106</id></profile>
 		<profile><id>r202109</id></profile>
+		<profile><id>r202112</id></profile>
 		<profile><id>latest</id></profile>
 	</profiles>
 	

--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202112.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-r202112.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="org.eclipse.xtext.latest.target" sequenceNumber="7">
+<target name="org.eclipse.xtext.r202112.target" sequenceNumber="10">
 <locations>
 	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.xtext.xbase.lib.feature.group" version="0.0.0"/>
@@ -64,15 +64,13 @@
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.api.tools.ee.feature.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/eclipse/updates/4.23-I-builds"/>
-	</location>
-
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
+		<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/releases/2021-12"/>
@@ -80,13 +78,7 @@
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/nightly/latest"/>
-	</location>
-
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
-		<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S202108160852/"/>
+		<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.28/"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -104,6 +96,8 @@
 		<unit id="org.junit.jupiter.api" version="0.0.0"/>
 		<unit id="org.junit.jupiter.engine" version="0.0.0"/>
 		<unit id="org.junit.jupiter.params" version="0.0.0"/>
+		<unit id="org.junit.platform.suite.api" version="0.0.0"/>
+		<unit id="org.junit.platform.runner" version="0.0.0"/>
 		<unit id="org.junit.platform.commons" version="0.0.0"/>
 		<unit id="org.junit.platform.engine" version="0.0.0"/>
 		<unit id="org.opentest4j" version="0.0.0"/>

--- a/releng/org.eclipse.xtext.target/pom.xml
+++ b/releng/org.eclipse.xtext.target/pom.xml
@@ -103,6 +103,11 @@
 									<classifier>${project.artifactId}-r202109</classifier>
 								</artifact>
 								<artifact>
+									<file>${project.artifactId}-r202112.target</file>
+									<type>target</type>
+									<classifier>${project.artifactId}-r202112</classifier>
+								</artifact>
+								<artifact>
 									<file>${project.artifactId}-latest.target</file>
 									<type>target</type>
 									<classifier>${project.artifactId}-latest</classifier>

--- a/releng/org.eclipse.xtext.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtext.tycho.parent/pom.xml
@@ -36,6 +36,13 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>r202112</id>
+			<properties>
+				<tycho-version>2.5.0</tycho-version>
+				<target-platform-classifier>org.eclipse.xtext.target-r202112</target-platform-classifier>
+			</properties>
+		</profile>
+		<profile>
 			<id>r202109</id>
 			<properties>
 				<tycho-version>2.4.0</tycho-version>


### PR DESCRIPTION
[eclipse/xtext#2017] repare 2021-12 target && use 4.23 I-Builds
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>