### PR TITLE
[eclipse/xtext#2038] build against 2022-06 in latest

### DIFF
--- a/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
+++ b/releng/org.eclipse.xtext.target/org.eclipse.xtext.target-latest.target
@@ -75,7 +75,7 @@
 		<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/releases/2022-03"/>
+		<repository location="https://download.eclipse.org/releases/2022-06"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#2038] build against 2022-06 in latest