### PR TITLE
[eclipse/xtext#2086] use gef classic instead of legacy draw2d

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -32,8 +32,8 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/2022-09"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201606061308"/>
-      <repository location="https://download.eclipse.org/tools/gef/updates/legacy/releases"/>
+      <unit id="org.eclipse.draw2d.feature.group" version="3.14.0.202206170857"/>
+      <repository location="https://download.eclipse.org/tools/gef/classic/releases/3.14.0/"/>
     </location>
   </locations>
 </target>


### PR DESCRIPTION
[eclipse/xtext#2086] use gef classic instead of legacy draw2d