### PR TITLE
[Bug 574908] Improve performance of Storage2UriMapperJavaImpl in modular project

### DIFF
--- a/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/javasupport/JdtToBeBuiltComputer.java
+++ b/org.eclipse.xtext.builder/src/org/eclipse/xtext/builder/impl/javasupport/JdtToBeBuiltComputer.java
@@ -40,7 +40,6 @@ import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.internal.core.ExternalFoldersManager;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaProject;
-import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.xtext.builder.impl.IToBeBuiltComputerContribution;
 import org.eclipse.xtext.builder.impl.QueuedBuildData;
 import org.eclipse.xtext.builder.impl.ToBeBuilt;
@@ -154,19 +153,13 @@ public class JdtToBeBuiltComputer implements IToBeBuiltComputerContribution {
 	}
 
 	/**
-	 * Handle all fragment roots that are on the classpath and not a source folder.
+	 * By default, handle all fragment roots that are on the class-path, not from the JRE and not a source folder.
+	 * 
+	 * @see IStorage2UriMapperJdtExtensions#shouldHandle(IPackageFragmentRoot)
 	 * @since 2.23
 	 */
 	protected boolean shouldHandle(IPackageFragmentRoot root) {
-		try {
-			boolean result = !JavaRuntime.newDefaultJREContainerPath().isPrefixOf(root.getRawClasspathEntry().getPath());
-			result &= (root.isArchive() || root.isExternal()); 
-			return result;
-		} catch (JavaModelException ex) {
-			if (!ex.isDoesNotExist())
-				log.error(ex.getMessage(), ex);
-			return false;
-		}
+		return this.jdtUriMapperExtension.shouldHandle(root);
 	}
 
 	@Override

--- a/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.java
+++ b/org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/core/resource/Storage2UriMapperJavaImplTest.java
@@ -8,18 +8,27 @@
  */
 package org.eclipse.xtext.ui.tests.core.resource;
 
+import static org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.*;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
 import org.eclipse.xtext.ui.resource.JarEntryLocator;
 import org.eclipse.xtext.ui.resource.Storage2UriMapperJavaImpl;
@@ -29,12 +38,15 @@ import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.ui.util.JavaProjectClasspathChangeAnalyzer;
 import org.eclipse.xtext.ui.workspace.WorkspaceLockAccess;
+import org.eclipse.xtext.util.JavaVersion;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -56,27 +68,6 @@ public class Storage2UriMapperJavaImplTest extends Assert {
 		IResourcesSetupUtil.cleanWorkspace();
 	}
 
