### PR TITLE
fix platform no longer packages jxpath but requires it slicer problem…

### DIFF
--- a/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
+++ b/org.eclipse.xtext.xtext.ui.examples/projects/domainmodel/org.eclipse.xtext.example.domainmodel.releng/tp/domainmodel.target
@@ -8,6 +8,7 @@
       <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.apache.commons.jxpath" version="0.0.0"/>
       <repository location="https://download.eclipse.org/releases/2023-03"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">


### PR DESCRIPTION
fix platform no longer packages jxpath but requires it slicer problem…
see https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/842