### PR TITLE
[eclipse/xtext#2068] use 4.25 I-builds in oomph

### DIFF
--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -1459,7 +1459,7 @@
           <repository
               url="${p2.draw2d}"/>
           <repository
-              url="https://download.eclipse.org/eclipse/updates/4.24-I-builds"/>
+              url="https://download.eclipse.org/eclipse/updates/4.25-I-builds"/>
           <repository
               url="${p2.xpand}"/>
           <repository


### PR DESCRIPTION
[eclipse/xtext#2068] use 4.25 I-builds in oomph