-	private boolean isExpectedJRESize(int size) {
-		switch (size) {
-			case 1:
-				/* java8 */ return true;
-			case 63:
-				/* java9 */ return true;
-			case 49:
-				/* java10 + java11 + java13 */ return true;
-			case 50:
-				/* java11.0.9+ */ return true;
-			case 51:
-				/* java14 + java 15 */ return true;
-			default:
-				return false;
-		}
-	}
-
-	private boolean isExpectedJRESize(int size, int multiplier) {
-		return isExpectedJRESize(size / multiplier) && size / multiplier * multiplier == size;
-	}
-
 	protected Storage2UriMapperJavaImpl createFreshStorage2UriMapper() {
 		Storage2UriMapperJavaImpl mapper = new Storage2UriMapperJavaImpl();
 		mapper.setUriValidator(new UriValidator() {
@@ -96,22 +87,130 @@ public class Storage2UriMapperJavaImplTest extends Assert {
 		mapper.setJavaProjectClasspathChangeAnalyzer(new JavaProjectClasspathChangeAnalyzer());
 		return mapper;
 	}
+	
+	@Test
+	public void testBug574908() throws Exception {
+		IJavaProject p = newModularProject("p0");
+		if (p == null) {
+			// Oxygen: No JRE11 available
+			return;
+		}
+		assertTrue(p.findType("java.lang.Module").exists());
+		storage2UriMapperJava = createFreshStorage2UriMapper();
+		storage2UriMapperJava.initializeCache();
+		Map<String, PackageFragmentRootData> data = getCachedPackageFragmentRootData();
+		assertNotNull(data);
+		assertTrue(data.isEmpty());
+	}
+	
+	@Test
+	public void testBug574908_Performance() throws Exception {
+		AtomicLong createProjectTimeMs = new AtomicLong();
+		new WorkspaceModifyOperation() {
+			@Override
+			protected void execute(IProgressMonitor monitor) throws CoreException, InvocationTargetException, InterruptedException {
+				Stopwatch sw = Stopwatch.createStarted();		
+				for(int i = 0; i < 25; i++) {
+					newModularProject("p" + i);
+				}
+				createProjectTimeMs.set(sw.elapsed(TimeUnit.MILLISECONDS));
+			}
+		}.run(null);
+		
+		Stopwatch sw = Stopwatch.createStarted();
+		storage2UriMapperJava = createFreshStorage2UriMapper();
+		storage2UriMapperJava.syncInitializeCache();
+		long mapperTime = sw.elapsed(TimeUnit.MILLISECONDS);
+		assertTrue("Creationg took: " + createProjectTimeMs.get()+ "ms; cacheInit took: " + mapperTime, mapperTime < 250);
+	}
+	
+	@Ignore("Can be enabled for performance test purposes")
+	@Test
+	public void testBug574908_Performance_500() throws Exception {
+		new WorkspaceModifyOperation() {
+			@Override
+			protected void execute(IProgressMonitor monitor) throws CoreException, InvocationTargetException, InterruptedException {
+				Stopwatch sw = Stopwatch.createStarted();		
+				for(int i = 0; i < 500; i++) {
+					newModularProject("p" + i);
+				}
+				System.err.println(sw.elapsed(TimeUnit.MILLISECONDS));
+			}
+		}.run(null);
+		
+		for(int i = 0; i < 50; i++) {
+			Stopwatch sw = Stopwatch.createStarted();
+			storage2UriMapperJava = createFreshStorage2UriMapper();
+			storage2UriMapperJava.syncInitializeCache();
+			System.err.println(sw.elapsed(TimeUnit.MILLISECONDS));
+		}
+	}
+
+	private IJavaProject newModularProject(String projectName) throws CoreException, JavaModelException, InvocationTargetException, InterruptedException {
+		AtomicReference<IJavaProject> result = new AtomicReference<IJavaProject>();
+		new WorkspaceModifyOperation() {
+
+			@Override
+			protected void execute(IProgressMonitor monitor) throws CoreException, InvocationTargetException, InterruptedException {
+				IProject project = JavaProjectSetupUtil.createSimpleProject(projectName);
+				JavaCore.initializeAfterLoad(monitor());
+				IJavaProject javaProject = JavaCore.create(project);
+				javaProject.save(null, true);
+				result.set(javaProject);
+				addNature(project, JavaCore.NATURE_ID);
+				JavaProjectSetupUtil.addSourceFolder(javaProject, "src", false);
+				JavaProjectSetupUtil.addJreClasspathEntry(javaProject, JavaVersion.JAVA11.getBree());
+				
+				IClasspathEntry defaultEntry = JavaProjectSetupUtil.getJreContainerClasspathEntry(javaProject);
+				if (defaultEntry == null) {
+					// Oxygen: No JRE11 available
+					result.set(null);
+					return;
+				}
+				if (isModular(defaultEntry)) {
+					return;
+				}
+				
+				IClasspathEntry newEntry = JavaCore.newContainerEntry(defaultEntry.getPath(), defaultEntry.getAccessRules(), new IClasspathAttribute[] { JavaCore.newClasspathAttribute(IClasspathAttribute.MODULE, "true") }, defaultEntry.isExported());
+				IClasspathEntry[] array = javaProject.getRawClasspath();
+				for(int i = 0; i < array.length; i++) {
+					if (array[i] == defaultEntry) {
+						array[i] = newEntry;
+						break;
+					}
+				}
+				javaProject.setRawClasspath(array, null);
+				assertTrue(isModular(JavaProjectSetupUtil.getJreContainerClasspathEntry(javaProject)));
+			}
+			
+		}.run(null);
+		return result.get();
+	}
+	
+	private boolean isModular(IClasspathEntry entry) {
+		IClasspathAttribute[] attributes = entry.getExtraAttributes();
+		for (int i = 0, length = attributes.length; i < length; i++) {
+			IClasspathAttribute attribute = attributes[i];
+			if (IClasspathAttribute.MODULE.equals(attribute.getName()) && "true".equals(attribute.getValue())) //$NON-NLS-1$
+				return true;
+		}
+		return false;
+	}
 
 	@Test
 	public void testOnClasspathChange() throws Exception {
 		Assert.assertEquals("" + getCachedPackageFragmentRootData(), 0, getCachedPackageFragmentRootData().size());
 		IJavaProject project = JavaProjectSetupUtil.createJavaProject("testProject");
-		int sizeBefore = getCachedPackageFragmentRootData().size();
-		// it should contain all the jars from JDK now
-		Assert.assertTrue(sizeBefore > 0);
+		Map<String, PackageFragmentRootData> map = getCachedPackageFragmentRootData();
+		int sizeBefore = map.size();
+		Assert.assertEquals("JRE is not cached", 0, sizeBefore);
 		Assert.assertFalse(getCachedPackageFragmentRootData().keySet().stream().filter(it -> it.contains("foo.jar")).findFirst().isPresent());
 		IFile file = createJar(project);
 		JavaProjectSetupUtil.addJarToClasspath(project, file);
 		Assert.assertEquals("" + getCachedPackageFragmentRootData(), sizeBefore + 1, getCachedPackageFragmentRootData().size());
 		Assert.assertNotNull(getCachedPackageFragmentRootData().keySet().stream().filter(it -> it.contains("foo.jar")).findFirst().get());
 		getCachedPackageFragmentRootData().entrySet().forEach((Map.Entry<String, PackageFragmentRootData> it) -> {
-			Assert.assertTrue(it.getValue().associatedRoots.size() + " / " + it.getKey(),
-					isExpectedJRESize(it.getValue().associatedRoots.size()));
+			Assert.assertEquals(it.getValue().associatedRoots.size() + " / " + it.getKey(), 1, it.getValue().associatedRoots.size());
 			String head = Iterables.getFirst(it.getValue().associatedRoots.keySet(), null);
 			Assert.assertTrue(head, head.startsWith("=testProject/"));
 		});
@@ -120,8 +219,7 @@ public class Storage2UriMapperJavaImplTest extends Assert {
 		Assert.assertEquals("" + getCachedPackageFragmentRootData(), (sizeBefore + 1), getCachedPackageFragmentRootData().size());
 		Assert.assertNotNull(getCachedPackageFragmentRootData().keySet().stream().filter(it -> it.contains("foo.jar")).findFirst().get());
 		getCachedPackageFragmentRootData().entrySet().forEach((Map.Entry<String, PackageFragmentRootData> it) -> {
-			Assert.assertTrue(it.getValue().associatedRoots.size() + " / " + it.getKey(),
-					isExpectedJRESize(it.getValue().associatedRoots.size(), 2));
+			Assert.assertEquals(it.getValue().associatedRoots.size() + " / " + it.getKey(), 2, it.getValue().associatedRoots.size());
 			String msg = Joiner.on("\n").join(it.getValue().associatedRoots.keySet());
 			Assert.assertTrue(msg, Iterables.any(it.getValue().associatedRoots.keySet(), r -> r.startsWith("=testProject/")));
 			Assert.assertTrue(msg, Iterables.any(it.getValue().associatedRoots.keySet(), r -> r.startsWith("=testProject2/")));
@@ -135,8 +233,7 @@ public class Storage2UriMapperJavaImplTest extends Assert {
 				String head = Iterables.getFirst(it.getValue().associatedRoots.keySet(), null);
 				Assert.assertTrue(head, head.startsWith("=testProject2/"));
 			} else {
-				Assert.assertTrue(it.getValue().associatedRoots.size() + "/" + it.getKey(),
-						isExpectedJRESize(it.getValue().associatedRoots.size(), 2));
+				Assert.assertEquals(it.getValue().associatedRoots.size() + " / " + it.getKey(), 2, it.getValue().associatedRoots.size());
 				String msg = Joiner.on("\n").join(it.getValue().associatedRoots.keySet());
 				Assert.assertTrue(msg, Iterables.any(it.getValue().associatedRoots.keySet(), r -> r.startsWith("=testProject/")));
 				Assert.assertTrue(msg, Iterables.any(it.getValue().associatedRoots.keySet(), r -> r.startsWith("=testProject2/")));
@@ -146,8 +243,7 @@ public class Storage2UriMapperJavaImplTest extends Assert {
 		Assert.assertEquals("" + getCachedPackageFragmentRootData(), sizeBefore, getCachedPackageFragmentRootData().size());
 		Assert.assertFalse(getCachedPackageFragmentRootData().keySet().stream().filter(it -> it.contains("foo.jar")).findFirst().isPresent());
 		getCachedPackageFragmentRootData().entrySet().forEach((Map.Entry<String, PackageFragmentRootData> it) -> {
-			Assert.assertTrue(it.getValue().associatedRoots.size() + "/" + it.getKey(),
-					isExpectedJRESize(it.getValue().associatedRoots.size(), 2));
+			Assert.assertEquals(it.getValue().associatedRoots.size() + " / " + it.getKey(), 2, it.getValue().associatedRoots.size());
 			String msg = Joiner.on("\n").join(it.getValue().associatedRoots.keySet());
 			Assert.assertTrue(msg, Iterables.any(it.getValue().associatedRoots.keySet(), r -> r.startsWith("=testProject/")));
 			Assert.assertTrue(msg, Iterables.any(it.getValue().associatedRoots.keySet(), r -> r.startsWith("=testProject2/")));
@@ -224,8 +320,7 @@ public class Storage2UriMapperJavaImplTest extends Assert {
 		Assert.assertEquals("" + getCachedPackageFragmentRootData(), sizeBefore + 1, getCachedPackageFragmentRootData().size());
 		Assert.assertNotNull(getCachedPackageFragmentRootData().keySet().stream().filter(it -> it.contains("foo.jar")).findFirst().get());
 		getCachedPackageFragmentRootData().entrySet().forEach((Map.Entry<String, PackageFragmentRootData> it) -> {
-			Assert.assertTrue(it.getValue().associatedRoots.size() + "/" + it.getKey(),
-					isExpectedJRESize(it.getValue().associatedRoots.size(), 2));
+			Assert.assertEquals(it.getValue().associatedRoots.size() + "/" + it.getKey(), 2, it.getValue().associatedRoots.size());
 			String msg = Joiner.on("\n").join(it.getValue().associatedRoots.keySet());
 			Assert.assertTrue(msg, Iterables.any(it.getValue().associatedRoots.keySet(), r -> r.startsWith("=testProject/")));
 			Assert.assertTrue(msg, Iterables.any(it.getValue().associatedRoots.keySet(), r -> r.startsWith("=testProject2/")));

--- a/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/Storage2UriMapperJavaImpl.java
+++ b/org.eclipse.xtext.ui/src/org/eclipse/xtext/ui/resource/Storage2UriMapperJavaImpl.java
@@ -16,6 +16,7 @@ import static java.util.Collections.*;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,7 +46,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.xtext.ui.util.IJdtHelper;
 import org.eclipse.xtext.ui.util.JavaProjectClasspathChangeAnalyzer;
 import org.eclipse.xtext.ui.workspace.WorkspaceLockAccess;
@@ -73,12 +73,12 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 	public static class PackageFragmentRootData {
 		public URI uriPrefix;
 		public final Object modificationStamp;
-		public Map<String, IPackageFragmentRoot> associatedRoots;
+		public final Map<String, IPackageFragmentRoot> associatedRoots;
 		public Map<URI, IStorage> uri2Storage = newLinkedHashMap();
 
 		public PackageFragmentRootData(Object modificationStamp) {
 			this.modificationStamp = modificationStamp;
-			this.associatedRoots = newLinkedHashMap();
+			this.associatedRoots = Collections.synchronizedMap(new LinkedHashMap<>());
 		}
 		
 		@Override
@@ -108,13 +108,7 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 				if ("JImageModuleFragmentBridge".equals(root.getClass().getSimpleName())) {
 					return;
 				}
-				String handleIdentifier = root.getHandleIdentifier();
-				Map<String, IPackageFragmentRoot> roots = associatedRoots;
-				if (!root.equals(roots.get(handleIdentifier))) {
-					Map<String,IPackageFragmentRoot> copy = newLinkedHashMap(roots);
-					copy.put(handleIdentifier, root);
-					associatedRoots = copy;
-				}
+				associatedRoots.put(root.getHandleIdentifier(), root);
 			}
 		}
 
@@ -243,7 +237,7 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 	}
 	
 	protected PackageFragmentRootData getData(IPackageFragmentRoot root) {
-		final boolean isCachable = root.isArchive() || root.isExternal();
+		final boolean isCachable = shouldHandle(root);
 		if (isCachable) {
 			return getCachedData(root);
 		}
@@ -314,43 +308,43 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 	protected PackageFragmentRootData initializeData(final IPackageFragmentRoot root) {
 		final PackageFragmentRootData data = new PackageFragmentRootData(computeModificationStamp(root));
 		data.addRoot(root);
-		try {
-			final SourceAttachmentPackageFragmentRootWalker<Void> walker = new SourceAttachmentPackageFragmentRootWalker<Void>() {
-				
-				@Override
-				protected URI getURI(IFile file,
-						org.eclipse.xtext.ui.resource.PackageFragmentRootWalker.TraversalState state) {
-					if (!uriValidator.isPossiblyManaged(file))
-						return null;
-					return super.getURI(file, state);
-				}
+		if (shouldHandle(root)) {
+			try {
+				final SourceAttachmentPackageFragmentRootWalker<Void> walker = new SourceAttachmentPackageFragmentRootWalker<Void>() {
 
-				@Override
-				protected URI getURI(IJarEntryResource jarEntry,
-						org.eclipse.xtext.ui.resource.PackageFragmentRootWalker.TraversalState state) {
-					if (!uriValidator.isPossiblyManaged(jarEntry))
-						return null;
-					final URI uri = locator.getURI(root, jarEntry, state);
-					if (!uriValidator.isValid(uri, jarEntry))
-						return null;
-					return uri;
-				}
+					@Override
+					protected URI getURI(IFile file, org.eclipse.xtext.ui.resource.PackageFragmentRootWalker.TraversalState state) {
+						if (!uriValidator.isPossiblyManaged(file))
+							return null;
+						return super.getURI(file, state);
+					}
 
-				@Override
-				protected Void handle(URI uri, IStorage storage,
-						org.eclipse.xtext.ui.resource.PackageFragmentRootWalker.TraversalState state) {
-					data.uri2Storage.put(uri, storage);
-					return null;
-				}
-				
-			};
-			walker.traverse(root, false);
-			if (walker.getBundleSymbolicName() != null)
-				data.uriPrefix = URI.createPlatformResourceURI(walker.getBundleSymbolicName()+"/", true);
-		} catch (RuntimeException e) {
-			log.error(e.getMessage(), e);
-		} catch (JavaModelException e) {
-			log.debug(e.getMessage(), e);
+					@Override
+					protected URI getURI(IJarEntryResource jarEntry,
+							org.eclipse.xtext.ui.resource.PackageFragmentRootWalker.TraversalState state) {
+						if (!uriValidator.isPossiblyManaged(jarEntry))
+							return null;
+						final URI uri = locator.getURI(root, jarEntry, state);
+						if (!uriValidator.isValid(uri, jarEntry))
+							return null;
+						return uri;
+					}
+
+					@Override
+					protected Void handle(URI uri, IStorage storage,
+							org.eclipse.xtext.ui.resource.PackageFragmentRootWalker.TraversalState state) {
+						data.uri2Storage.put(uri, storage);
+						return null;
+					}
+				};
+				walker.traverse(root, false);
+				if (walker.getBundleSymbolicName() != null)
+					data.uriPrefix = URI.createPlatformResourceURI(walker.getBundleSymbolicName() + "/", true);
+			} catch (RuntimeException e) {
+				log.error(e.getMessage(), e);
+			} catch (JavaModelException e) {
+				log.debug(e.getMessage(), e);
+			}
 		}
 		return data;
 	}
@@ -476,9 +470,10 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 		try {
 			if (project.exists() && project.getProject().isAccessible()) {
 				for(IPackageFragmentRoot root: project.getPackageFragmentRoots()) {
-					boolean isCachable = root.isArchive() || root.isExternal();
-					if(isCachable) 
+					boolean isCachable = shouldHandle(root);
+					if(isCachable) {
 						datas.add(getCachedData(root));
+					}
 				}
 			}
 		} catch (JavaModelException e) {
@@ -499,39 +494,37 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 			if (toBeKept.contains(data)) {
 				continue;
 			}
-			// create a copy of the known associated roots to avoid concurrent modification
-			// and conflicts with other readers
-			Map<String, IPackageFragmentRoot> copy = newLinkedHashMap(data.associatedRoots);
-			Iterator<IPackageFragmentRoot> i = copy.values().iterator();
-			IPackageFragmentRoot someRoot = null;
-			boolean didChange = false;
-			while (i.hasNext()) {
-				IPackageFragmentRoot root = i.next();
-				if (project.equals(root.getJavaProject())) {
-					i.remove();
-					didChange = true;
-				} else if (someRoot == null) {
-					someRoot = root;
-				}
-			}
-			if (copy.size() == 0) {
-				toBeRemoved.add(data);
-			} else if (didChange) {
-				// get rid of cached storages that still point to roots / projects that are no longer available
-				// and recompute them lazily on demand
-				data.associatedRoots = copy;
-				final IPackageFragmentRoot rootToProcess = someRoot;
-				data.uri2Storage = new ForwardingMap<URI, IStorage>() {
-					Map<URI, IStorage> delegate;
-					@Override
-					protected Map<URI, IStorage> delegate() {
-						if (delegate == null) {
-							PackageFragmentRootData newlyCollected = initializeData(rootToProcess);
-							return delegate = newlyCollected.uri2Storage; 
-						}
-						return delegate;
+			Map<String, IPackageFragmentRoot> associatedRoots = data.associatedRoots;
+			synchronized(associatedRoots) {
+				Iterator<IPackageFragmentRoot> i = associatedRoots.values().iterator();
+				IPackageFragmentRoot someRoot = null;
+				boolean didChange = false;
+				while (i.hasNext()) {
+					IPackageFragmentRoot root = i.next();
+					if (project.equals(root.getJavaProject())) {
+						i.remove();
+						didChange = true;
+					} else if (someRoot == null) {
+						someRoot = root;
 					}
-				};
+				}
+				if (associatedRoots.size() == 0) {
+					toBeRemoved.add(data);
+				} else if (didChange) {
+					// get rid of cached storages that still point to roots / projects that are no longer available
+					// and recompute them lazily on demand
+					final IPackageFragmentRoot rootToProcess = someRoot;
+					data.uri2Storage = new ForwardingMap<URI, IStorage>() {
+						Map<URI, IStorage> delegate;
+						@Override
+						protected Map<URI, IStorage> delegate() {
+							if (delegate == null) {
+								return delegate = initializeData(rootToProcess).uri2Storage; 
+							}
+							return delegate;
+						}
+					};
+				}
 			}
 		}
 		if(!toBeRemoved.isEmpty()) {
@@ -551,7 +544,7 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 	
 	/**
 	 * Schedules cache initialization to be performed in the background.
-	 * Cache init needs a WS lock, though.
+	 * Cache initialization needs a WS lock, though.
 	 * 
 	 * @since 2.9
 	 */
@@ -560,6 +553,13 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 			useNewThreadToInitialize(false);
 		}
 	}
+	
+	/**
+	 * @since 2.26
+	 */
+	public void syncInitializeCache() {
+		initializeCache(true);
+	}
 
 	protected boolean initializeCache(boolean wait) {
 		if(!isInitialized) {
@@ -567,13 +567,13 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 			 * IWorkspace.run(IWorkspaceRunnable, ISchedulingRule, int, IProgressMonitor)
 			 * accepts a scheduling rule to allow a workspace runnable to be postponed
 			 * when another plain job with the same SR is still running (and vice versa),
-			 * but the main lock during the run is the one of the Workmanager.
+			 * but the main lock during the run is the one of the WorkManager.
 			 * Even if there is no current rule on the manager, the workspace may be currently
 			 * locked by this thread. If that is already the case, initialize the cache
 			 * immediately, otherwise postpone the initialization to another thread.  
 			 */
 			// basically two scenarios: the current thread has the build rule or ws-root rule
-			// that is, we can init directly
+			// that is, we can initialize directly
 			switch(workspaceLockAccess.isWorkspaceLockedByCurrentThread(workspace)) {
 				case YES: {
 					// perform initialization from the current thread and everything should be fine
@@ -583,7 +583,7 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 					} catch (CoreException e) {
 						log.error(e.getMessage(), e);
 					}
-					// this may have happend while another thread is already waiting to aquire the WS root
+					// this may have happened while another thread is already waiting to acquire the WS root
 					// release the guard to let potentially waiting threads continue as early as possible 
 					CountDownLatch guard = initializerGuard.get();
 					if (guard != null) {
@@ -605,7 +605,7 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 	}
 
 	/**
-	 * If no thread has been spawned so far, spawns a new one that will perform the cache init.
+	 * If no thread has been spawned so far, spawns a new one that will perform the cache initialization.
 	 * Optionally waits for the cache initialization to be performed in a another thread.
 	 */
 	protected void useNewThreadToInitialize(boolean wait) {
@@ -626,7 +626,7 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 			if (initializerGuard.compareAndSet(null, newGuard)) {
 				// still no other thread created a guard in the (short) meantime 
 				myGuard = newGuard;
-				// aquire the WS rule in an own thread and perform the initialization from there
+				// acquire the WS rule in an own thread and perform the initialization from there
 				startInitializerThread(newGuard);
 			} else {
 				// use the guard that was created by another thread
@@ -665,11 +665,12 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 	protected void doInitializeCache() throws CoreException {
 		if(!isInitialized) {
 			IWorkspaceRunnable runnable = new IWorkspaceRunnable() {
+				@SuppressWarnings("restriction")
 				@Override
 				public void run(IProgressMonitor monitor) throws CoreException {
 					if(!isInitialized) {
 						for(IProject project: workspace.getRoot().getProjects()) {
-							if(project.isAccessible() && JavaProject.hasJavaNature(project)) {
+							if(project.isAccessible() && org.eclipse.jdt.internal.core.JavaProject.hasJavaNature(project)) {
 								IJavaProject javaProject = JavaCore.create(project);
 								updateCache(javaProject);
 							}
@@ -706,7 +707,4 @@ public class Storage2UriMapperJavaImpl implements IStorage2UriMapperJdtExtension
 		}
 		return result == null ? Collections.<IJavaElementDelta>emptySet() : result;
 	}
-	
-	
-
 }


### PR DESCRIPTION
Since it is extremely unlikely that the JRE contains sources for which
an Xtext builder is supposed to be executed, the JdtTobeBuiltComputer
was always filtering the JRE from the build processing. The
Storage2UriMapperJavaImpl can do the same. Both share the same
implementation to make that decision.

Also replace pessimistic copies of maps by a synchronized collection in
the PackageFragmentRootData to avoid unnecessary copies of data.

In an unscientific coarse measurement, the time to init the cache for
500 projects was reduced from 15seconds to 40ms.