### PR TITLE
dont propose Java 6-10 in Wizard anymore

### DIFF
--- a/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/WizardNewXtextProjectCreationPage.java
+++ b/org.eclipse.xtext.xtext.ui/src/org/eclipse/xtext/xtext/ui/wizard/project/WizardNewXtextProjectCreationPage.java
@@ -142,7 +142,7 @@ public class WizardNewXtextProjectCreationPage extends WizardNewProjectCreationP
 			availableBrees.add(ee.getId());
 		}
 		for (JavaVersion supportedVersion : JavaVersion.values()) {
-			if (supportedVersion.isAtLeast(JavaVersion.JAVA6)) {
+			if (supportedVersion.isAtLeast(JavaVersion.JAVA11)) {
 				String bree = supportedVersion.getBree();
 				if (availableBrees.contains(bree))
 					brees.add(bree);


### PR DESCRIPTION
dont propose Java 6-10 in Wizard anymore

@szarnekow what do you think? or should we keep 8+ and the error message as we have it in current Xtext 2.29?