### PR TITLE
Update to M2E 2.0

### DIFF
--- a/org.eclipse.xtext.m2e/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.m2e/META-INF/MANIFEST.MF
@@ -5,17 +5,13 @@ Bundle-SymbolicName: org.eclipse.xtext.m2e;singleton:=true
 Bundle-Version: 2.28.0.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: %providerName
-Require-Bundle: org.eclipse.m2e.core;bundle-version="1.8.0";resolution:=optional,
- org.eclipse.core.resources;bundle-version="3.12.0",
- org.eclipse.equinox.registry;bundle-version="3.7.0",
- org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
+Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.8.0,3.0.0)";resolution:=optional,
  org.eclipse.xtend.lib,
  org.eclipse.xtext.builder,
  org.eclipse.xtext.ui,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,2.0.0)";resolution:=optional,
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,4.0.0)";resolution:=optional,
  org.eclipse.jdt.core;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtext.m2e;x-internal:=true
-Import-Package: org.apache.maven.plugin;provider=m2e;resolution:=optional,
- org.apache.maven.project;provider=m2e;resolution:=optional
+Import-Package: org.apache.maven.plugin;provider=m2e;resolution:=optional
 Automatic-Module-Name: org.eclipse.xtext.m2e

--- a/org.eclipse.xtext.m2e/src/org/eclipse/xtext/m2e/BinFolderConfigurator.java
+++ b/org.eclipse.xtext.m2e/src/org/eclipse/xtext/m2e/BinFolderConfigurator.java
@@ -31,16 +31,16 @@ public class BinFolderConfigurator extends AbstractProjectConfigurator {
 
 	@Override
 	public void configure(ProjectConfigurationRequest request, IProgressMonitor monitor) throws CoreException {
-		IProject project = request.getProject();
+		IProject project = XtextProjectConfigurator.getProject(request);
 		if (compileToBin(project)) {
 			IPath projectRoot = project.getFullPath();
 			IPath binPath = projectRoot.append("bin");
 			IPath binTestPath = projectRoot.append("bin-test");
 			IJavaProject javaProject = JavaCore.create(project);
 			javaProject.setOutputLocation(binPath, monitor);
-			
+
 			IClasspathEntry[] rawClasspath = javaProject.getRawClasspath();
-			for(int i = 0; i < rawClasspath.length; i++) {
+			for (int i = 0; i < rawClasspath.length; i++) {
 				IClasspathEntry entry = rawClasspath[i];
 				if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
 					if (isTest(entry)) {
@@ -53,7 +53,7 @@ public class BinFolderConfigurator extends AbstractProjectConfigurator {
 			javaProject.setRawClasspath(rawClasspath, monitor);
 		}
 	}
-	
+
 	/**
 	 * IClasspathEntry.isTest is not avaiable on Oxygen.
 	 */
@@ -91,6 +91,5 @@ public class BinFolderConfigurator extends AbstractProjectConfigurator {
 		IEclipsePreferences instancePreferences = InstanceScope.INSTANCE.getNode(pluginId);
 		return "true".equals(instancePreferences.get(key, "false"));
 	}
-
 
 }

--- a/releng/org.eclipse.xtext.contributor/Xtext.setup
+++ b/releng/org.eclipse.xtext.contributor/Xtext.setup
@@ -189,14 +189,6 @@
       value="https://download.eclipse.org/technology/m2e/releases"/>
   <setupTask
       xsi:type="setup:VariableTask"
-      name="p2.m2e.connector.jdt"
-      value="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-jdt-compiler"/>
-  <setupTask
-      xsi:type="setup:VariableTask"
-      name="p2.m2e.connector.tycho"
-      value="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST"/>
-  <setupTask
-      xsi:type="setup:VariableTask"
       name="p2.webtools"
       value="https://download.eclipse.org/webtools/repository/oxygen/">
     <description>required by m2e</description>
@@ -456,19 +448,9 @@
     <requirement
         name="org.eclipse.m2e.feature.feature.group"/>
     <requirement
-        name="org.jboss.tools.m2e.jdt.feature.feature.group"/>
-    <requirement
         name="org.eclipse.buildship.feature.group"/>
-    <requirement
-        name="org.eclipse.wst.jsdt.feature.feature.group"/>
-    <requirement
-        name="org.sonatype.tycho.m2e.feature.feature.group"/>
-    <repository
-        url="${p2.m2e.connector.jdt}"/>
     <repository
         url="${p2.buildship}"/>
-    <repository
-        url="${p2.m2e.connector.tycho}"/>
   </setupTask>
   <setupTask
       xsi:type="setup.workingsets:WorkingSetTask"


### PR DESCRIPTION
This PR aims to update `org.eclipse.xtext.m2e` Plugin to the M2E 2.0.1 release that is contributed to Eclipse 2022-09 M3 SimRel.
M2E 2.0 is a major release that has breaking changes in its API, that are incompatible with previous 1.x releases.

I updated the code and adjusted required bundle version ranges accordingly. Furthermore I update the target file to include the latest m2e release 2.0.1. That release is not yet in the 2022-09 release repo but will be with M3, so this change in advance should prevent trouble with the xText contribution.
I hope that is all correct, but please let me know if anything is wrong or missing.


Besides that I updated the setup and removed M2E-connectors incompatible with M2E 2.0.
The connectors for tycho-plugins are not required because M2E now has the interesting parts of the Tycho-M2E connector build in and for all other parts PDE does in the IDE what Tycho does during build. Since Tycho 2.7.4 this is reflected by M2E-lifecycle-mapping-metadata embedded into Tycho's plugins that say that their execution can be ignored. For the parts of xText that use older Tycho warnings, those missing lifecyclemappings are now only just warnings so you can ignore them. If you want you can change the severity to `INFO`.