### PR TITLE
explicitely pull commons.io as platform no longer packages it

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -25,6 +25,7 @@
       <unit id="com.google.inject" version="5.0.1.v20210324-2015"/>
       <unit id="io.github.classgraph" version="4.8.138.v20211212-1642"/>
       <unit id="org.apache.commons.cli" version="1.4.0.v20200417-1444"/>
+      <unit id="org.apache.commons.io" version="2.8.0.v20210415-0900"/>
       <unit id="org.apache.log4j" version="1.2.19.v20220208-1728"/>
       <unit id="org.apache.log4j.source" version="1.2.19.v20220208-1728"/>
       <unit id="org.aopalliance" version="1.0.0.v20220404-1927"/>


### PR DESCRIPTION
explicitely pull commons.io as platform no longer packages it
see eclipse-platform/eclipse.platform.releng.aggregator#444