### PR TITLE
772: updated dmodel compiler tests

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/CompilerTest.xtend
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/src/org/eclipse/xtext/example/domainmodel/tests/CompilerTest.xtend
@@ -81,21 +81,21 @@ class CompilerTest {
 			public class Foo {
 			  public Foo() {
 			  }
-			  
+			
 			  public Foo(final Procedure1<Foo> initializer) {
 			    initializer.apply(this);
 			  }
-			  
+			
 			  private String name;
-			  
+			
 			  public String getName() {
 			    return this.name;
 			  }
-			  
+			
 			  public void setName(final String name) {
 			    this.name = name;
 			  }
-			  
+			
 			  @Override
 			  public String toString() {
 			    String result = new ToStringBuilder(this).addAllFields().toString();
@@ -142,24 +142,24 @@ class CompilerTest {
 				public class Foo {
 				  public Foo() {
 				  }
-				  
+				
 				  public Foo(final Procedure1<Foo> initializer) {
 				    initializer.apply(this);
 				  }
-				  
+				
 				  private String name;
-				  
+				
 				  public void setName(final String name) {
 				    this.name = name;
 				  }
-				  
+				
 				  /**
 				   * explicit getter will replace the generated one
 				   */
 				  public String getName() {
 				    return StringExtensions.toFirstUpper(this.name);
 				  }
-				  
+				
 				  @Override
 				  public String toString() {
 				    String result = new ToStringBuilder(this).addAllFields().toString();
@@ -195,17 +195,17 @@ class CompilerTest {
 				public class Foo {
 				  public Foo() {
 				  }
-				  
+				
 				  public Foo(final Procedure1<Foo> initializer) {
 				    initializer.apply(this);
 				  }
-				  
+				
 				  private String name;
-				  
+				
 				  public String getName() {
 				    return this.name;
 				  }
-				  
+				
 				  /**
 				   * explicit setter will replace the generated one,
 				   * even if it's not void
@@ -213,7 +213,7 @@ class CompilerTest {
 				  public String setName(final String name) {
 				    return this.name = StringExtensions.toFirstUpper(name);
 				  }
-				  
+				
 				  @Override
 				  public String toString() {
 				    String result = new ToStringBuilder(this).addAllFields().toString();
@@ -253,20 +253,20 @@ class CompilerTest {
 				public class Foo {
 				  public Foo() {
 				  }
-				  
+				
 				  public Foo(final Procedure1<Foo> initializer) {
 				    initializer.apply(this);
 				  }
-				  
+				
 				  private String name;
-				  
+				
 				  /**
 				   * explicit getter will replace the generated one
 				   */
 				  public String getName() {
 				    return this.name.toUpperCase();
 				  }
-				  
+				
 				  /**
 				   * explicit setter will replace the generated one,
 				   * even if it's not void
@@ -274,7 +274,7 @@ class CompilerTest {
 				  public String setName(final String name) {
 				    return this.name = StringExtensions.toFirstUpper(name);
 				  }
-				  
+				
 				  @Override
 				  public String toString() {
 				    String result = new ToStringBuilder(this).addAllFields().toString();

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/CompilerTest.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.tests/xtend-gen/org/eclipse/xtext/example/domainmodel/tests/CompilerTest.java
@@ -140,7 +140,6 @@ public class CompilerTest {
       _builder_1.append("  ");
       _builder_1.append("}");
       _builder_1.newLine();
-      _builder_1.append("  ");
       _builder_1.newLine();
       _builder_1.append("  ");
       _builder_1.append("public Foo(final Procedure1<Foo> initializer) {");
@@ -151,12 +150,10 @@ public class CompilerTest {
       _builder_1.append("  ");
       _builder_1.append("}");
       _builder_1.newLine();
-      _builder_1.append("  ");
       _builder_1.newLine();
       _builder_1.append("  ");
       _builder_1.append("private String name;");
       _builder_1.newLine();
-      _builder_1.append("  ");
       _builder_1.newLine();
       _builder_1.append("  ");
       _builder_1.append("public String getName() {");
@@ -167,7 +164,6 @@ public class CompilerTest {
       _builder_1.append("  ");
       _builder_1.append("}");
       _builder_1.newLine();
-      _builder_1.append("  ");
       _builder_1.newLine();
       _builder_1.append("  ");
       _builder_1.append("public void setName(final String name) {");
@@ -178,7 +174,6 @@ public class CompilerTest {
       _builder_1.append("  ");
       _builder_1.append("}");
       _builder_1.newLine();
-      _builder_1.append("  ");
       _builder_1.newLine();
       _builder_1.append("  ");
       _builder_1.append("@Override");
@@ -281,7 +276,6 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("public Foo(final Procedure1<Foo> initializer) {");
@@ -292,12 +286,10 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("private String name;");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("public void setName(final String name) {");
@@ -308,7 +300,6 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("/**");
@@ -328,7 +319,6 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("@Override");
@@ -403,7 +393,6 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("public Foo(final Procedure1<Foo> initializer) {");
@@ -414,12 +403,10 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("private String name;");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("public String getName() {");
@@ -430,7 +417,6 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("/**");
@@ -453,7 +439,6 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("@Override");
@@ -540,7 +525,6 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("public Foo(final Procedure1<Foo> initializer) {");
@@ -551,12 +535,10 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("private String name;");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("/**");
@@ -576,7 +558,6 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("/**");
@@ -599,7 +580,6 @@ public class CompilerTest {
         _builder_1.append("  ");
         _builder_1.append("}");
         _builder_1.newLine();
-        _builder_1.append("  ");
         _builder_1.newLine();
         _builder_1.append("  ");
         _builder_1.append("@Override");


### PR DESCRIPTION
This updates compilation test expectations (https://github.com/eclipse/xtext-extras/pull/774 fixing https://github.com/eclipse/xtext-extras/issues/772).