### PR TITLE
waitForBuild throws with reference to original exception

### DIFF
--- a/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/IResourcesSetupUtil.java
+++ b/org.eclipse.xtext.junit4/src/org/eclipse/xtext/junit4/ui/util/IResourcesSetupUtil.java
@@ -339,7 +339,9 @@ public class IResourcesSetupUtil {
 		try {
 			ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
 		} catch (CoreException e) {
-			throw new OperationCanceledException(e.getMessage());
+			OperationCanceledException operationCanceledException = new OperationCanceledException(e.getMessage());
+			operationCanceledException.addSuppressed(e);
+			throw operationCanceledException;
 		}
 	}
 

--- a/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
+++ b/org.eclipse.xtext.ui.testing/src/org/eclipse/xtext/ui/testing/util/IResourcesSetupUtil.java
@@ -370,7 +370,9 @@ public class IResourcesSetupUtil {
 		try {
 			ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
 		} catch (CoreException e) {
-			throw new OperationCanceledException(e.getMessage());
+			OperationCanceledException operationCanceledException = new OperationCanceledException(e.getMessage());
+			operationCanceledException.addSuppressed(e);
+			throw operationCanceledException;
 		}
 	}
 


### PR DESCRIPTION
Currently, waitForBuild catches a CoreException and throws an
OperationCanceledException with just the message of the original
CoreException. Indeed, OperationCanceledException does not have a
constructor for passing also an exception. Without the original
exception, though, it is hard to understand what went wrong during the
test, since we lost the original exception's stacktracke

Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>