### PR TITLE
[eclipse/xtext-eclipse#1963] remove Class.forName guard for code minings

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src-gen/org/eclipse/xtext/example/arithmetics/ui/AbstractArithmeticsUiModule.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/arithmetics/org.eclipse.xtext.example.arithmetics.ui/src-gen/org/eclipse/xtext/example/arithmetics/ui/AbstractArithmeticsUiModule.java
@@ -272,15 +272,10 @@ public abstract class AbstractArithmeticsUiModule extends DefaultUiModule {
 	
 	// contributed by org.eclipse.xtext.xtext.generator.ui.codemining.CodeMiningFragment
 	public void configureCodeMinding(Binder binder) {
-		try {
-			Class.forName("org.eclipse.jface.text.codemining.ICodeMiningProvider");
-			binder.bind(ICodeMiningProvider.class)
-				.to(ArithmeticsCodeMiningProvider.class);
-			binder.bind(IReconcileStrategyFactory.class).annotatedWith(Names.named("codeMinding"))
-				.to(XtextCodeMiningReconcileStrategy.Factory.class);
-		} catch(ClassNotFoundException ignore) {
-			// no bindings if code mining is not available at runtime
-		}
+		binder.bind(ICodeMiningProvider.class)
+			.to(ArithmeticsCodeMiningProvider.class);
+		binder.bind(IReconcileStrategyFactory.class).annotatedWith(Names.named("codeMinding"))
+			.to(XtextCodeMiningReconcileStrategy.Factory.class);
 	}
 	
 }

--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src-gen/org/eclipse/xtext/example/domainmodel/ui/AbstractDomainmodelUiModule.java
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.ui/src-gen/org/eclipse/xtext/example/domainmodel/ui/AbstractDomainmodelUiModule.java
@@ -416,15 +416,10 @@ public abstract class AbstractDomainmodelUiModule extends DefaultXbaseUiModule {
 	
 	// contributed by org.eclipse.xtext.xtext.generator.ui.codemining.CodeMiningFragment
 	public void configureCodeMinding(Binder binder) {
-		try {
-			Class.forName("org.eclipse.jface.text.codemining.ICodeMiningProvider");
-			binder.bind(ICodeMiningProvider.class)
-				.to(DomainmodelCodeMiningProvider.class);
-			binder.bind(IReconcileStrategyFactory.class).annotatedWith(Names.named("codeMinding"))
-				.to(XtextCodeMiningReconcileStrategy.Factory.class);
-		} catch(ClassNotFoundException ignore) {
-			// no bindings if code mining is not available at runtime
-		}
+		binder.bind(ICodeMiningProvider.class)
+			.to(DomainmodelCodeMiningProvider.class);
+		binder.bind(IReconcileStrategyFactory.class).annotatedWith(Names.named("codeMinding"))
+			.to(XtextCodeMiningReconcileStrategy.Factory.class);
 	}
 	
 }


### PR DESCRIPTION
[eclipse/xtext-eclipse#1963] remove Class.forName guard for code minings